### PR TITLE
fix: restrict config file permissions to owner only

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -108,8 +108,11 @@ function readConfigFile() {
 function saveConfigFile(data) {
   if (!fs.existsSync(CONFIG_DIR)) {
     fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+  } else {
+    fs.chmodSync(CONFIG_DIR, 0o700);
   }
   fs.writeFileSync(CONFIG_FILE, JSON.stringify(data, null, 2), { mode: 0o600 });
+  fs.chmodSync(CONFIG_FILE, 0o600);
 }
 
 // Helper function to validate CLI-provided options

--- a/tests/profile.test.js
+++ b/tests/profile.test.js
@@ -9,6 +9,7 @@ jest.mock('fs', () => {
     readFileSync: jest.fn((...args) => actual.readFileSync(...args)),
     writeFileSync: jest.fn((...args) => actual.writeFileSync(...args)),
     mkdirSync: jest.fn((...args) => actual.mkdirSync(...args)),
+    chmodSync: jest.fn(),
   };
 });
 
@@ -100,6 +101,15 @@ function captureConfigWrite() {
     getWriteOptions: () => capturedOptions,
     getMkdirOptions: () => capturedMkdirOptions,
   };
+}
+
+// Capture chmodSync calls
+function captureChmod() {
+  const calls = [];
+  fs.chmodSync.mockImplementation((filePath, mode) => {
+    calls.push({ filePath, mode });
+  });
+  return { getCalls: () => calls };
 }
 
 describe('Profile management', () => {
@@ -362,6 +372,34 @@ describe('Profile management', () => {
       setActiveProfile('staging');
 
       expect(getMkdirOptions()).toMatchObject({ mode: 0o700 });
+    });
+
+    test('chmods existing config directory to 0o700', () => {
+      const { CONFIG_DIR } = require('../lib/config');
+      mockConfigFile(multiProfileConfig());
+      // Both CONFIG_DIR and CONFIG_FILE exist
+      fs.existsSync.mockImplementation(() => true);
+      captureConfigWrite();
+      const { getCalls } = captureChmod();
+
+      setActiveProfile('staging');
+
+      const dirChmod = getCalls().find(c => c.filePath === CONFIG_DIR);
+      expect(dirChmod).toBeDefined();
+      expect(dirChmod.mode).toBe(0o700);
+    });
+
+    test('chmods config file to 0o600 on every save', () => {
+      mockConfigFile(multiProfileConfig());
+      fs.existsSync.mockImplementation(() => true);
+      captureConfigWrite();
+      const { getCalls } = captureChmod();
+
+      setActiveProfile('staging');
+
+      const fileChmod = getCalls().find(c => c.filePath === CONFIG_FILE);
+      expect(fileChmod).toBeDefined();
+      expect(fileChmod.mode).toBe(0o600);
     });
   });
 });


### PR DESCRIPTION
### Description

Set config directory to 0o700 and config file to 0o600 to prevent other users from reading stored API tokens in multi-user environments.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

### Testing
- [x] Tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

### Screenshots (if applicable)

### Additional Context
