### PR TITLE
feat: Add copy-tree command for recursive page copying with children

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ confluence copy-tree 123456789 987654321 --max-depth 3
 # Exclude pages by title (supports wildcards * and ?; case-insensitive)
 confluence copy-tree 123456789 987654321 --exclude "temp*,test*,*draft*"
 
+# Control pacing and naming
+confluence copy-tree 123456789 987654321 --delay-ms 150 --copy-suffix " (Backup)"
+
 # Quiet mode (suppress progress output)
 confluence copy-tree 123456789 987654321 --quiet
 ```
@@ -150,7 +153,9 @@ Notes:
 - Preserves the original parent-child hierarchy when copying.
 - Continues on errors: failed pages are logged and the copy proceeds.
 - Exclude patterns use simple globbing: `*` matches any sequence, `?` matches any single character, and special regex characters are treated literally.
-- Large trees may take time; the CLI applies a small delay between creations to avoid rate limits.
+- Large trees may take time; the CLI applies a small delay between sibling page creations to avoid rate limits (configurable via `--delay-ms`).
+- Root title suffix defaults to ` (Copy)`; override with `--copy-suffix`. Child pages keep their original titles.
+- Use `--fail-on-error` to exit non-zero if any page fails to copy.
 
 ### Update an Existing Page
 ```bash
@@ -197,7 +202,7 @@ confluence stats
 | `find <title>` | Find a page by its title | `--space <spaceKey>` |
 | `create <title> <spaceKey>` | Create a new page | `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>`|
 | `create-child <title> <parentId>` | Create a child page | `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>` |
-| `copy-tree <sourcePageId> <targetParentId> [newTitle]` | Copy page tree with all children | `--max-depth <number>`, `--exclude <patterns>`, `--quiet` |
+| `copy-tree <sourcePageId> <targetParentId> [newTitle]` | Copy page tree with all children | `--max-depth <number>`, `--exclude <patterns>`, `--delay-ms <ms>`, `--copy-suffix <text>`, `--fail-on-error`, `--quiet` |
 | `update <pageId>` | Update a page's title or content | `--title <string>`, `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>` |
 | `edit <pageId>` | Export page content for editing | `--output <file>` |
 | `stats` | View your usage statistics | |

--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ confluence copy-tree 123456789 987654321 --exclude "temp*,test*,*draft*"
 # Control pacing and naming
 confluence copy-tree 123456789 987654321 --delay-ms 150 --copy-suffix " (Backup)"
 
+# Dry run (preview only)
+confluence copy-tree 123456789 987654321 --dry-run
+
 # Quiet mode (suppress progress output)
 confluence copy-tree 123456789 987654321 --quiet
 ```
@@ -202,7 +205,7 @@ confluence stats
 | `find <title>` | Find a page by its title | `--space <spaceKey>` |
 | `create <title> <spaceKey>` | Create a new page | `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>`|
 | `create-child <title> <parentId>` | Create a child page | `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>` |
-| `copy-tree <sourcePageId> <targetParentId> [newTitle]` | Copy page tree with all children | `--max-depth <number>`, `--exclude <patterns>`, `--delay-ms <ms>`, `--copy-suffix <text>`, `--fail-on-error`, `--quiet` |
+| `copy-tree <sourcePageId> <targetParentId> [newTitle]` | Copy page tree with all children | `--max-depth <number>`, `--exclude <patterns>`, `--delay-ms <ms>`, `--copy-suffix <text>`, `--dry-run`, `--fail-on-error`, `--quiet` |
 | `update <pageId>` | Update a page's title or content | `--title <string>`, `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>` |
 | `edit <pageId>` | Export page content for editing | `--output <file>` |
 | `stats` | View your usage statistics | |

--- a/README.md
+++ b/README.md
@@ -131,6 +131,21 @@ confluence create-child "Meeting Notes" 123456789 --content "This is a child pag
 confluence create-child "Tech Specs" 123456789 --file ./specs.md --format markdown
 ```
 
+### Copy Page Tree
+```bash
+# Copy a page and all its children to a new location
+confluence copy-tree 123456789 987654321 "프로젝트 문서 (복사본)"
+
+# Copy with maximum depth limit
+confluence copy-tree 123456789 987654321 --max-depth 3
+
+# Copy excluding certain pages (supports wildcards)
+confluence copy-tree 123456789 987654321 --exclude "임시*,테스트*,*draft*"
+
+# Quiet mode (no progress output)
+confluence copy-tree 123456789 987654321 --quiet
+```
+
 ### Update an Existing Page
 ```bash
 # Update title only
@@ -176,6 +191,7 @@ confluence stats
 | `find <title>` | Find a page by its title | `--space <spaceKey>` |
 | `create <title> <spaceKey>` | Create a new page | `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>`|
 | `create-child <title> <parentId>` | Create a child page | `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>` |
+| `copy-tree <sourcePageId> <targetParentId> [newTitle]` | Copy page tree with all children | `--max-depth <number>`, `--exclude <patterns>`, `--quiet` |
 | `update <pageId>` | Update a page's title or content | `--title <string>`, `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>` |
 | `edit <pageId>` | Export page content for editing | `--output <file>` |
 | `stats` | View your usage statistics | |

--- a/README.md
+++ b/README.md
@@ -134,17 +134,23 @@ confluence create-child "Tech Specs" 123456789 --file ./specs.md --format markdo
 ### Copy Page Tree
 ```bash
 # Copy a page and all its children to a new location
-confluence copy-tree 123456789 987654321 "프로젝트 문서 (복사본)"
+confluence copy-tree 123456789 987654321 "Project Docs (Copy)"
 
-# Copy with maximum depth limit
+# Copy with maximum depth limit (only 3 levels deep)
 confluence copy-tree 123456789 987654321 --max-depth 3
 
-# Copy excluding certain pages (supports wildcards)
-confluence copy-tree 123456789 987654321 --exclude "임시*,테스트*,*draft*"
+# Exclude pages by title (supports wildcards * and ?; case-insensitive)
+confluence copy-tree 123456789 987654321 --exclude "temp*,test*,*draft*"
 
-# Quiet mode (no progress output)
+# Quiet mode (suppress progress output)
 confluence copy-tree 123456789 987654321 --quiet
 ```
+
+Notes:
+- Preserves the original parent-child hierarchy when copying.
+- Continues on errors: failed pages are logged and the copy proceeds.
+- Exclude patterns use simple globbing: `*` matches any sequence, `?` matches any single character, and special regex characters are treated literally.
+- Large trees may take time; the CLI applies a small delay between creations to avoid rate limits.
 
 ### Update an Existing Page
 ```bash

--- a/examples/copy-tree-example.sh
+++ b/examples/copy-tree-example.sh
@@ -3,111 +3,115 @@
 # Confluence CLI - 페이지 트리 복사 예제
 # 이 스크립트는 페이지와 모든 하위 페이지를 새로운 위치로 복사하는 방법을 보여줍니다.
 
-echo "📋 Confluence CLI - 페이지 트리 복사 예제"
+echo "📋 Confluence CLI - Copy Page Tree Example"
 echo "=================================================="
 
 # 사전 요구사항
 echo ""
-echo "📝 사전 요구사항:"
-echo "- confluence CLI가 올바르게 설정되어 있어야 합니다 (confluence init)"
-echo "- 원본 페이지와 대상 위치에 대한 적절한 권한이 필요합니다"
-echo "- 페이지 생성 권한이 있는지 확인하세요"
+echo "📝 Prerequisites:"
+echo "- confluence CLI is set up (confluence init)"
+echo "- You have access to source and target locations"
+echo "- You have permissions to create pages"
 echo ""
 
 # 1단계: 복사할 원본 페이지 찾기
-echo "1️⃣ 복사할 원본 페이지 찾기"
+echo "1️⃣ Find the source page"
 echo "=============================="
 echo ""
-echo "방법 1: 제목으로 페이지 찾기"
-echo "confluence find \"프로젝트 문서\" --space MYTEAM"
+echo "Method 1: Find by title"
+echo "confluence find \"Project Docs\" --space MYTEAM"
 echo ""
-echo "방법 2: 검색으로 페이지 찾기"
-echo "confluence search \"프로젝트\""
+echo "Method 2: Search"
+echo "confluence search \"Project\""
 echo ""
-echo "📝 위 명령어 결과에서 원본 페이지 ID를 확인하세요 (예: 123456789)"
+echo "📝 Note the source page ID from the output (e.g., 123456789)"
 echo ""
 
 # 2단계: 대상 부모 페이지 찾기
-echo "2️⃣ 대상 부모 페이지 찾기"
+echo "2️⃣ Find the target parent page"
 echo "========================="
 echo ""
-echo "confluence find \"백업\" --space BACKUP"
-echo "또는"
-echo "confluence find \"아카이브\" --space ARCHIVE"
+echo "confluence find \"Backup\" --space BACKUP"
+echo "or"
+echo "confluence find \"Archive\" --space ARCHIVE"
 echo ""
-echo "📝 대상 부모 페이지 ID를 확인하세요 (예: 987654321)"
+echo "📝 Note the target parent page ID (e.g., 987654321)"
 echo ""
 
 # 3단계: 페이지 트리 복사 실행
-echo "3️⃣ 페이지 트리 복사 실행"
+echo "3️⃣ Run copy"
 echo "========================"
 echo ""
 
-echo "📄 방법 1: 기본 복사 (모든 하위 페이지 포함)"
-echo 'confluence copy-tree 123456789 987654321 "프로젝트 문서 (백업)"'
+echo "📄 Basic: copy with all children"
+echo 'confluence copy-tree 123456789 987654321 "Project Docs (Backup)"'
 echo ""
 
-echo "📄 방법 2: 깊이 제한 복사 (3단계까지만)"
-echo 'confluence copy-tree 123456789 987654321 "프로젝트 문서 (요약)" --max-depth 3'
+echo "📄 Depth-limited (3 levels)"
+echo 'confluence copy-tree 123456789 987654321 "Project Docs (Summary)" --max-depth 3'
 echo ""
 
-echo "📄 방법 3: 특정 페이지 제외하고 복사"
-echo 'confluence copy-tree 123456789 987654321 "프로젝트 문서 (정리본)" --exclude "임시*,테스트*,*draft*"'
+echo "📄 Exclude patterns"
+echo 'confluence copy-tree 123456789 987654321 "Project Docs (Clean)" --exclude "temp*,test*,*draft*"'
 echo ""
 
-echo "📄 방법 4: 조용한 모드 (진행상황 표시 안함)"
+echo "📄 Quiet mode"
 echo 'confluence copy-tree 123456789 987654321 --quiet'
 echo ""
 
+echo "📄 Control pacing and naming"
+echo 'confluence copy-tree 123456789 987654321 --delay-ms 150 --copy-suffix " (Backup)"'
+echo ""
+
 # 실제 사용 예제
-echo "💡 실제 사용 예제"
+echo "💡 Practical example"
 echo "================="
 echo ""
-echo "# 1. 원본 페이지 ID 찾기"
-echo 'SOURCE_ID=$(confluence find "프로젝트 문서" --space MYTEAM | grep "ID:" | awk "{print \$2}")'
+echo "# 1. Capture source page ID"
+echo 'SOURCE_ID=$(confluence find "Project Docs" --space MYTEAM | grep "ID:" | awk "{print \$2}")'
 echo ""
-echo "# 2. 대상 부모 페이지 ID 찾기"
-echo 'TARGET_ID=$(confluence find "백업 폴더" --space BACKUP | grep "ID:" | awk "{print \$2}")'
+echo "# 2. Capture target parent ID"
+echo 'TARGET_ID=$(confluence find "Backup Folder" --space BACKUP | grep "ID:" | awk "{print \$2}")'
 echo ""
-echo "# 3. 날짜와 함께 백업 복사"
-echo 'confluence copy-tree $SOURCE_ID $TARGET_ID "프로젝트 문서 백업 - $(date +%Y%m%d)"'
+echo "# 3. Run backup with date suffix"
+echo 'confluence copy-tree $SOURCE_ID $TARGET_ID "Project Docs Backup - $(date +%Y%m%d)"'
 echo ""
 
 # 고급 사용법
-echo "🚀 고급 사용법"
+echo "🚀 Advanced"
 echo "============="
 echo ""
-echo "1. 대용량 페이지 트리 복사 (진행상황 모니터링)"
+echo "1. Large trees with progress"
 echo "   confluence copy-tree 123456789 987654321 | tee copy-log.txt"
 echo ""
-echo "2. 특정 패턴 제외 (여러 패턴)"
-echo "   confluence copy-tree 123456789 987654321 --exclude \"임시*,테스트*,*draft*,*temp*\""
+echo "2. Multiple exclude patterns"
+echo "   confluence copy-tree 123456789 987654321 --exclude \"temp*,test*,*draft*,*temp*\""
 echo ""
-echo "3. 얕은 복사 (1단계 하위만)"
+echo "3. Shallow copy (only direct children)"
 echo "   confluence copy-tree 123456789 987654321 --max-depth 1"
 echo ""
 
 # 주의사항 및 팁
-echo "⚠️  주의사항 및 팁"
+echo "⚠️  Notes and tips"
 echo "=================="
-echo "- 큰 페이지 트리는 복사하는데 시간이 오래 걸릴 수 있습니다"
-echo "- API 레이트 리밋을 피하기 위해 페이지 간 짧은 지연이 있습니다"
-echo "- 복사 중 오류가 발생하면 부분적으로 복사된 페이지들이 남을 수 있습니다"
-echo "- 권한이 부족한 페이지는 건너뛰고 계속 진행됩니다"
-echo "- 복사 후에는 링크와 참조가 올바른지 확인하세요"
-echo "- 테스트용 소규모 트리로 먼저 테스트해보는 것을 권장합니다"
+echo "- Large trees may take time to copy"
+echo "- A short delay between siblings helps avoid rate limits (tune with --delay-ms)"
+echo "- Partial copies can remain if errors occur"
+echo "- Pages without permission are skipped; run with --fail-on-error to fail the run"
+echo "- Validate links and references after copying"
+echo "- Try with a small tree first"
 echo ""
 
-echo "📊 복사 결과 확인"
+echo "📊 Verify results"
 echo "================"
-echo "복사 완료 후 다음 명령어로 결과를 확인할 수 있습니다:"
+echo "After completion, you can check the results:"
 echo ""
-echo "# 복사된 루트 페이지 정보 확인"
+echo "# Root page info"
 echo "confluence info [새로운페이지ID]"
 echo ""
-echo "# 복사된 페이지의 하위 페이지들 확인"
-echo "confluence search \"복사본\" --limit 20"
+echo "# Find copied pages"
+echo "confluence search \"Copy\" --limit 20"
 echo ""
 
-echo "✅ 예제 완료!"
-echo "실제 사용 시에는 위의 예제 명령어에서 실제 페이지 ID를 대입하여 사용하세요."
+echo "✅ Example complete!"
+echo "Replace example IDs with real ones when running."

--- a/examples/copy-tree-example.sh
+++ b/examples/copy-tree-example.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# Confluence CLI - 페이지 트리 복사 예제
-# 이 스크립트는 페이지와 모든 하위 페이지를 새로운 위치로 복사하는 방법을 보여줍니다.
+# Confluence CLI - Copy Page Tree Example
+# This script shows how to copy a page and all its descendants to a new location.
 
 echo "📋 Confluence CLI - Copy Page Tree Example"
 echo "=================================================="
 
-# 사전 요구사항
+# Prerequisites
 echo ""
 echo "📝 Prerequisites:"
 echo "- confluence CLI is set up (confluence init)"
@@ -14,7 +14,7 @@ echo "- You have access to source and target locations"
 echo "- You have permissions to create pages"
 echo ""
 
-# 1단계: 복사할 원본 페이지 찾기
+# Step 1: Find the source page
 echo "1️⃣ Find the source page"
 echo "=============================="
 echo ""
@@ -27,7 +27,7 @@ echo ""
 echo "📝 Note the source page ID from the output (e.g., 123456789)"
 echo ""
 
-# 2단계: 대상 부모 페이지 찾기
+# Step 2: Find the target parent page
 echo "2️⃣ Find the target parent page"
 echo "========================="
 echo ""
@@ -38,7 +38,7 @@ echo ""
 echo "📝 Note the target parent page ID (e.g., 987654321)"
 echo ""
 
-# 3단계: 페이지 트리 복사 실행
+# Step 3: Run the copy
 echo "3️⃣ Run copy"
 echo "========================"
 echo ""
@@ -63,7 +63,7 @@ echo "📄 Control pacing and naming"
 echo 'confluence copy-tree 123456789 987654321 --delay-ms 150 --copy-suffix " (Backup)"'
 echo ""
 
-# 실제 사용 예제
+# Practical example
 echo "💡 Practical example"
 echo "================="
 echo ""
@@ -77,7 +77,7 @@ echo "# 3. Run backup with date suffix"
 echo 'confluence copy-tree $SOURCE_ID $TARGET_ID "Project Docs Backup - $(date +%Y%m%d)"'
 echo ""
 
-# 고급 사용법
+# Advanced usage
 echo "🚀 Advanced"
 echo "============="
 echo ""
@@ -91,7 +91,7 @@ echo "3. Shallow copy (only direct children)"
 echo "   confluence copy-tree 123456789 987654321 --max-depth 1"
 echo ""
 
-# 주의사항 및 팁
+# Notes and tips
 echo "⚠️  Notes and tips"
 echo "=================="
 echo "- Large trees may take time to copy"
@@ -107,7 +107,7 @@ echo "================"
 echo "After completion, you can check the results:"
 echo ""
 echo "# Root page info"
-echo "confluence info [새로운페이지ID]"
+echo "confluence info [NEW_PAGE_ID]"
 echo ""
 echo "# Find copied pages"
 echo "confluence search \"Copy\" --limit 20"

--- a/examples/copy-tree-example.sh
+++ b/examples/copy-tree-example.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# Confluence CLI - 페이지 트리 복사 예제
+# 이 스크립트는 페이지와 모든 하위 페이지를 새로운 위치로 복사하는 방법을 보여줍니다.
+
+echo "📋 Confluence CLI - 페이지 트리 복사 예제"
+echo "=================================================="
+
+# 사전 요구사항
+echo ""
+echo "📝 사전 요구사항:"
+echo "- confluence CLI가 올바르게 설정되어 있어야 합니다 (confluence init)"
+echo "- 원본 페이지와 대상 위치에 대한 적절한 권한이 필요합니다"
+echo "- 페이지 생성 권한이 있는지 확인하세요"
+echo ""
+
+# 1단계: 복사할 원본 페이지 찾기
+echo "1️⃣ 복사할 원본 페이지 찾기"
+echo "=============================="
+echo ""
+echo "방법 1: 제목으로 페이지 찾기"
+echo "confluence find \"프로젝트 문서\" --space MYTEAM"
+echo ""
+echo "방법 2: 검색으로 페이지 찾기"
+echo "confluence search \"프로젝트\""
+echo ""
+echo "📝 위 명령어 결과에서 원본 페이지 ID를 확인하세요 (예: 123456789)"
+echo ""
+
+# 2단계: 대상 부모 페이지 찾기
+echo "2️⃣ 대상 부모 페이지 찾기"
+echo "========================="
+echo ""
+echo "confluence find \"백업\" --space BACKUP"
+echo "또는"
+echo "confluence find \"아카이브\" --space ARCHIVE"
+echo ""
+echo "📝 대상 부모 페이지 ID를 확인하세요 (예: 987654321)"
+echo ""
+
+# 3단계: 페이지 트리 복사 실행
+echo "3️⃣ 페이지 트리 복사 실행"
+echo "========================"
+echo ""
+
+echo "📄 방법 1: 기본 복사 (모든 하위 페이지 포함)"
+echo 'confluence copy-tree 123456789 987654321 "프로젝트 문서 (백업)"'
+echo ""
+
+echo "📄 방법 2: 깊이 제한 복사 (3단계까지만)"
+echo 'confluence copy-tree 123456789 987654321 "프로젝트 문서 (요약)" --max-depth 3'
+echo ""
+
+echo "📄 방법 3: 특정 페이지 제외하고 복사"
+echo 'confluence copy-tree 123456789 987654321 "프로젝트 문서 (정리본)" --exclude "임시*,테스트*,*draft*"'
+echo ""
+
+echo "📄 방법 4: 조용한 모드 (진행상황 표시 안함)"
+echo 'confluence copy-tree 123456789 987654321 --quiet'
+echo ""
+
+# 실제 사용 예제
+echo "💡 실제 사용 예제"
+echo "================="
+echo ""
+echo "# 1. 원본 페이지 ID 찾기"
+echo 'SOURCE_ID=$(confluence find "프로젝트 문서" --space MYTEAM | grep "ID:" | awk "{print \$2}")'
+echo ""
+echo "# 2. 대상 부모 페이지 ID 찾기"
+echo 'TARGET_ID=$(confluence find "백업 폴더" --space BACKUP | grep "ID:" | awk "{print \$2}")'
+echo ""
+echo "# 3. 날짜와 함께 백업 복사"
+echo 'confluence copy-tree $SOURCE_ID $TARGET_ID "프로젝트 문서 백업 - $(date +%Y%m%d)"'
+echo ""
+
+# 고급 사용법
+echo "🚀 고급 사용법"
+echo "============="
+echo ""
+echo "1. 대용량 페이지 트리 복사 (진행상황 모니터링)"
+echo "   confluence copy-tree 123456789 987654321 | tee copy-log.txt"
+echo ""
+echo "2. 특정 패턴 제외 (여러 패턴)"
+echo "   confluence copy-tree 123456789 987654321 --exclude \"임시*,테스트*,*draft*,*temp*\""
+echo ""
+echo "3. 얕은 복사 (1단계 하위만)"
+echo "   confluence copy-tree 123456789 987654321 --max-depth 1"
+echo ""
+
+# 주의사항 및 팁
+echo "⚠️  주의사항 및 팁"
+echo "=================="
+echo "- 큰 페이지 트리는 복사하는데 시간이 오래 걸릴 수 있습니다"
+echo "- API 레이트 리밋을 피하기 위해 페이지 간 짧은 지연이 있습니다"
+echo "- 복사 중 오류가 발생하면 부분적으로 복사된 페이지들이 남을 수 있습니다"
+echo "- 권한이 부족한 페이지는 건너뛰고 계속 진행됩니다"
+echo "- 복사 후에는 링크와 참조가 올바른지 확인하세요"
+echo "- 테스트용 소규모 트리로 먼저 테스트해보는 것을 권장합니다"
+echo ""
+
+echo "📊 복사 결과 확인"
+echo "================"
+echo "복사 완료 후 다음 명령어로 결과를 확인할 수 있습니다:"
+echo ""
+echo "# 복사된 루트 페이지 정보 확인"
+echo "confluence info [새로운페이지ID]"
+echo ""
+echo "# 복사된 페이지의 하위 페이지들 확인"
+echo "confluence search \"복사본\" --limit 20"
+echo ""
+
+echo "✅ 예제 완료!"
+echo "실제 사용 시에는 위의 예제 명령어에서 실제 페이지 ID를 대입하여 사용하세요."

--- a/examples/create-child-page-example.sh
+++ b/examples/create-child-page-example.sh
@@ -1,65 +1,67 @@
 #!/bin/bash
 
-# 실제 Project Documentation 페이지 하위에 테스트 페이지 생성 예제
-# 이 스크립트는 일반적인 Confluence 설정에서 작동합니다.
+#!/bin/bash
 
-echo "🔍 Project Documentation 페이지 하위에 테스트 페이지 생성"
-echo "=============================================================="
+# Create a test page under the Project Documentation page
+# This script demonstrates typical Confluence CLI usage.
 
-# 1단계: 부모 페이지 찾기
+echo "🔍 Create a test page under Project Documentation"
+echo "================================================"
+
+# Step 1: Find the parent page
 echo ""
-echo "1️⃣ 부모 페이지 찾기..."
-echo "실행: confluence find \"Project Documentation\" --space MYTEAM"
+echo "1️⃣ Find the parent page..."
+echo "Run: confluence find \"Project Documentation\" --space MYTEAM"
 echo ""
 
-# 실제 실행할 때는 아래 주석을 해제하세요
+# For real execution, uncomment below
 # confluence find "Project Documentation" --space MYTEAM
 
-echo "📝 위 명령어 결과에서 페이지 ID를 확인하세요 (예: 123456789)"
+echo "📝 Note the page ID from the output (e.g., 123456789)"
 echo ""
 
-# 2단계: 페이지 정보 확인
-echo "2️⃣ 페이지 정보 확인..."
-echo "실행: confluence info [페이지ID]"
-echo "예시: confluence info 123456789"
+# Step 2: Inspect page info
+echo "2️⃣ Inspect page info..."
+echo "Run: confluence info [PAGE_ID]"
+echo "Example: confluence info 123456789"
 echo ""
 
-# 3단계: 페이지 내용 읽기 (선택사항)
-echo "3️⃣ 페이지 내용 확인 (선택사항)..."
-echo "실행: confluence read [페이지ID] | head -20"
-echo "예시: confluence read 123456789 | head -20"
+# Step 3: Read page content (optional)
+echo "3️⃣ Read content (optional)..."
+echo "Run: confluence read [PAGE_ID] | head -20"
+echo "Example: confluence read 123456789 | head -20"
 echo ""
 
-# 4단계: 테스트 페이지 생성
-echo "4️⃣ 하위 테스트 페이지 생성..."
+# Step 4: Create a child test page
+echo "4️⃣ Create child test page..."
 echo ""
 
-# 간단한 텍스트 콘텐츠로 테스트 페이지 생성
-echo "📄 방법 1: 간단한 텍스트 콘텐츠로 생성"
-echo 'confluence create-child "Test Page - $(date +%Y%m%d)" [부모페이지ID] --content "이것은 CLI로 생성된 테스트 페이지입니다. 생성 시간: $(date)"'
+# Simple text content
+echo "📄 Option 1: Simple text content"
+echo 'confluence create-child "Test Page - $(date +%Y%m%d)" [PARENT_PAGE_ID] --content "This is a test page created via CLI. Created at: $(date)"'
 echo ""
 
-# 마크다운 파일에서 테스트 페이지 생성
-echo "📄 방법 2: 마크다운 파일에서 생성"
-echo "confluence create-child \"Test Documentation - $(date +%Y%m%d)\" [부모페이지ID] --file ./sample-page.md --format markdown"
+# From Markdown file
+echo "📄 Option 2: From Markdown file"
+echo "confluence create-child \"Test Documentation - $(date +%Y%m%d)\" [PARENT_PAGE_ID] --file ./sample-page.md --format markdown"
 echo ""
 
-# HTML 콘텐츠로 생성
-echo "📄 방법 3: HTML 콘텐츠로 생성"
-echo 'confluence create-child "Test HTML Page" [부모페이지ID] --content "<h1>테스트 페이지</h1><p>이것은 <strong>HTML</strong>로 작성된 테스트 페이지입니다.</p>" --format html'
+# From HTML content
+echo "📄 Option 3: From HTML content"
+echo 'confluence create-child "Test HTML Page" [PARENT_PAGE_ID] --content "<h1>Test Page</h1><p>This is a <strong>HTML</strong> example page.</p>" --format html'
 echo ""
 
-echo "💡 실제 사용 예제:"
+echo "💡 Practical example:"
 echo "=============================="
-echo "# 1. 부모 페이지 ID 찾기"
+echo "# 1. Get parent page ID"
 echo 'PARENT_ID=$(confluence find "Project Documentation" --space MYTEAM | grep "ID:" | cut -d" " -f2)'
 echo ""
-echo "# 2. 테스트 페이지 생성"
-echo 'confluence create-child "테스트 페이지 - $(date +%Y%m%d_%H%M)" $PARENT_ID --content "CLI 테스트용 페이지입니다."'
+echo "# 2. Create test page"
+echo 'confluence create-child "Test Page - $(date +%Y%m%d_%H%M)" $PARENT_ID --content "Page for CLI testing."'
 echo ""
 
-echo "⚠️  주의사항:"
-echo "- confluence CLI가 올바르게 설정되어 있어야 합니다 (confluence init)"
-echo "- 해당 Confluence 인스턴스에 대한 적절한 권한이 있어야 합니다"
-echo "- 페이지 생성 권한이 있는지 확인하세요"
-echo "- 테스트 후에는 불필요한 페이지를 정리하세요"
+echo "⚠️  Notes:"
+echo "- confluence CLI must be set up (confluence init)"
+echo "- You need appropriate permissions on the Confluence instance"
+echo "- Ensure you have page creation permission"
+echo "- Clean up test pages afterward"

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -656,7 +656,8 @@ class ConfluenceClient {
     const response = await this.client.get(`/content/${pageId}/child/page`, {
       params: {
         limit: limit,
-        expand: 'body.storage,space'
+        // Fetch lightweight payload; content fetched on-demand when copying
+        expand: 'space,version'
       }
     });
 
@@ -666,7 +667,6 @@ class ConfluenceClient {
       type: page.type,
       status: page.status,
       space: page.space,
-      content: page.body?.storage?.value || '',
       version: page.version?.number || 1
     }));
   }
@@ -837,9 +837,17 @@ class ConfluenceClient {
         await this.copyChildrenRecursive(child.id, newPage.id, currentDepth + 1, opts, result);
       } catch (error) {
         if (!quiet && onProgress) {
-          onProgress(`Failed: ${child.title} - ${error.message}`);
+          const status = error?.response?.status;
+          const statusText = error?.response?.statusText;
+          const msg = status ? `${status} ${statusText || ''}`.trim() : error.message;
+          onProgress(`Failed: ${child.title} - ${msg}`);
         }
-        result.failures.push({ id: child.id, title: child.title, error: error.message });
+        result.failures.push({
+          id: child.id,
+          title: child.title,
+          error: error.message,
+          status: error?.response?.status || null
+        });
         // Continue with other pages (do not throw)
         continue;
       }

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -648,6 +648,207 @@ class ConfluenceClient {
       url: content._links?.webui || ''
     };
   }
+
+  /**
+   * Get child pages of a given page
+   */
+  async getChildPages(pageId, limit = 500) {
+    const response = await this.client.get(`/content/${pageId}/child/page`, {
+      params: {
+        limit: limit,
+        expand: 'body.storage,space'
+      }
+    });
+
+    return response.data.results.map(page => ({
+      id: page.id,
+      title: page.title,
+      type: page.type,
+      status: page.status,
+      space: page.space,
+      content: page.body?.storage?.value || '',
+      version: page.version?.number || 1
+    }));
+  }
+
+  /**
+   * Get all descendant pages recursively
+   */
+  async getAllDescendantPages(pageId, maxDepth = 10, currentDepth = 0) {
+    if (currentDepth >= maxDepth) {
+      return [];
+    }
+
+    const children = await this.getChildPages(pageId);
+    let allDescendants = [...children];
+
+    for (const child of children) {
+      const grandChildren = await this.getAllDescendantPages(
+        child.id, 
+        maxDepth, 
+        currentDepth + 1
+      );
+      allDescendants = allDescendants.concat(grandChildren);
+    }
+
+    return allDescendants;
+  }
+
+  /**
+   * Copy a page tree (page and all its descendants) to a new location
+   */
+  async copyPageTree(sourcePageId, targetParentId, newTitle = null, options = {}) {
+    const {
+      maxDepth = 10,
+      excludePatterns = [],
+      onProgress = null,
+      quiet = false
+    } = options;
+
+    // Get source page information
+    const sourcePage = await this.getPageForEdit(sourcePageId);
+    const sourceInfo = await this.getPageInfo(sourcePageId);
+    
+    // Determine new title
+    const finalTitle = newTitle || `${sourcePage.title} (복사본)`;
+    
+    if (!quiet && onProgress) {
+      onProgress(`📄 복사 중: ${sourcePage.title} -> ${finalTitle}`);
+    }
+
+    // Create the root copied page
+    const newRootPage = await this.createChildPage(
+      finalTitle,
+      sourceInfo.space.key,
+      targetParentId,
+      sourcePage.content,
+      'storage'
+    );
+
+    if (!quiet && onProgress) {
+      onProgress(`✅ 루트 페이지 생성됨: ${newRootPage.title} (ID: ${newRootPage.id})`);
+    }
+
+    // Get all descendant pages
+    const allDescendants = await this.getAllDescendantPages(sourcePageId, maxDepth);
+    
+    if (!quiet && onProgress) {
+      onProgress(`🔍 발견된 하위 페이지: ${allDescendants.length}개`);
+    }
+
+    // Build a tree structure to maintain hierarchy
+    const pageTree = this.buildPageTree(allDescendants, sourcePageId);
+    
+    // Copy pages recursively maintaining hierarchy
+    const pageMapping = { [sourcePageId]: newRootPage.id };
+    const copiedPages = [newRootPage];
+    
+    await this.copyPageTreeRecursive(
+      pageTree,
+      pageMapping,
+      sourceInfo.space.key,
+      excludePatterns,
+      copiedPages,
+      onProgress,
+      quiet
+    );
+
+    return {
+      rootPage: newRootPage,
+      copiedPages: copiedPages,
+      totalCopied: copiedPages.length
+    };
+  }
+
+  /**
+   * Build a tree structure from flat array of pages
+   */
+  buildPageTree(pages, rootPageId) {
+    const pageMap = new Map();
+    const tree = [];
+
+    // Create a map of all pages
+    pages.forEach(page => {
+      pageMap.set(page.id, { ...page, children: [] });
+    });
+
+    // Build the tree structure by finding parent-child relationships
+    pages.forEach(page => {
+      // For now, we'll use a simple approach: group by depth level
+      // In a real implementation, we'd need to track parent-child relationships
+      tree.push(pageMap.get(page.id));
+    });
+
+    return tree;
+  }
+
+  /**
+   * Recursively copy pages maintaining hierarchy
+   */
+  async copyPageTreeRecursive(pageTree, pageMapping, spaceKey, excludePatterns, copiedPages, onProgress, quiet) {
+    for (const page of pageTree) {
+      // Check if page should be excluded
+      if (this.shouldExcludePage(page.title, excludePatterns)) {
+        if (!quiet && onProgress) {
+          onProgress(`⏭️  제외됨: ${page.title}`);
+        }
+        continue;
+      }
+
+      // Find the parent page ID in our mapping
+      // For now, we'll assume all pages are direct children of the root
+      // In a more sophisticated implementation, we'd track the actual hierarchy
+      const parentId = pageMapping[Object.keys(pageMapping)[0]]; // Use root as parent for simplicity
+
+      if (!quiet && onProgress) {
+        onProgress(`📄 복사 중: ${page.title}`);
+      }
+
+      try {
+        const newPage = await this.createChildPage(
+          page.title,
+          spaceKey,
+          parentId,
+          page.content,
+          'storage'
+        );
+
+        pageMapping[page.id] = newPage.id;
+        copiedPages.push(newPage);
+
+        if (!quiet && onProgress) {
+          onProgress(`✅ 생성됨: ${newPage.title} (ID: ${newPage.id})`);
+        }
+
+        // Small delay to avoid rate limiting
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+      } catch (error) {
+        if (!quiet && onProgress) {
+          onProgress(`❌ 실패: ${page.title} - ${error.message}`);
+        }
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Check if a page should be excluded based on patterns
+   */
+  shouldExcludePage(title, excludePatterns) {
+    if (!excludePatterns || excludePatterns.length === 0) {
+      return false;
+    }
+
+    return excludePatterns.some(pattern => {
+      // Convert glob-like pattern to regex
+      const regexPattern = pattern
+        .replace(/\*/g, '.*')
+        .replace(/\?/g, '.');
+      const regex = new RegExp(`^${regexPattern}$`, 'i');
+      return regex.test(title);
+    });
+  }
 }
 
 module.exports = ConfluenceClient;

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -706,6 +706,7 @@ class ConfluenceClient {
       onProgress = null,
       quiet = false,
       delayMs = 100,
+      copySuffix = ' (Copy)'
     } = options;
 
     // Get source page information
@@ -713,10 +714,10 @@ class ConfluenceClient {
     const sourceInfo = await this.getPageInfo(sourcePageId);
     
     // Determine new title
-    const finalTitle = newTitle || `${sourcePage.title} (복사본)`;
+    const finalTitle = newTitle || `${sourcePage.title}${copySuffix}`;
     
     if (!quiet && onProgress) {
-      onProgress(`📄 복사 중: ${sourcePage.title} -> ${finalTitle}`);
+      onProgress(`Copying root: ${sourcePage.title} -> ${finalTitle}`);
     }
 
     // Create the root copied page
@@ -729,19 +730,7 @@ class ConfluenceClient {
     );
 
     if (!quiet && onProgress) {
-      onProgress(`✅ 루트 페이지 생성됨: ${newRootPage.title} (ID: ${newRootPage.id})`);
-    }
-
-    // Optional: pre-count descendants for progress only
-    let descendantsCount = 0;
-    try {
-      const allDescendants = await this.getAllDescendantPages(sourcePageId, maxDepth);
-      descendantsCount = allDescendants.length;
-    } catch (_) {
-      // Non-fatal if counting fails
-    }
-    if (!quiet && onProgress && descendantsCount) {
-      onProgress(`🔍 발견된 하위 페이지: ${descendantsCount}개`);
+      onProgress(`Root page created: ${newRootPage.title} (ID: ${newRootPage.id})`);
     }
 
     const result = {
@@ -810,16 +799,17 @@ class ConfluenceClient {
     }
 
     const children = await this.getChildPages(sourceParentId);
-    for (const child of children) {
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
       if (this.shouldExcludePage(child.title, excludePatterns)) {
         if (!quiet && onProgress) {
-          onProgress(`⏭️  제외됨: ${child.title}`);
+          onProgress(`Skipped: ${child.title}`);
         }
         continue;
       }
 
       if (!quiet && onProgress) {
-        onProgress(`📄 복사 중: ${child.title}`);
+        onProgress(`Copying: ${child.title}`);
       }
 
       try {
@@ -835,11 +825,11 @@ class ConfluenceClient {
 
         result.copiedPages.push(newPage);
         if (!quiet && onProgress) {
-          onProgress(`✅ 생성됨: ${newPage.title} (ID: ${newPage.id})`);
+          onProgress(`Created: ${newPage.title} (ID: ${newPage.id})`);
         }
 
-        // Rate limiting safety
-        if (delayMs > 0) {
+        // Rate limiting safety: only pause between siblings
+        if (delayMs > 0 && i < children.length - 1) {
           await new Promise(resolve => setTimeout(resolve, delayMs));
         }
 
@@ -847,13 +837,26 @@ class ConfluenceClient {
         await this.copyChildrenRecursive(child.id, newPage.id, currentDepth + 1, opts, result);
       } catch (error) {
         if (!quiet && onProgress) {
-          onProgress(`❌ 실패: ${child.title} - ${error.message}`);
+          onProgress(`Failed: ${child.title} - ${error.message}`);
         }
         result.failures.push({ id: child.id, title: child.title, error: error.message });
         // Continue with other pages (do not throw)
         continue;
       }
     }
+  }
+
+  /**
+   * Convert a simple glob pattern to a safe RegExp
+   * Supports '*' → '.*' and '?' → '.', escapes other regex metacharacters.
+   */
+  globToRegExp(pattern, flags = 'i') {
+    // Escape regex special characters: . + ^ $ { } ( ) | [ ] \
+    const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+    const regexPattern = escaped
+      .replace(/\*/g, '.*')
+      .replace(/\?/g, '.');
+    return new RegExp(`^${regexPattern}$`, flags);
   }
 
   /**
@@ -864,14 +867,7 @@ class ConfluenceClient {
       return false;
     }
 
-    return excludePatterns.some(pattern => {
-      // Convert glob-like pattern to regex
-      const regexPattern = pattern
-        .replace(/\*/g, '.*')
-        .replace(/\?/g, '.');
-      const regex = new RegExp(`^${regexPattern}$`, 'i');
-      return regex.test(title);
-    });
+    return excludePatterns.some(pattern => this.globToRegExp(pattern).test(title));
   }
 }
 

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -680,7 +680,9 @@ class ConfluenceClient {
     }
 
     const children = await this.getChildPages(pageId);
-    let allDescendants = [...children];
+    // Attach parentId so we can later reconstruct hierarchy if needed
+    const childrenWithParent = children.map(child => ({ ...child, parentId: pageId }));
+    let allDescendants = [...childrenWithParent];
 
     for (const child of children) {
       const grandChildren = await this.getAllDescendantPages(
@@ -702,7 +704,8 @@ class ConfluenceClient {
       maxDepth = 10,
       excludePatterns = [],
       onProgress = null,
-      quiet = false
+      quiet = false,
+      delayMs = 100,
     } = options;
 
     // Get source page information
@@ -729,35 +732,42 @@ class ConfluenceClient {
       onProgress(`✅ 루트 페이지 생성됨: ${newRootPage.title} (ID: ${newRootPage.id})`);
     }
 
-    // Get all descendant pages
-    const allDescendants = await this.getAllDescendantPages(sourcePageId, maxDepth);
-    
-    if (!quiet && onProgress) {
-      onProgress(`🔍 발견된 하위 페이지: ${allDescendants.length}개`);
+    // Optional: pre-count descendants for progress only
+    let descendantsCount = 0;
+    try {
+      const allDescendants = await this.getAllDescendantPages(sourcePageId, maxDepth);
+      descendantsCount = allDescendants.length;
+    } catch (_) {
+      // Non-fatal if counting fails
+    }
+    if (!quiet && onProgress && descendantsCount) {
+      onProgress(`🔍 발견된 하위 페이지: ${descendantsCount}개`);
     }
 
-    // Build a tree structure to maintain hierarchy
-    const pageTree = this.buildPageTree(allDescendants, sourcePageId);
-    
-    // Copy pages recursively maintaining hierarchy
-    const pageMapping = { [sourcePageId]: newRootPage.id };
-    const copiedPages = [newRootPage];
-    
-    await this.copyPageTreeRecursive(
-      pageTree,
-      pageMapping,
-      sourceInfo.space.key,
-      excludePatterns,
-      copiedPages,
-      onProgress,
-      quiet
+    const result = {
+      rootPage: newRootPage,
+      copiedPages: [newRootPage],
+      failures: [],
+      totalCopied: 1,
+    };
+
+    await this.copyChildrenRecursive(
+      sourcePageId,
+      newRootPage.id,
+      0,
+      {
+        spaceKey: sourceInfo.space.key,
+        maxDepth,
+        excludePatterns,
+        onProgress,
+        quiet,
+        delayMs,
+      },
+      result
     );
 
-    return {
-      rootPage: newRootPage,
-      copiedPages: copiedPages,
-      totalCopied: copiedPages.length
-    };
+    result.totalCopied = result.copiedPages.length;
+    return result;
   }
 
   /**
@@ -767,16 +777,23 @@ class ConfluenceClient {
     const pageMap = new Map();
     const tree = [];
 
-    // Create a map of all pages
+    // Create nodes
     pages.forEach(page => {
       pageMap.set(page.id, { ...page, children: [] });
     });
 
-    // Build the tree structure by finding parent-child relationships
+    // Link by parentId if available; otherwise attach to root
     pages.forEach(page => {
-      // For now, we'll use a simple approach: group by depth level
-      // In a real implementation, we'd need to track parent-child relationships
-      tree.push(pageMap.get(page.id));
+      const node = pageMap.get(page.id);
+      const parentId = page.parentId;
+      if (parentId && pageMap.has(parentId)) {
+        pageMap.get(parentId).children.push(node);
+      } else if (parentId === rootPageId || !parentId) {
+        tree.push(node);
+      } else {
+        // Parent not present in the list; treat as top-level under root
+        tree.push(node);
+      }
     });
 
     return tree;
@@ -785,49 +802,56 @@ class ConfluenceClient {
   /**
    * Recursively copy pages maintaining hierarchy
    */
-  async copyPageTreeRecursive(pageTree, pageMapping, spaceKey, excludePatterns, copiedPages, onProgress, quiet) {
-    for (const page of pageTree) {
-      // Check if page should be excluded
-      if (this.shouldExcludePage(page.title, excludePatterns)) {
+  async copyChildrenRecursive(sourceParentId, targetParentId, currentDepth, opts, result) {
+    const { spaceKey, maxDepth, excludePatterns, onProgress, quiet, delayMs = 100 } = opts || {};
+
+    if (currentDepth >= maxDepth) {
+      return;
+    }
+
+    const children = await this.getChildPages(sourceParentId);
+    for (const child of children) {
+      if (this.shouldExcludePage(child.title, excludePatterns)) {
         if (!quiet && onProgress) {
-          onProgress(`⏭️  제외됨: ${page.title}`);
+          onProgress(`⏭️  제외됨: ${child.title}`);
         }
         continue;
       }
 
-      // Find the parent page ID in our mapping
-      // For now, we'll assume all pages are direct children of the root
-      // In a more sophisticated implementation, we'd track the actual hierarchy
-      const parentId = pageMapping[Object.keys(pageMapping)[0]]; // Use root as parent for simplicity
-
       if (!quiet && onProgress) {
-        onProgress(`📄 복사 중: ${page.title}`);
+        onProgress(`📄 복사 중: ${child.title}`);
       }
 
       try {
+        // Fetch full content to ensure complete copy
+        const fullChild = await this.getPageForEdit(child.id);
         const newPage = await this.createChildPage(
-          page.title,
+          fullChild.title,
           spaceKey,
-          parentId,
-          page.content,
+          targetParentId,
+          fullChild.content,
           'storage'
         );
 
-        pageMapping[page.id] = newPage.id;
-        copiedPages.push(newPage);
-
+        result.copiedPages.push(newPage);
         if (!quiet && onProgress) {
           onProgress(`✅ 생성됨: ${newPage.title} (ID: ${newPage.id})`);
         }
 
-        // Small delay to avoid rate limiting
-        await new Promise(resolve => setTimeout(resolve, 100));
+        // Rate limiting safety
+        if (delayMs > 0) {
+          await new Promise(resolve => setTimeout(resolve, delayMs));
+        }
 
+        // Recurse into this child's subtree
+        await this.copyChildrenRecursive(child.id, newPage.id, currentDepth + 1, opts, result);
       } catch (error) {
         if (!quiet && onProgress) {
-          onProgress(`❌ 실패: ${page.title} - ${error.message}`);
+          onProgress(`❌ 실패: ${child.title} - ${error.message}`);
         }
-        throw error;
+        result.failures.push({ id: child.id, title: child.title, error: error.message });
+        // Continue with other pages (do not throw)
+        continue;
       }
     }
   }

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -740,6 +740,11 @@ class ConfluenceClient {
       totalCopied: 1,
     };
 
+    // Precompile exclude patterns once for efficiency
+    const compiledExclude = Array.isArray(excludePatterns)
+      ? excludePatterns.filter(Boolean).map(p => this.globToRegExp(p))
+      : [];
+
     await this.copyChildrenRecursive(
       sourcePageId,
       newRootPage.id,
@@ -748,6 +753,7 @@ class ConfluenceClient {
         spaceKey: sourceInfo.space.key,
         maxDepth,
         excludePatterns,
+        compiledExclude,
         onProgress,
         quiet,
         delayMs,
@@ -792,7 +798,7 @@ class ConfluenceClient {
    * Recursively copy pages maintaining hierarchy
    */
   async copyChildrenRecursive(sourceParentId, targetParentId, currentDepth, opts, result) {
-    const { spaceKey, maxDepth, excludePatterns, onProgress, quiet, delayMs = 100 } = opts || {};
+    const { spaceKey, maxDepth, excludePatterns, compiledExclude = [], onProgress, quiet, delayMs = 100 } = opts || {};
 
     if (currentDepth >= maxDepth) {
       return;
@@ -801,7 +807,8 @@ class ConfluenceClient {
     const children = await this.getChildPages(sourceParentId);
     for (let i = 0; i < children.length; i++) {
       const child = children[i];
-      if (this.shouldExcludePage(child.title, excludePatterns)) {
+      const patterns = (compiledExclude && compiledExclude.length) ? compiledExclude : excludePatterns;
+      if (this.shouldExcludePage(child.title, patterns)) {
         if (!quiet && onProgress) {
           onProgress(`Skipped: ${child.title}`);
         }
@@ -860,6 +867,7 @@ class ConfluenceClient {
    */
   globToRegExp(pattern, flags = 'i') {
     // Escape regex special characters: . + ^ $ { } ( ) | [ ] \
+    // Note: backslash must be escaped properly in string and class contexts
     const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
     const regexPattern = escaped
       .replace(/\*/g, '.*')
@@ -875,7 +883,10 @@ class ConfluenceClient {
       return false;
     }
 
-    return excludePatterns.some(pattern => this.globToRegExp(pattern).test(title));
+    return excludePatterns.some(pattern => {
+      if (pattern instanceof RegExp) return pattern.test(title);
+      return this.globToRegExp(pattern).test(title);
+    });
   }
 }
 

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -211,5 +211,15 @@ describe('ConfluenceClient', () => {
       const a = tree.find(n => n.title === 'A');
       expect(a.children.map(n => n.title)).toEqual(['B']);
     });
+
+    test('exclude parser should tolerate spaces and empty items', () => {
+      const raw = ' temp* , , *draft* ,,test? ';
+      const patterns = raw.split(',').map(p => p.trim()).filter(Boolean);
+      expect(patterns).toEqual(['temp*', '*draft*', 'test?']);
+      expect(client.shouldExcludePage('temp file', patterns)).toBe(true);
+      expect(client.shouldExcludePage('my draft page', patterns)).toBe(true);
+      expect(client.shouldExcludePage('test1', patterns)).toBe(true);
+      expect(client.shouldExcludePage('production', patterns)).toBe(false);
+    });
   });
 });

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -154,4 +154,30 @@ describe('ConfluenceClient', () => {
       expect(typeof client.findPageByTitle).toBe('function');
     });
   });
+
+  describe('page tree operations', () => {
+    test('should have required methods for tree operations', () => {
+      expect(typeof client.getChildPages).toBe('function');
+      expect(typeof client.getAllDescendantPages).toBe('function');
+      expect(typeof client.copyPageTree).toBe('function');
+      expect(typeof client.buildPageTree).toBe('function');
+      expect(typeof client.shouldExcludePage).toBe('function');
+    });
+
+    test('should correctly exclude pages based on patterns', () => {
+      const patterns = ['임시*', '테스트*', '*draft*'];
+      
+      expect(client.shouldExcludePage('임시 문서', patterns)).toBe(true);
+      expect(client.shouldExcludePage('테스트 페이지', patterns)).toBe(true);
+      expect(client.shouldExcludePage('my draft page', patterns)).toBe(true);
+      expect(client.shouldExcludePage('정상 문서', patterns)).toBe(false);
+      expect(client.shouldExcludePage('프로덕션 페이지', patterns)).toBe(false);
+    });
+
+    test('should handle empty exclude patterns', () => {
+      expect(client.shouldExcludePage('any page', [])).toBe(false);
+      expect(client.shouldExcludePage('any page', null)).toBe(false);
+      expect(client.shouldExcludePage('any page', undefined)).toBe(false);
+    });
+  });
 });

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -165,13 +165,13 @@ describe('ConfluenceClient', () => {
     });
 
     test('should correctly exclude pages based on patterns', () => {
-      const patterns = ['임시*', '테스트*', '*draft*'];
-      
-      expect(client.shouldExcludePage('임시 문서', patterns)).toBe(true);
-      expect(client.shouldExcludePage('테스트 페이지', patterns)).toBe(true);
+      const patterns = ['temp*', 'test*', '*draft*'];
+
+      expect(client.shouldExcludePage('temporary document', patterns)).toBe(true);
+      expect(client.shouldExcludePage('test page', patterns)).toBe(true);
       expect(client.shouldExcludePage('my draft page', patterns)).toBe(true);
-      expect(client.shouldExcludePage('정상 문서', patterns)).toBe(false);
-      expect(client.shouldExcludePage('프로덕션 페이지', patterns)).toBe(false);
+      expect(client.shouldExcludePage('normal document', patterns)).toBe(false);
+      expect(client.shouldExcludePage('production page', patterns)).toBe(false);
     });
 
     test('should handle empty exclude patterns', () => {


### PR DESCRIPTION
## Overview
Adds a new `copy-tree` command to the Confluence CLI to copy a page and all of its child pages to a new location while preserving the original hierarchy.

## Key Features
- Recursive tree copy with hierarchy preservation
- Depth control via `--max-depth`
- Flexible exclusions with simple glob patterns (`*`, `?`, case-insensitive)
- Progress reporting and quiet mode
- English-only CLI output for consistency
- Rate limiting safety with `--delay-ms` between siblings
- Configurable root naming via `--copy-suffix` (default: ` (Copy)`)
- Strict exit option with `--fail-on-error`
- Dry run support with `--dry-run` (preview only, no writes)

## Implementation Notes
- New client methods:
  - `getChildPages(pageId)` – lightweight child listing (no body payload)
  - `getAllDescendantPages(pageId, maxDepth)` – recursive traversal (adds `parentId`)
  - `copyPageTree(sourcePageId, targetParentId, newTitle, options)` – orchestrates copy
  - `buildPageTree(pages, rootPageId)` – helper for previews/tree building
  - `globToRegExp(pattern)` and `shouldExcludePage(title, patterns)` – robust pattern handling
- Precompiled exclude regex patterns for performance during recursion
- Reduced payload: child fetch no longer expands `body.storage`; full content fetched only when needed for creation
- Error handling: operations continue on failure; failures are summarized (with HTTP status when available)

## CLI Usage
```bash
# Copy entire tree under new parent, set root title
confluence copy-tree 123456789 987654321 "Project Docs (Copy)"

# Limit recursion depth to 3 levels
confluence copy-tree 123456789 987654321 --max-depth 3

# Exclude by title (simple globbing; case-insensitive)
confluence copy-tree 123456789 987654321 --exclude "temp*,test*,*draft*"

# Control pacing and naming
confluence copy-tree 123456789 987654321 --delay-ms 150 --copy-suffix " (Backup)"

# Dry run (preview only; prints planned root and first 50 children)
confluence copy-tree 123456789 987654321 --dry-run

# Fail the run if any page fails to copy
confluence copy-tree 123456789 987654321 --fail-on-error
```

## Behavior Notes
- Preserves parent–child relationships in the destination
- Continues on errors by default (failures listed at the end)
- Exclude patterns treat special regex chars literally; `*` matches any sequence, `?` matches one char
- Delay is applied between sibling creations to reduce rate limit risk
- Root title suffix defaults to ` (Copy)`; children retain their original titles

## Tests & Quality
- Added tests for:
  - `globToRegExp` edge cases (escaping metacharacters, case-insensitivity)
  - `buildPageTree` linking and orphan handling
  - Exclude parsing tolerance (spaces, empty items)
- All tests passing locally; lint clean

## Docs & Examples
- README updated with `copy-tree` usage and options
- Example scripts converted to English and reflect new flags

## Backwards Compatibility
- No breaking changes. New command and flags are additive.

Closes: Copy page tree feature request
