### PR TITLE
fix(docs): correct search examples in SKILL.md to use --cql flag

### DIFF
--- a/.claude/skills/confluence/SKILL.md
+++ b/.claude/skills/confluence/SKILL.md
@@ -197,16 +197,17 @@ confluence find "API Reference" --space MYSPACE
 Search pages using a keyword or CQL expression.
 
 ```sh
-confluence search <query> [--limit <number>]
+confluence search <query> [--limit <number>] [--cql]
 ```
 
 | Option | Default | Description |
 |---|---|---|
 | `--limit` | `10` | Maximum number of results |
+| `--cql` | false | Pass query as raw CQL instead of text search |
 
 ```sh
 confluence search "deployment pipeline"
-confluence search "type=page AND space=MYSPACE" --limit 50
+confluence search --cql 'siteSearch ~ "deployment pipeline" and space = "MYSPACE"' --limit 50
 ```
 
 ---
@@ -697,7 +698,7 @@ confluence children 123456789 --recursive --format json | jq '.[].id'
 ### Search and process results
 
 ```sh
-confluence search "release notes" --limit 20
+confluence search --cql 'siteSearch ~ "release notes" and space = "MYSPACE"' --limit 20
 ```
 
 ---


### PR DESCRIPTION
## Summary

- The search examples in SKILL.md showed raw CQL passed as a plain query string (e.g. `confluence search "type=page AND space=MYSPACE"`), but without the `--cql` flag this is treated as a literal text search (`text ~ "type=page AND space=MYSPACE"`), not a CQL query
- Added `--cql` option to the search command reference table
- Updated examples to use `--cql` with `siteSearch ~` which works more reliably on Confluence Server/DC

## Test plan

- [x] Verified `confluence search --cql 'siteSearch ~ "keyword" and space = "SPACE"'` returns correct results
- [x] Confirmed without `--cql`, the old example `confluence search "type=page AND space=MYSPACE"` does NOT execute as CQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)