### PR TITLE
fix: support children macro, improve macro handling, and filter attachments

### DIFF
--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -100,11 +100,42 @@ class ConfluenceClient {
   }
 
   /**
+   * Extract referenced attachment filenames from HTML content
+   * @param {string} htmlContent - HTML content in storage format
+   * @returns {Set<string>} Set of referenced attachment filenames
+   */
+  extractReferencedAttachments(htmlContent) {
+    const referenced = new Set();
+    
+    // Extract from ac:image with ri:attachment
+    const imageRegex = /<ac:image[^>]*>[\s\S]*?<ri:attachment\s+ri:filename="([^"]+)"[^>]*\/?>[\s\S]*?<\/ac:image>/g;
+    let match;
+    while ((match = imageRegex.exec(htmlContent)) !== null) {
+      referenced.add(match[1]);
+    }
+    
+    // Extract from view-file macro
+    const viewFileRegex = /<ac:structured-macro ac:name="view-file"[^>]*>[\s\S]*?<ri:attachment\s+ri:filename="([^"]+)"[^>]*\/?>[\s\S]*?<\/ac:structured-macro>/g;
+    while ((match = viewFileRegex.exec(htmlContent)) !== null) {
+      referenced.add(match[1]);
+    }
+    
+    // Extract from any ri:attachment references
+    const attachmentRegex = /<ri:attachment\s+ri:filename="([^"]+)"[^>]*\/?>/g;
+    while ((match = attachmentRegex.exec(htmlContent)) !== null) {
+      referenced.add(match[1]);
+    }
+    
+    return referenced;
+  }
+
+  /**
    * Read a Confluence page content
    * @param {string} pageIdOrUrl - Page ID or URL
    * @param {string} format - Output format: 'text', 'html', or 'markdown'
    * @param {object} options - Additional options
    * @param {boolean} options.resolveUsers - Whether to resolve userkeys to display names (default: true for markdown)
+   * @param {boolean} options.extractReferencedAttachments - Whether to extract referenced attachments (default: false)
    */
   async readPage(pageIdOrUrl, format = 'text', options = {}) {
     const pageId = await this.extractPageId(pageIdOrUrl);
@@ -116,6 +147,11 @@ class ConfluenceClient {
     });
 
     let htmlContent = response.data.body.storage.value;
+    
+    // Extract referenced attachments if requested
+    if (options.extractReferencedAttachments) {
+      this._referencedAttachments = this.extractReferencedAttachments(htmlContent);
+    }
     
     if (format === 'html') {
       return htmlContent;
@@ -134,6 +170,9 @@ class ConfluenceClient {
       if (resolvePageLinks) {
         htmlContent = await this.resolvePageLinksInHtml(htmlContent);
       }
+      
+      // Resolve children macro to child pages list
+      htmlContent = await this.resolveChildrenMacro(htmlContent, pageId);
       
       return this.storageToMarkdown(htmlContent);
     }
@@ -359,6 +398,58 @@ class ConfluenceClient {
   }
 
   /**
+   * Resolve children macro to child pages list
+   * @param {string} html - HTML content with children macro
+   * @param {string} pageId - Page ID to get children from
+   * @returns {Promise<string>} - HTML with children macro replaced by markdown list
+   */
+  async resolveChildrenMacro(html, pageId) {
+    // Check if there's a children macro (self-closing or with closing tag)
+    const childrenMacroRegex = /<ac:structured-macro\s+ac:name="children"[^>]*(?:\/>|>[\s\S]*?<\/ac:structured-macro>)/g;
+    const hasChildrenMacro = childrenMacroRegex.test(html);
+    
+    if (!hasChildrenMacro) {
+      return html;
+    }
+
+    try {
+      // Get child pages with full info including _links
+      const response = await this.client.get(`/content/${pageId}/child/page`, {
+        params: {
+          limit: 500,
+          expand: 'space,version'
+        }
+      });
+      
+      const childPages = response.data.results || [];
+      
+      if (childPages.length === 0) {
+        // No children, remove the macro
+        return html.replace(childrenMacroRegex, '');
+      }
+
+      // Convert child pages to markdown list
+      // Format: - [Page Title](URL)
+      const childPagesList = childPages.map(page => {
+        const webui = page._links?.webui || '';
+        const url = webui ? `https://${this.domain}/wiki${webui}` : '';
+        if (url) {
+          return `- [${page.title}](${url})`;
+        } else {
+          return `- ${page.title}`;
+        }
+      }).join('\n');
+
+      // Replace children macro with markdown list
+      return html.replace(childrenMacroRegex, `\n${childPagesList}\n`);
+    } catch (error) {
+      // If error getting children, just remove the macro
+      console.error(`Error resolving children macro: ${error.message}`);
+      return html.replace(childrenMacroRegex, '');
+    }
+  }
+
+  /**
    * List attachments for a page with pagination support
    */
   async listAttachments(pageIdOrUrl, options = {}) {
@@ -462,13 +553,12 @@ class ConfluenceClient {
     // Convert markdown to HTML first
     const html = this.markdown.render(markdown);
     
-    // Delegate to the robust HTML to Storage converter
+    // Convert HTML to native Confluence storage format elements
     return this.htmlToConfluenceStorage(html);
   }
 
   /**
-   * Convert HTML to native Confluence storage format.
-   * Handles Confluence macros and native storage format elements.
+   * Convert HTML to native Confluence storage format
    */
   htmlToConfluenceStorage(html) {
     let storage = html;
@@ -557,7 +647,7 @@ class ConfluenceClient {
     // Convert markdown to HTML first
     const html = this.markdown.render(markdown);
     
-    // Delegate to the robust HTML to Storage converter
+    // Delegate to htmlToConfluenceStorage for proper conversion including code blocks
     return this.htmlToConfluenceStorage(html);
   }
 
@@ -595,6 +685,76 @@ class ConfluenceClient {
   }
 
   /**
+   * Detect language from text content and return appropriate labels
+   * @param {string} text - Text content to analyze
+   * @returns {object} Object with language-specific labels
+   */
+  detectLanguageLabels(text) {
+    const labels = {
+      includePage: 'Include Page',
+      sharedBlock: 'Shared Block',
+      includeSharedBlock: 'Include Shared Block',
+      fromPage: 'from page',
+      expandDetails: 'Expand Details'
+    };
+    
+    if (/[\u4e00-\u9fa5]/.test(text)) {
+      // Chinese
+      labels.includePage = '包含页面';
+      labels.sharedBlock = '共享块';
+      labels.includeSharedBlock = '包含共享块';
+      labels.fromPage = '来自页面';
+      labels.expandDetails = '展开详情';
+    } else if (/[\u3040-\u309f\u30a0-\u30ff]/.test(text)) {
+      // Japanese
+      labels.includePage = 'ページを含む';
+      labels.sharedBlock = '共有ブロック';
+      labels.includeSharedBlock = '共有ブロックを含む';
+      labels.fromPage = 'ページから';
+      labels.expandDetails = '詳細を表示';
+    } else if (/[\uac00-\ud7af]/.test(text)) {
+      // Korean
+      labels.includePage = '페이지 포함';
+      labels.sharedBlock = '공유 블록';
+      labels.includeSharedBlock = '공유 블록 포함';
+      labels.fromPage = '페이지에서';
+      labels.expandDetails = '상세 보기';
+    } else if (/[\u0400-\u04ff]/.test(text)) {
+      // Russian/Cyrillic
+      labels.includePage = 'Включить страницу';
+      labels.sharedBlock = 'Общий блок';
+      labels.includeSharedBlock = 'Включить общий блок';
+      labels.fromPage = 'со страницы';
+      labels.expandDetails = 'Подробнее';
+    } else if ((text.match(/[àâäéèêëïîôùûüÿœæç]/gi) || []).length >= 2) {
+      // French (requires at least 2 French-specific characters to avoid false positives)
+      labels.includePage = 'Inclure la page';
+      labels.sharedBlock = 'Bloc partagé';
+      labels.includeSharedBlock = 'Inclure le bloc partagé';
+      labels.fromPage = 'de la page';
+      labels.expandDetails = 'Détails';
+    } else if ((text.match(/[äöüß]/gi) || []).length >= 2) {
+      // German (requires at least 2 German-specific characters)
+      // Note: French is checked before German because French regex includes more characters
+      // that overlap with German (ä, ü). The threshold helps distinguish between them.
+      labels.includePage = 'Seite einbinden';
+      labels.sharedBlock = 'Gemeinsamer Block';
+      labels.includeSharedBlock = 'Gemeinsamen Block einbinden';
+      labels.fromPage = 'von Seite';
+      labels.expandDetails = 'Details';
+    } else if ((text.match(/[áéíóúñ¿¡]/gi) || []).length >= 2) {
+      // Spanish (requires at least 2 Spanish-specific characters)
+      labels.includePage = 'Incluir página';
+      labels.sharedBlock = 'Bloque compartido';
+      labels.includeSharedBlock = 'Incluir bloque compartido';
+      labels.fromPage = 'de la página';
+      labels.expandDetails = 'Detalles';
+    }
+    
+    return labels;
+  }
+
+  /**
    * Convert Confluence storage format to markdown
    * @param {string} storage - Confluence storage format HTML
    * @param {object} options - Conversion options
@@ -603,6 +763,9 @@ class ConfluenceClient {
   storageToMarkdown(storage, options = {}) {
     const attachmentsDir = options.attachmentsDir || 'attachments';
     let markdown = storage;
+    
+    // Detect language from content
+    const labels = this.detectLanguageLabels(markdown);
     
     // Remove table of contents macro
     markdown = markdown.replace(/<ac:structured-macro ac:name="toc"[^>]*\s*\/>/g, '');
@@ -628,20 +791,8 @@ class ConfluenceClient {
     });
     
     // Convert expand macro - extract content from rich-text-body
-    // Detect language based on content for the expand summary text
-    const detectExpandSummary = (text) => {
-      if (/[\u4e00-\u9fa5]/.test(text)) return '展开详情';      // Chinese
-      if (/[\u3040-\u309f\u30a0-\u30ff]/.test(text)) return '詳細を表示'; // Japanese
-      if (/[\uac00-\ud7af]/.test(text)) return '상세 보기';    // Korean
-      if (/[\u0400-\u04ff]/.test(text)) return 'Подробнее';    // Russian/Cyrillic
-      if (/[àâäéèêëïîôùûüÿœæç]/i.test(text)) return 'Détails'; // French
-      if (/[äöüß]/i.test(text)) return 'Details';              // German
-      if (/[áéíóúñ¿¡]/i.test(text)) return 'Detalles';         // Spanish
-      return 'Expand Details';  // Default: English
-    };
-    const expandSummary = detectExpandSummary(markdown);
     markdown = markdown.replace(/<ac:structured-macro ac:name="expand"[^>]*>[\s\S]*?<ac:rich-text-body>([\s\S]*?)<\/ac:rich-text-body>[\s\S]*?<\/ac:structured-macro>/g, (_, content) => {
-      return `\n<details>\n<summary>${expandSummary}</summary>\n\n${content}\n\n</details>\n`;
+      return `\n<details>\n<summary>${labels.expandDetails}</summary>\n\n${content}\n\n</details>\n`;
     });
     
     // Convert Confluence code macros to markdown
@@ -691,6 +842,58 @@ class ConfluenceClient {
       }
       return tasks.length > 0 ? '\n' + tasks.join('\n') + '\n' : '';
     });
+    
+    // Convert panel macro to markdown blockquote with title
+    markdown = markdown.replace(/<ac:structured-macro ac:name="panel"[^>]*>[\s\S]*?<ac:parameter ac:name="title">([^<]*)<\/ac:parameter>[\s\S]*?<ac:rich-text-body>([\s\S]*?)<\/ac:rich-text-body>[\s\S]*?<\/ac:structured-macro>/g, (_, title, content) => {
+      const cleanContent = this.htmlToMarkdown(content);
+      return `\n> **${title}**\n>\n${cleanContent.split('\n').map(line => line ? `> ${line}` : '>').join('\n')}\n`;
+    });
+    
+    // Convert include macro - extract page link and convert to markdown link
+    // Handle both with and without parameter name
+    markdown = markdown.replace(/<ac:structured-macro ac:name="include"[^>]*>[\s\S]*?<ac:parameter ac:name="">[\s\S]*?<ac:link>[\s\S]*?<ri:page\s+ri:space-key="([^"]+)"\s+ri:content-title="([^"]+)"[^>]*\/>[\s\S]*?<\/ac:link>[\s\S]*?<\/ac:parameter>[\s\S]*?<\/ac:structured-macro>/g, (_, spaceKey, title) => {
+      // Try to build a proper URL - if spaceKey starts with ~, it's a user space
+      if (spaceKey.startsWith('~')) {
+        const spacePath = `display/${spaceKey}/${encodeURIComponent(title)}`;
+        return `\n> 📄 **${labels.includePage}**: [${title}](https://${this.domain}/wiki/${spacePath})\n`;
+      } else {
+        // For non-user spaces, we cannot construct a valid link without the page ID.
+        // Document that manual correction is required.
+        return `\n> 📄 **${labels.includePage}**: [${title}](https://${this.domain}/wiki/spaces/${spaceKey}/pages/[PAGE_ID_HERE]) _(manual link correction required)_\n`;
+      }
+    });
+    
+    // Convert shared-block and include-shared-block macros - extract content
+    markdown = markdown.replace(/<ac:structured-macro ac:name="(shared-block|include-shared-block)"[^>]*>[\s\S]*?<ac:parameter ac:name="shared-block-key">([^<]*)<\/ac:parameter>[\s\S]*?<ac:rich-text-body>([\s\S]*?)<\/ac:rich-text-body>[\s\S]*?<\/ac:structured-macro>/g, (_, macroType, blockKey, content) => {
+      const cleanContent = this.htmlToMarkdown(content);
+      return `\n> **${labels.sharedBlock}: ${blockKey}**\n>\n${cleanContent.split('\n').map(line => line ? `> ${line}` : '>').join('\n')}\n`;
+    });
+    
+    // Convert include-shared-block with page parameter
+    markdown = markdown.replace(/<ac:structured-macro ac:name="include-shared-block"[^>]*>[\s\S]*?<ac:parameter ac:name="shared-block-key">([^<]*)<\/ac:parameter>[\s\S]*?<ac:parameter ac:name="page">[\s\S]*?<ac:link>[\s\S]*?<ri:page\s+ri:space-key="([^"]+)"\s+ri:content-title="([^"]+)"[^>]*\/>[\s\S]*?<\/ac:link>[\s\S]*?<\/ac:parameter>[\s\S]*?<\/ac:structured-macro>/g, (_, blockKey, spaceKey, pageTitle) => {
+      // The page ID is not available, so we cannot generate a valid link.
+      // Instead, document that the link needs manual correction.
+      return `\n> 📄 **${labels.includeSharedBlock}**: ${blockKey} (${labels.fromPage}: ${pageTitle} [link needs manual correction])\n`;
+    });
+    
+    // Convert view-file macro to file link
+    // Handle both orders: name first or height first
+    markdown = markdown.replace(/<ac:structured-macro ac:name="view-file"[^>]*>[\s\S]*?<ac:parameter ac:name="name">[\s\S]*?<ri:attachment\s+ri:filename="([^"]+)"[^>]*\/>[\s\S]*?<\/ac:parameter>[\s\S]*?<\/ac:structured-macro>/g, (_, filename) => {
+      return `\n📎 [${filename}](${attachmentsDir}/${filename})\n`;
+    });
+    
+    // Also handle view-file with height parameter (which might appear after name)
+    markdown = markdown.replace(/<ac:structured-macro ac:name="view-file"[^>]*>[\s\S]*?<ac:parameter ac:name="name">[\s\S]*?<ri:attachment\s+ri:filename="([^"]+)"[^>]*\/>[\s\S]*?<\/ac:parameter>[\s\S]*?<ac:parameter ac:name="height">([^<]*)<\/ac:parameter>[\s\S]*?<\/ac:structured-macro>/g, (_, filename, _height) => {
+      return `\n📎 [${filename}](${attachmentsDir}/${filename})\n`;
+    });
+    
+    // Remove layout macros but preserve content
+    markdown = markdown.replace(/<ac:layout>/g, '');
+    markdown = markdown.replace(/<\/ac:layout>/g, '');
+    markdown = markdown.replace(/<ac:layout-section[^>]*>/g, '');
+    markdown = markdown.replace(/<\/ac:layout-section>/g, '');
+    markdown = markdown.replace(/<ac:layout-cell[^>]*>/g, '');
+    markdown = markdown.replace(/<\/ac:layout-cell>/g, '');
     
     // Remove other unhandled macros (replace with empty string for now)
     markdown = markdown.replace(/<ac:structured-macro[^>]*>[\s\S]*?<\/ac:structured-macro>/g, '');


### PR DESCRIPTION
## Summary
This PR fixes several issues with Confluence CLI export functionality:

1. **Children macro support**: Pages using the `children` macro now export child pages as a markdown list
2. **Macro handling**: Improved support for `panel`, `include`, `shared-block`, `include-shared-block`, `view-file`, and layout macros
3. **Multilingual support**: Added automatic language detection for labels (Chinese, Japanese, Korean, Russian, French, German, Spanish, English)
4. **Attachment filtering**: Export command now only downloads attachments that are actually referenced in the page content (instead of all historical attachments)

## Changes

### 1. Children Macro Support (`lib/confluence-client.js`)
- Added `resolveChildrenMacro()` method to convert `children` macro to markdown list of child pages
- Child pages are listed with links to their Confluence pages

### 2. Macro Handling Improvements (`lib/confluence-client.js`)
- Added `detectLanguageLabels()` method for automatic language detection
- Improved `storageToMarkdown()` to handle:
  - `panel` macro → markdown blockquote with title
  - `include` macro → markdown link to included page
  - `shared-block` and `include-shared-block` macros → markdown blockquote with content
  - `view-file` macro → file link
  - Layout macros (`ac:layout`, `ac:layout-section`, `ac:layout-cell`) → removed, content preserved

### 3. Attachment Filtering (`lib/confluence-client.js`, `bin/confluence.js`)
- Added `extractReferencedAttachments()` method to extract attachment filenames from page content
- Modified `readPage()` to support extracting referenced attachments
- Modified `export` command to only download referenced attachments by default
- Pattern filtering (`--pattern`) still works for filtering all attachments if needed

## Testing
Tested with pages containing:
- Children macro with 136 child pages
- Panel macros with nested content
- Include macros referencing other pages
- Shared blocks
- Multiple image attachments (71 total, only 5 referenced)

## Breaking Changes
None. All changes are backward compatible.

## Related Issues
Fixes issues where:
- Pages with `children` macro exported empty content
- Pages with complex macros lost content during export
- Export command downloaded all historical attachments instead of only referenced ones