### PR TITLE
Fix version display in CLI

### DIFF
--- a/bin/confluence.js
+++ b/bin/confluence.js
@@ -5,11 +5,12 @@ const chalk = require('chalk');
 const ConfluenceClient = require('../lib/confluence-client');
 const { getConfig, initConfig } = require('../lib/config');
 const Analytics = require('../lib/analytics');
+const pkg = require('../package.json');
 
 program
   .name('confluence')
   .description('CLI tool for Atlassian Confluence')
-  .version('1.0.0');
+  .version(pkg.version);
 
 // Init command
 program


### PR DESCRIPTION
## Summary
- Replace hardcoded version '1.0.0' with dynamic package.json version
- Fixes issue where `confluence --version` showed incorrect version

## Test plan
- [x] Test `confluence --version` shows correct version (1.4.0)
- [x] Verify package.json version is read correctly