### PR TITLE
fix: add required YAML frontmatter to SKILL.md

### DIFF
--- a/.claude/skills/confluence/SKILL.md
+++ b/.claude/skills/confluence/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: confluence
+description: Use confluence-cli to read, search, create, update, move, and delete Confluence pages and attachments from the terminal.
+---
+
 # confluence-cli Skill
 
 A CLI tool for Atlassian Confluence. Lets you read, search, create, update, move, and delete pages and attachments from the terminal or from an agent.


### PR DESCRIPTION
## Summary
- SKILL.md was missing the required YAML frontmatter (`name`, `description`), causing Claude Code to fail to recognize the skill definition
- Added frontmatter with `name: confluence` and a description matching the skill's purpose

## Test plan
- [x] `confluence install-skill --dest /tmp/test-skill -y` copies SKILL.md with frontmatter intact
- [x] `name` field matches the skill directory name (`confluence`)

Fixes #52