### PR TITLE
fix: upgrade axios to ^1.15.0 to address security vulnerabilities

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
       "version": "1.29.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.12.0",
+        "axios": "^1.15.0",
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
         "form-data": "^4.0.5",
@@ -1503,14 +1503,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-mock-adapter": {
@@ -4691,10 +4691,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "pchuri",
   "license": "MIT",
   "dependencies": {
-    "axios": "^1.12.0",
+    "axios": "^1.15.0",
     "chalk": "^4.1.2",
     "commander": "^11.1.0",
     "form-data": "^4.0.5",


### PR DESCRIPTION
### Description
Upgrade axios from `^1.12.0` to `^1.15.0` to fix the **Unrestricted Cloud Metadata Exfiltration via Header Injection Chain** vulnerability reported in #96.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Testing
- [x] Tests pass locally with my changes
- [x] New and existing unit tests pass locally with my changes

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

### Additional Context
- Dependabot alert: Axios has Unrestricted Cloud Metadata Exfiltration via Header Injection Chain
- All 171 tests pass with the upgraded version
- `npm audit` reports 0 vulnerabilities

Closes #96