### PR TITLE
# Fix: Preserve /wiki context when downloading attachments from Confluence Cloud

### DIFF
--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -2078,6 +2078,12 @@ class ConfluenceClient {
       return pathOrUrl;
     }
 
+    // For download paths and other web UI paths, include the webUrlPrefix
+    if (pathOrUrl.startsWith('/download/') || pathOrUrl.startsWith('/plugins/')) {
+      const normalized = this.webUrlPrefix || '';
+      return `${this.protocol}://${this.domain}${normalized}${pathOrUrl}`;
+    }
+
     return this.buildUrl(pathOrUrl);
   }
 


### PR DESCRIPTION
# Fix: Preserve /wiki context when downloading attachments from Confluence Cloud

## Problem
Attachment downloads from Confluence Cloud were failing with 404 errors. When Confluence Cloud returns relative download paths in attachment metadata (like `/download/attachments/6141247564/image.png`), they need to be appended to the correct base URL including the `/wiki` prefix. 

The `toAbsoluteUrl()` method was incorrectly dropping the `webUrlPrefix`, resulting in broken URLs being constructed.

## Root Cause
In `lib/confluence-client.js`, the `toAbsoluteUrl()` method was not considering the `webUrlPrefix` when building absolute URLs for download paths. This caused relative paths to lose the `/wiki` context they need on Confluence Cloud instances.

**Before (broken):**
```
/download/attachments/6141247564/image.png
→ https://domain.atlassian.net/download/attachments/... (404)
```

**After (fixed):**
```
/download/attachments/6141247564/image.png
→ https://domain.atlassian.net/wiki/download/attachments/... (200 OK)
```

## Solution
Modified `toAbsoluteUrl()` to detect relative paths starting with `/download/` or `/plugins/` and prepend the `webUrlPrefix` (typically `/wiki` for Cloud instances) before building the absolute URL.

## Changes
- **File:** `lib/confluence-client.js`
- **Method:** `toAbsoluteUrl()`
- **Lines:** Added check for download/plugin paths to include `webUrlPrefix`

## Testing
✅ **Manual Testing:**
- Ran `confluence attachments <PAGE_ID>` to list attachments
- Ran `confluence attachments <PAGE_ID> --download --dest ./test-downloads --limit 2`
- Successfully downloaded 2 PNG files (20 KB and 35 KB)
- Verified files were properly saved with correct content

✅ **Automated Testing:**
- Ran `npm test` - all tests passed (exit code 0)

## Impact
- **Users affected:** Anyone using confluence-cli to download attachments from Confluence Cloud
- **Backwards compatible:** Yes - only fixes broken behavior
- **Breaking changes:** None

## References
- Atlassian Developer: https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-attachment/
- Community guidance: Confluence Cloud uses `/wiki/download/` paths while self-hosted uses `/download/`
- Related issue: Download links were inconsistent between Cloud and self-hosted instances

## Checklist
- [x] Code changes tested with real Confluence Cloud instance
- [x] Automated tests pass
- [x] No breaking changes introduced
- [x] Files correctly downloaded with proper content