### PR TITLE
feat: add page delete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A powerful command-line interface for Atlassian Confluence that allows you to re
 - 🏠 **List spaces** - View all available Confluence spaces
 - ✏️ **Create pages** - Create new pages with support for Markdown, HTML, or Storage format
 - 📝 **Update pages** - Update existing page content and titles
+- 🗑️ **Delete pages** - Delete (or move to trash) pages by ID or URL
 - 📎 **Attachments** - List or download page attachments
 - 📦 **Export** - Save a page and its attachments to a local folder
 - 🛠️ **Edit workflow** - Export page content for editing and re-import
@@ -207,6 +208,18 @@ confluence update 123456789 --file ./updated-content.md --format markdown
 
 # Update both title and content
 confluence update 123456789 --title "New Title" --content "And new content"
+```
+
+### Delete a Page
+```bash
+# Delete by page ID (prompts for confirmation)
+confluence delete 123456789
+
+# Delete by URL
+confluence delete "https://your-domain.atlassian.net/wiki/viewpage.action?pageId=123456789"
+
+# Skip confirmation (useful for scripts)
+confluence delete 123456789 --yes
 ```
 
 ### Edit Workflow

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -1209,6 +1209,16 @@ class ConfluenceClient {
   }
 
   /**
+   * Delete a Confluence page
+   * Note: Confluence may move the page to trash depending on instance settings.
+   */
+  async deletePage(pageIdOrUrl) {
+    const pageId = await this.extractPageId(pageIdOrUrl);
+    await this.client.delete(`/content/${pageId}`);
+    return { id: String(pageId) };
+  }
+
+  /**
    * Search for a page by title and space
    */
   async findPageByTitle(title, spaceKey = null) {

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -267,6 +267,29 @@ describe('ConfluenceClient', () => {
       expect(typeof client.getPageForEdit).toBe('function');
       expect(typeof client.createChildPage).toBe('function');
       expect(typeof client.findPageByTitle).toBe('function');
+      expect(typeof client.deletePage).toBe('function');
+    });
+  });
+
+  describe('deletePage', () => {
+    test('should delete a page by ID', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onDelete('/content/123456789').reply(204);
+
+      await expect(client.deletePage('123456789')).resolves.toEqual({ id: '123456789' });
+
+      mock.restore();
+    });
+
+    test('should delete a page by URL', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onDelete('/content/987654321').reply(204);
+
+      await expect(
+        client.deletePage('https://test.atlassian.net/wiki/viewpage.action?pageId=987654321')
+      ).resolves.toEqual({ id: '987654321' });
+
+      mock.restore();
     });
   });
 


### PR DESCRIPTION
Closes #24.

## What
- Adds `ConfluenceClient.deletePage(pageIdOrUrl)` using `DELETE /content/{id}`
- Adds CLI command `confluence delete <pageIdOrUrl>` with confirmation prompt (`--yes` to skip)
- Adds Jest coverage for `deletePage`
- Documents the new command in README

## Usage
- `confluence delete 123456789`
- `confluence delete "https://your-domain.atlassian.net/wiki/viewpage.action?pageId=123456789"`
- `confluence delete 123456789 --yes`
