### PR TITLE
ci: audit production dependencies only in security check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Run npm audit
-      run: npm audit --audit-level moderate
+    - run: npm ci
+    - name: Run npm audit (production only)
+      run: npm audit --audit-level moderate --omit=dev
 
   publish:
     needs: [test, security]


### PR DESCRIPTION
## Summary
- Add `--omit=dev` to `npm audit` so only production dependencies are checked
- Run `npm ci` before audit to ensure consistent results based on the lock file

## Why
Current `ajv` (ReDoS) and `minimatch` (ReDoS) vulnerabilities originate from devDependency chains (`eslint`, `jest`). These are not shipped to end users but cause the CI security job to fail, blocking the `publish` job.

## Changes
| Before | After |
|--------|-------|
| `npm audit --audit-level moderate` | `npm ci` + `npm audit --audit-level moderate --omit=dev` |

## Test plan
- [ ] Verify security job passes
- [ ] Verify publish job triggers normally on main