### PR TITLE
fix: add read:confluence-content.summary to required scopes

### DIFF
--- a/.claude/skills/confluence/SKILL.md
+++ b/.claude/skills/confluence/SKILL.md
@@ -65,7 +65,7 @@ export CONFLUENCE_API_TOKEN="your-scoped-token"
 ```
 
 Required classic scopes for scoped tokens:
-- Read-only: `read:confluence-content.all`, `read:confluence-space.summary`, `search:confluence`
+- Read-only: `read:confluence-content.all`, `read:confluence-content.summary`, `read:confluence-space.summary`, `search:confluence`
 - Write: add `write:confluence-content`, `write:confluence-file`, `write:confluence-space`
 - Attachments: `readonly:content.attachment:confluence` (download), `write:confluence-file` (upload)
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ When creating a scoped token, select the following [classic scopes](https://deve
 | Scope | Required for |
 |-------|-------------|
 | `read:confluence-content.all` | Reading pages and blog posts (`read`, `info`) |
+| `read:confluence-content.summary` | Reading content summaries and metadata (`read`, `info`) |
 | `read:confluence-space.summary` | Listing spaces (`spaces`) |
 | `search:confluence` | Searching content (`search`) |
 | `readonly:content.attachment:confluence` | Downloading attachments (`attachments --download`) |
@@ -207,7 +208,7 @@ When creating a scoped token, select the following [classic scopes](https://deve
 | `write:confluence-file` | Uploading attachments (`attachments --upload`) |
 | `write:confluence-space` | Managing spaces |
 
-For **read-only** usage, select at minimum: `read:confluence-content.all`, `read:confluence-space.summary`, and `search:confluence`.
+For **read-only** usage, select at minimum: `read:confluence-content.all`, `read:confluence-content.summary`, `read:confluence-space.summary`, and `search:confluence`.
 
 **On-premise / Data Center:** Use your Confluence username and password for basic authentication.
 

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -57,7 +57,7 @@ class ConfluenceClient {
           if (this.isScopedToken()) {
             hints.push(
               'You are using a scoped API token (api.atlassian.com). Please verify:',
-              '  - Your token has the required scopes (e.g., read:confluence-content.all, read:confluence-space.summary)',
+              '  - Your token has the required scopes (e.g., read:confluence-content.all, read:confluence-content.summary, read:confluence-space.summary)',
               '  - Your Cloud ID in the API path is correct',
               '  - Your email matches the account that created the token',
               'See: https://developer.atlassian.com/cloud/confluence/scopes-for-oauth-2-3LO-and-forge-apps/'


### PR DESCRIPTION
### Description
Add missing `read:confluence-content.summary` scope to documentation and 401 error hints. This scope is required for reading content but was not listed, causing 401 errors for users with scoped API tokens.

Reported by @Anigif in #76 (post-fix comment).

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

### Testing
- [x] Tests pass locally with my changes (144 passed)
- [x] New and existing unit tests pass locally with my changes

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### Files Changed
- `README.md` — added scope to table and read-only minimum list
- `lib/confluence-client.js` — added scope to 401 error hint message
- `.claude/skills/confluence/SKILL.md` — added scope to read-only list