### PR TITLE
feat: Add children command to list child pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,17 @@ npx confluence-cli
    confluence search "my search term"
    ```
 
-4. **Create a new page:**
+4. **List child pages:**
+   ```bash
+   confluence children 123456789
+   ```
+
+5. **Create a new page:**
    ```bash
    confluence create "My New Page" SPACEKEY --content "Hello World!"
    ```
 
-5. **Update a page:**
+6. **Update a page:**
    ```bash
    confluence update 123456789 --content "Updated content"
    ```
@@ -137,6 +142,27 @@ confluence export 123456789 --skip-attachments
 ### List Spaces
 ```bash
 confluence spaces
+```
+
+### List Child Pages
+```bash
+# List direct child pages
+confluence children 123456789
+
+# List all descendants recursively
+confluence children 123456789 --recursive
+
+# Display as tree structure
+confluence children 123456789 --recursive --format tree
+
+# Show page IDs and URLs
+confluence children 123456789 --show-id --show-url
+
+# Limit recursion depth
+confluence children 123456789 --recursive --max-depth 3
+
+# Output as JSON for scripting
+confluence children 123456789 --recursive --format json > children.json
 ```
 
 ### Find a Page by Title
@@ -250,6 +276,7 @@ confluence stats
 | `search <query>` | Search for pages | `--limit <number>` |
 | `spaces` | List all available spaces | |
 | `find <title>` | Find a page by its title | `--space <spaceKey>` |
+| `children <pageId>` | List child pages of a page | `--recursive`, `--max-depth <number>`, `--format <list\|tree\|json>`, `--show-url`, `--show-id` |
 | `create <title> <spaceKey>` | Create a new page | `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>`|
 | `create-child <title> <parentId>` | Create a child page | `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>` |
 | `copy-tree <sourcePageId> <targetParentId> [newTitle]` | Copy page tree with all children | `--max-depth <number>`, `--exclude <patterns>`, `--delay-ms <ms>`, `--copy-suffix <text>`, `--dry-run`, `--fail-on-error`, `--quiet` |


### PR DESCRIPTION
## Summary

This PR adds a new `children` command to list and explore child pages of a Confluence page.

## Features

- **List direct child pages**: Simple listing of immediate children
- **Recursive listing**: Display all descendants with `--recursive` flag
- **Multiple output formats**: 
  - `list` (default): Simple numbered list
  - `tree`: Hierarchical tree visualization
  - `json`: Machine-readable JSON output
- **Flexible display options**:
  - `--show-id`: Display page IDs
  - `--show-url`: Display page URLs
  - `--max-depth`: Limit recursion depth
- **Integration with existing methods**: Leverages existing `getChildPages()` and `getAllDescendantPages()` methods

## Usage Examples

```bash
# List direct children
confluence children 123456789

# Recursive tree view
confluence children 123456789 --recursive --format tree

# Show IDs and URLs
confluence children 123456789 --show-id --show-url

# Limit depth
confluence children 123456789 --recursive --max-depth 3

# JSON output for scripting
confluence children 123456789 --format json > children.json
```

## Testing

- ✅ All existing tests pass
- ✅ Lint checks pass
- ✅ Help command works correctly
- ✅ Command appears in main help menu

## Changes

- Added `children` command in `bin/confluence.js`
- Added helper functions `buildTree()` and `printTree()` for tree visualization
- Updated README.md with documentation and examples
- Added to command table in documentation

## Related

This addresses the need for users to easily explore and understand page hierarchies in Confluence spaces.