### PR TITLE
feat: make Confluence API path configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Added
+- Make the Confluence REST base path configurable to support both `/rest/api` and `/wiki/rest/api`.
+
 # [1.7.0](https://github.com/pchuri/confluence-cli/compare/v1.6.0...v1.7.0) (2025-09-28)
 
 

--- a/README.md
+++ b/README.md
@@ -58,18 +58,19 @@ npx confluence-cli
 confluence init
 ```
 
-The wizard now asks for your authentication method. Choose **Basic** to supply your Atlassian email and API token, or switch to **Bearer** when working with self-hosted/Data Center environments.
+The wizard now helps you choose the right API endpoint and authentication method. It recommends `/wiki/rest/api` for Atlassian Cloud domains (e.g., `*.atlassian.net`) and `/rest/api` for self-hosted/Data Center instances, then prompts for Basic (email + token) or Bearer authentication.
 
 ### Option 2: Environment Variables
 ```bash
 export CONFLUENCE_DOMAIN="your-domain.atlassian.net"
 export CONFLUENCE_API_TOKEN="your-api-token"
 export CONFLUENCE_EMAIL="your.email@example.com"  # required when using Atlassian Cloud
+export CONFLUENCE_API_PATH="/wiki/rest/api"         # Cloud default; use /rest/api for Server/DC
 # Optional: set to 'bearer' for self-hosted/Data Center instances
 export CONFLUENCE_AUTH_TYPE="basic"
 ```
 
-`CONFLUENCE_AUTH_TYPE` defaults to `basic` when an email is present and falls back to `bearer` otherwise. Provide an email for Atlassian Cloud (Basic auth) or set `CONFLUENCE_AUTH_TYPE=bearer` to keep bearer-token flows for on-premises installations.
+`CONFLUENCE_API_PATH` defaults to `/wiki/rest/api` for Atlassian Cloud domains and `/rest/api` otherwise. Override it when your site lives under a custom reverse proxy or on-premises path. `CONFLUENCE_AUTH_TYPE` defaults to `basic` when an email is present and falls back to `bearer` otherwise.
 
 ### Getting Your API Token
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -74,7 +74,7 @@ async function initConfig() {
       validate: (input, responses) => {
         const value = (input || '').trim();
         if (!value) {
-          return 'API path is required';
+          return true;
         }
         if (!value.startsWith('/')) {
           return 'API path must start with "/"';

--- a/lib/config.js
+++ b/lib/config.js
@@ -27,6 +27,34 @@ const normalizeAuthType = (rawValue, hasEmail) => {
   return hasEmail ? 'basic' : 'bearer';
 };
 
+const inferApiPath = (domain) => {
+  if (!domain) {
+    return '/rest/api';
+  }
+
+  const normalizedDomain = domain.trim().toLowerCase();
+  if (normalizedDomain.endsWith('.atlassian.net')) {
+    return '/wiki/rest/api';
+  }
+
+  return '/rest/api';
+};
+
+const normalizeApiPath = (rawValue, domain) => {
+  const trimmed = (rawValue || '').trim();
+
+  if (!trimmed) {
+    return inferApiPath(domain);
+  }
+
+  if (!trimmed.startsWith('/')) {
+    throw new Error('Confluence API path must start with "/".');
+  }
+
+  const withoutTrailing = trimmed.replace(/\/+$/, '');
+  return withoutTrailing || inferApiPath(domain);
+};
+
 async function initConfig() {
   console.log(chalk.blue('🚀 Confluence CLI Configuration'));
   console.log('Please provide your Confluence connection details:\n');
@@ -37,6 +65,27 @@ async function initConfig() {
       name: 'domain',
       message: 'Confluence domain (e.g., yourcompany.atlassian.net):',
       validate: requiredInput('Domain')
+    },
+    {
+      type: 'input',
+      name: 'apiPath',
+      message: 'REST API path (Cloud: /wiki/rest/api, Server: /rest/api):',
+      default: (responses) => inferApiPath(responses.domain),
+      validate: (input, responses) => {
+        const value = (input || '').trim();
+        if (!value) {
+          return 'API path is required';
+        }
+        if (!value.startsWith('/')) {
+          return 'API path must start with "/"';
+        }
+        try {
+          normalizeApiPath(value, responses.domain);
+          return true;
+        } catch (error) {
+          return error.message;
+        }
+      }
     },
     {
       type: 'list',
@@ -66,6 +115,7 @@ async function initConfig() {
 
   const config = {
     domain: answers.domain.trim(),
+    apiPath: normalizeApiPath(answers.apiPath, answers.domain),
     token: answers.token.trim(),
     authType: answers.authType,
     email: answers.authType === 'basic' ? answers.email.trim() : undefined
@@ -83,9 +133,18 @@ function getConfig() {
   const envToken = process.env.CONFLUENCE_API_TOKEN;
   const envEmail = process.env.CONFLUENCE_EMAIL;
   const envAuthType = process.env.CONFLUENCE_AUTH_TYPE;
+  const envApiPath = process.env.CONFLUENCE_API_PATH;
 
   if (envDomain && envToken) {
     const authType = normalizeAuthType(envAuthType, Boolean(envEmail));
+    let apiPath;
+
+    try {
+      apiPath = normalizeApiPath(envApiPath, envDomain);
+    } catch (error) {
+      console.error(chalk.red(`❌ ${error.message}`));
+      process.exit(1);
+    }
 
     if (authType === 'basic' && !envEmail) {
       console.error(chalk.red('❌ Basic authentication requires CONFLUENCE_EMAIL.'));
@@ -95,6 +154,7 @@ function getConfig() {
 
     return {
       domain: envDomain.trim(),
+      apiPath,
       token: envToken.trim(),
       email: envEmail ? envEmail.trim() : undefined,
       authType
@@ -104,7 +164,7 @@ function getConfig() {
   if (!fs.existsSync(CONFIG_FILE)) {
     console.error(chalk.red('❌ No configuration found!'));
     console.log(chalk.yellow('Please run "confluence init" to set up your configuration.'));
-    console.log(chalk.gray('Or set environment variables: CONFLUENCE_DOMAIN, CONFLUENCE_API_TOKEN, and CONFLUENCE_EMAIL.'));
+    console.log(chalk.gray('Or set environment variables: CONFLUENCE_DOMAIN, CONFLUENCE_API_TOKEN, CONFLUENCE_EMAIL, and optionally CONFLUENCE_API_PATH.'));
     process.exit(1);
   }
 
@@ -114,6 +174,7 @@ function getConfig() {
     const trimmedToken = (storedConfig.token || '').trim();
     const trimmedEmail = storedConfig.email ? storedConfig.email.trim() : undefined;
     const authType = normalizeAuthType(storedConfig.authType, Boolean(trimmedEmail));
+    let apiPath;
 
     if (!trimmedDomain || !trimmedToken) {
       console.error(chalk.red('❌ Configuration file is missing required values.'));
@@ -127,8 +188,17 @@ function getConfig() {
       process.exit(1);
     }
 
+    try {
+      apiPath = normalizeApiPath(storedConfig.apiPath, trimmedDomain);
+    } catch (error) {
+      console.error(chalk.red(`❌ ${error.message}`));
+      console.log(chalk.yellow('Please rerun "confluence init" to update your API path.'));
+      process.exit(1);
+    }
+
     return {
       domain: trimmedDomain,
+      apiPath,
       token: trimmedToken,
       email: trimmedEmail,
       authType

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -8,7 +8,8 @@ class ConfluenceClient {
     this.token = config.token;
     this.email = config.email;
     this.authType = (config.authType || (this.email ? 'basic' : 'bearer')).toLowerCase();
-    this.baseURL = `https://${this.domain}/rest/api`;
+    this.apiPath = this.sanitizeApiPath(config.apiPath);
+    this.baseURL = `https://${this.domain}${this.apiPath}`;
     this.markdown = new MarkdownIt();
     this.setupConfluenceMarkdownExtensions();
 
@@ -21,6 +22,19 @@ class ConfluenceClient {
       baseURL: this.baseURL,
       headers
     });
+  }
+
+  sanitizeApiPath(rawPath) {
+    const fallback = '/rest/api';
+    const value = (rawPath || '').trim();
+
+    if (!value) {
+      return fallback;
+    }
+
+    const withoutLeading = value.replace(/^\/+/, '');
+    const normalized = `/${withoutLeading}`.replace(/\/+$/, '');
+    return normalized || fallback;
   }
 
   buildBasicAuthHeader() {

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -10,6 +10,27 @@ describe('ConfluenceClient', () => {
     });
   });
 
+  describe('api path handling', () => {
+    test('defaults to /rest/api when path is not provided', () => {
+      const defaultClient = new ConfluenceClient({
+        domain: 'example.com',
+        token: 'no-path-token'
+      });
+
+      expect(defaultClient.baseURL).toBe('https://example.com/rest/api');
+    });
+
+    test('normalizes custom api paths', () => {
+      const customClient = new ConfluenceClient({
+        domain: 'cloud.example',
+        token: 'custom-path',
+        apiPath: 'wiki/rest/api/'
+      });
+
+      expect(customClient.baseURL).toBe('https://cloud.example/wiki/rest/api');
+    });
+  });
+
   describe('authentication setup', () => {
     test('uses bearer token headers by default', () => {
       const bearerClient = new ConfluenceClient({


### PR DESCRIPTION
## Summary
Adds first-class support for both `/rest/api` and `/wiki/rest/api` so the CLI works out of the box with Confluence Server/Data Center and Cloud.

## Changes
- Extend `confluence init` to capture the REST API path, defaulting to `/wiki/rest/api` for `*.atlassian.net` domains and `/rest/api` otherwise.
- Allow overrides through a new `CONFLUENCE_API_PATH` environment variable.
- Update `ConfluenceClient` to normalize the base path before constructing the axios client.
- Refresh README/CHANGELOG and add unit tests covering defaulting and normalization logic.

## Testing
- `npm run lint`
- `npm test -- --runInBand`
