### PR TITLE
fix: return descriptive error when find matches a space instead of a page

### DIFF
--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -1707,8 +1707,18 @@ class ConfluenceClient {
     }
 
     const result = response.data.results[0];
-    const content = result.content || result;
-    
+    const content = result.content;
+
+    if (!content) {
+      const spaceName = result.space?.name || result.title || title;
+      const sKey = result.space?.key || 'Unknown';
+      throw new Error(
+        `No page found with title "${title}". ` +
+        `A space named "${spaceName}" (${sKey}) matched instead. ` +
+        `Use "confluence search --cql 'space=${sKey} AND type=page'" to list pages in that space.`
+      );
+    }
+
     return {
       id: content.id,
       title: content.title,


### PR DESCRIPTION
## Summary

- When using `confluence find "<title>"`, if the Confluence `/search` API returns a **space result** instead of a page result, the CLI returns `ID: undefined` because `result.content` is undefined for space results.
- The previous fallback `result.content || result` silently fell through to `result`, which has no `.id` property.
- This fix detects when `result.content` is missing (space-only match) and throws a clear, actionable error message guiding the user to use CQL search instead.

## Root Cause

The `/search` API with `cql=title="X"` matches both pages and spaces by title. Space results have a different structure (`result.space` instead of `result.content`). The `findPageByTitle()` method assumed all results would have `result.content`.

## Before

```
$ confluence find "RND3 DEV3"
ID: undefined
Title: undefined
```

## After

```
$ confluence find "RND3 DEV3"
Error: No page found with title "RND3 DEV3". A space named "RND3 DEV3" (MLB) matched instead. Use "confluence search --cql 'space=MLB AND type=page'" to list pages in that space.
```

## Test plan

- [ ] Run `confluence find "<space-name>"` where the name matches only a space — should get descriptive error
- [ ] Run `confluence find "<page-title>"` where the name matches a page — should work as before
- [ ] Run `confluence find "<nonexistent>"` — should get "Page not found" error as before