### PR TITLE
fix: align README with CLI behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,10 @@ confluence stats
 | `create-child <title> <parentId>` | Create a child page | `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>` |
 | `copy-tree <sourcePageId> <targetParentId> [newTitle]` | Copy page tree with all children | `--max-depth <number>`, `--exclude <patterns>`, `--delay-ms <ms>`, `--copy-suffix <text>`, `--dry-run`, `--fail-on-error`, `--quiet` |
 | `update <pageId>` | Update a page's title or content | `--title <string>`, `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>` |
+| `delete <pageId_or_url>` | Delete a page by ID or URL | `--yes` |
 | `edit <pageId>` | Export page content for editing | `--output <file>` |
+| `attachments <pageId_or_url>` | List or download attachments for a page | `--limit <number>`, `--pattern <glob>`, `--download`, `--dest <directory>` |
+| `export <pageId_or_url>` | Export a page to a directory with its attachments | `--format <html\|text\|markdown>`, `--dest <directory>`, `--file <filename>`, `--attachments-dir <name>`, `--pattern <glob>`, `--referenced-only`, `--skip-attachments` |
 | `stats` | View your usage statistics | |
 
 ## Examples

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A command-line interface for Atlassian Confluence with page creation and editing capabilities",
   "main": "index.js",
   "bin": {
-    "confluence": "bin/index.js"
+    "confluence": "bin/index.js",
+    "confluence-cli": "bin/index.js"
   },
   "scripts": {
     "start": "node bin/confluence.js",


### PR DESCRIPTION
## Summary
- Align README command list with implemented CLI commands.
- Make `export` download all attachments by default; preserve previous behavior behind `--referenced-only`.
- Add `confluence-cli` bin alias so `npx confluence-cli` works as documented.

## Notes
- Tests: `npm test`
- Lint: `npm run lint`
