### PR TITLE
fix: publish npm-shrinkwrap.json to pin transitive dependencies

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "confluence-cli",
-  "version": "1.17.0",
+  "version": "1.27.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "confluence-cli",
-      "version": "1.17.0",
+      "version": "1.27.6",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.12.0",


### PR DESCRIPTION
### Description
Convert `package-lock.json` to `npm-shrinkwrap.json` so that published installs resolve the exact dependency versions tested in CI, preventing supply-chain drift.

`package-lock.json` is not included in npm publishes, so users installing via `npm install -g confluence-cli` resolve dependencies from `package.json` semver ranges. `npm-shrinkwrap.json` is the publishable lockfile and is [recommended by npm for CLI tools](https://docs.npmjs.com/cli/v10/configuring-npm/npm-shrinkwrap-json).

Closes #86

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Testing
- [x] Tests pass locally with my changes
- [x] New and existing unit tests pass locally with my changes

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings