### PR TITLE
feat: add protocol configuration support for HTTP/HTTPS

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -378,7 +378,8 @@ function getConfig() {
       apiPath,
       token: envToken.trim(),
       email: envEmail ? envEmail.trim() : undefined,
-      authType
+      authType,
+      protocol: (process.env.CONFLUENCE_PROTOCOL || 'https').toLowerCase()
     };
   }
 
@@ -422,7 +423,8 @@ function getConfig() {
       apiPath,
       token: trimmedToken,
       email: trimmedEmail,
-      authType
+      authType,
+      protocol: (storedConfig.protocol || 'https').toLowerCase()
     };
   } catch (error) {
     console.error(chalk.red('❌ Error reading configuration file:'), error.message);

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -33,7 +33,8 @@ class ConfluenceClient {
     this.email = config.email;
     this.authType = (config.authType || (this.email ? 'basic' : 'bearer')).toLowerCase();
     this.apiPath = this.sanitizeApiPath(config.apiPath);
-    this.baseURL = `https://${this.domain}${this.apiPath}`;
+    this.protocol = (config.protocol || 'https').toLowerCase();
+    this.baseURL = `${this.protocol}://${this.domain}${this.apiPath}`;
     this.markdown = new MarkdownIt();
     this.setupConfluenceMarkdownExtensions();
 

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -68,6 +68,35 @@ describe('ConfluenceClient', () => {
 
       expect(customClient.baseURL).toBe('https://cloud.example/wiki/rest/api');
     });
+
+    test('defaults to https protocol when not specified', () => {
+      const defaultProtocolClient = new ConfluenceClient({
+        domain: 'example.com',
+        token: 'test-token'
+      });
+
+      expect(defaultProtocolClient.baseURL).toBe('https://example.com/rest/api');
+    });
+
+    test('supports http protocol configuration', () => {
+      const httpClient = new ConfluenceClient({
+        domain: 'example.com',
+        token: 'test-token',
+        protocol: 'http'
+      });
+
+      expect(httpClient.baseURL).toBe('http://example.com/rest/api');
+    });
+
+    test('normalizes protocol to lowercase', () => {
+      const upperCaseClient = new ConfluenceClient({
+        domain: 'example.com',
+        token: 'test-token',
+        protocol: 'HTTP'
+      });
+
+      expect(upperCaseClient.baseURL).toBe('http://example.com/rest/api');
+    });
   });
 
   describe('authentication setup', () => {


### PR DESCRIPTION
### Description

Add `protocol` configuration option to support HTTP connections for on-premise Confluence servers.

Closes #59

Currently, the CLI hardcodes HTTPS protocol which prevents users from connecting to Confluence servers that only have HTTP enabled. This PR adds a `protocol` option that can be configured via config file or environment variable.

**Usage:**

Add to `~/.confluence-cli/config.json`:
```json
{
  "domain": "wiki.example.com",
  "protocol": "http",
  "apiPath": "/rest/api",
  "token": "xxx",
  "authType": "basic",
  "email": "user@example.com"
}
```

Or set environment variable:
```bash
export CONFLUENCE_PROTOCOL=http
```

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

### Testing
- [x] Tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

### Screenshots (if applicable)
N/A

### Additional Context

This is a minimal, backward-compatible change. The default protocol remains `https`, so existing users are not affected.

**Files changed:**
- `lib/confluence-client.js` - Add `protocol` parameter to constructor
- `lib/config.js` - Read `protocol` from config file and `CONFLUENCE_PROTOCOL` env variable
- `tests/confluence-client.test.js` - Add 3 unit tests for protocol configuration