### PR TITLE
docs: add scoped API token setup for Confluence Cloud

### DIFF
--- a/.claude/skills/confluence/SKILL.md
+++ b/.claude/skills/confluence/SKILL.md
@@ -39,14 +39,14 @@ confluence init \
 
 **Cloud vs Server/DC:**
 - Atlassian Cloud (`*.atlassian.net`): use `--api-path "/wiki/rest/api"`, auth type `basic` with email + API token
-- Atlassian Cloud (scoped token): use `--domain "api.atlassian.com"`, `--api-path "/ex/confluence/{cloudId}/wiki/rest/api"`, auth type `basic` with email + scoped token. Get your Cloud ID from `https://<site>.atlassian.net/_edge/tenant_info`. Recommended for agents (least privilege).
+- Atlassian Cloud (scoped token): use `--domain "api.atlassian.com"`, `--api-path "/ex/confluence/<your-cloud-id>/wiki/rest/api"`, auth type `basic` with email + scoped token. Get your Cloud ID from `https://<your-site>.atlassian.net/_edge/tenant_info`. Recommended for agents (least privilege).
 - Self-hosted / Data Center: use `--api-path "/rest/api"`, auth type `bearer` with a personal access token (no email needed)
 
 **Scoped API token for agents (recommended):**
 
 ```sh
 export CONFLUENCE_DOMAIN="api.atlassian.com"
-export CONFLUENCE_API_PATH="/ex/confluence/{cloudId}/wiki/rest/api"
+export CONFLUENCE_API_PATH="/ex/confluence/<your-cloud-id>/wiki/rest/api"
 export CONFLUENCE_AUTH_TYPE="basic"
 export CONFLUENCE_EMAIL="user@company.com"
 export CONFLUENCE_API_TOKEN="your-scoped-token"

--- a/README.md
+++ b/README.md
@@ -106,9 +106,10 @@ confluence init \
 
 **Scoped API token** (recommended for agents — least privilege):
 ```bash
+# Replace <your-cloud-id> with your actual Cloud ID
 confluence init \
   --domain "api.atlassian.com" \
-  --api-path "/ex/confluence/{cloudId}/wiki/rest/api" \
+  --api-path "/ex/confluence/<your-cloud-id>/wiki/rest/api" \
   --auth-type "basic" \
   --email "user@example.com" \
   --token "your-scoped-token"
@@ -145,7 +146,7 @@ export CONFLUENCE_AUTH_TYPE="basic"
 **Scoped API token** (recommended for agents):
 ```bash
 export CONFLUENCE_DOMAIN="api.atlassian.com"
-export CONFLUENCE_API_PATH="/ex/confluence/{cloudId}/wiki/rest/api"
+export CONFLUENCE_API_PATH="/ex/confluence/<your-cloud-id>/wiki/rest/api"
 export CONFLUENCE_AUTH_TYPE="basic"
 export CONFLUENCE_EMAIL="user@example.com"
 export CONFLUENCE_API_TOKEN="your-scoped-token"


### PR DESCRIPTION
### Description
Document Atlassian scoped API token configuration in both README.md and installed skill docs (SKILL.md). Users with scoped tokens previously hit 401/403/404 errors because only the standard `*.atlassian.net` setup was documented.

Closes #57

### Type of Change
- [x] Documentation update

### Testing
- [x] Tests pass locally with my changes
- [x] New and existing unit tests pass locally with my changes

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### Additional Context
**README.md changes:**
- Non-interactive init example for scoped tokens
- Environment variable example for scoped tokens
- "Getting Your API Token" section with scoped token setup guide (Cloud ID lookup, domain, apiPath, authType)

**SKILL.md changes:**
- Scoped token entry in "Cloud vs Server/DC" comparison
- Scoped token environment variable example block