### PR TITLE
fix: prepend /wiki context path in toAbsoluteUrl for Cloud attachment downloads

### DIFF
--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -2078,7 +2078,16 @@ class ConfluenceClient {
       return pathOrUrl;
     }
 
-    return this.buildUrl(pathOrUrl);
+    // Prepend context path (e.g. /wiki on Atlassian Cloud) when the API returns
+    // a path relative to the Confluence context root. Without this, URLs such as
+    // attachment download links (_links.download → "/download/attachments/...")
+    // get built as https://<domain>/download/... instead of
+    // https://<domain>/wiki/download/..., which returns 404 on Cloud.
+    const prefix = this.webUrlPrefix || '';
+    const needsPrefix = prefix && !pathOrUrl.startsWith(`${prefix}/`);
+    const withPrefix = needsPrefix ? `${prefix}${pathOrUrl}` : pathOrUrl;
+
+    return this.buildUrl(withPrefix);
   }
 
   parseNextStart(nextLink) {

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -105,6 +105,39 @@ describe('ConfluenceClient', () => {
       });
       expect(httpClient.toAbsoluteUrl('https://cdn.example.com/file.pdf')).toBe('https://cdn.example.com/file.pdf');
     });
+
+    test('toAbsoluteUrl prepends /wiki context path on Atlassian Cloud', () => {
+      const cloudClient = new ConfluenceClient({
+        domain: 'test.atlassian.net',
+        token: 'token',
+        apiPath: '/wiki/rest/api'
+      });
+      // _links.download from the API is relative to the Confluence context root,
+      // so on Cloud (apiPath starts with /wiki/) we must prepend /wiki. Otherwise
+      // the resulting URL hits https://<domain>/download/... and returns 404.
+      expect(cloudClient.toAbsoluteUrl('/download/attachments/123/file.png?version=1&modificationDate=1700000000000&cacheVersion=1&api=v2'))
+        .toBe('https://test.atlassian.net/wiki/download/attachments/123/file.png?version=1&modificationDate=1700000000000&cacheVersion=1&api=v2');
+    });
+
+    test('toAbsoluteUrl does not double-prepend /wiki when path already starts with it', () => {
+      const cloudClient = new ConfluenceClient({
+        domain: 'test.atlassian.net',
+        token: 'token',
+        apiPath: '/wiki/rest/api'
+      });
+      expect(cloudClient.toAbsoluteUrl('/wiki/download/attachments/123/file.png'))
+        .toBe('https://test.atlassian.net/wiki/download/attachments/123/file.png');
+    });
+
+    test('toAbsoluteUrl leaves Server/DC paths untouched (no webUrlPrefix)', () => {
+      const serverClient = new ConfluenceClient({
+        domain: 'confluence.example.com',
+        token: 'token',
+        apiPath: '/rest/api'
+      });
+      expect(serverClient.toAbsoluteUrl('/download/attachments/123/file.png'))
+        .toBe('https://confluence.example.com/download/attachments/123/file.png');
+    });
   });
 
   describe('api path handling', () => {


### PR DESCRIPTION
## Summary

Fixes #98.

`confluence attachments <pageId> --download` always fails with `Error: Request failed with status code 404` on Atlassian Cloud, even though listing attachments on the same page works correctly.

### Root cause

The REST API returns each attachment's `_links.download` as a path **relative to the Confluence context root**, e.g.:

```
/download/attachments/123456789/example.png?version=1&modificationDate=1700000000000&cacheVersion=1&api=v2
```

On Atlassian Cloud the context root is `/wiki`, so the correct absolute URL is:

```
https://example.atlassian.net/wiki/download/attachments/123456789/example.png?version=...
```

But `downloadAttachment` calls `toAbsoluteUrl(attachment._links?.download)` (lib/confluence-client.js:864), which goes straight through `buildUrl` and produces:

```
https://example.atlassian.net/download/attachments/123456789/example.png?version=...
```

**Missing the `/wiki` prefix.** Cloud returns 404 for that URL.

The interesting part: the constructor already computes `this.webUrlPrefix = this.apiPath.startsWith('/wiki/') ? '/wiki' : ''` on line 38, and it's correctly prepended in four places when building web UI links (lines 416, 510, 1356, 1360). But it was never applied inside `toAbsoluteUrl`, so attachment downloads (and the `downloadLink` field on formatted attachments, line 2063) fell through the gap.

Query parameters (`version`, `modificationDate`, `cacheVersion`) are all preserved correctly — the original issue hypothesis about missing query params was wrong. The only thing missing is the context path.

### Fix

Prepend `webUrlPrefix` inside `toAbsoluteUrl` when the input is a relative path and doesn't already include the prefix. Server/DC behavior is unchanged because `webUrlPrefix` is an empty string on those instances.

```js
toAbsoluteUrl(pathOrUrl) {
  if (!pathOrUrl) return null;
  if (pathOrUrl.startsWith('http://') || pathOrUrl.startsWith('https://')) {
    return pathOrUrl;
  }

  const prefix = this.webUrlPrefix || '';
  const needsPrefix = prefix && !pathOrUrl.startsWith(`${prefix}/`);
  const withPrefix = needsPrefix ? `${prefix}${pathOrUrl}` : pathOrUrl;

  return this.buildUrl(withPrefix);
}
```

The double-prefix guard (`!pathOrUrl.startsWith(\`${prefix}/\`)`) protects against future API changes where `_links.download` might start returning paths that already include `/wiki`.

### Tests

Added three targeted tests to `tests/confluence-client.test.js`:

1. Cloud client prepends `/wiki` to a relative download path with full query string
2. Cloud client does not double-prepend when the path already starts with `/wiki/`
3. Server/DC client (no `webUrlPrefix`) leaves relative paths untouched — regression guard

Full suite: **174 passed / 174 total** (was 171 before).

## Test plan

- [x] `npx jest tests/confluence-client.test.js` — 103/103 passed (3 new)
- [x] `npx jest` — 174/174 passed
- [x] End-to-end: built locally with `npm link`, ran `confluence attachments <pageId> --download --dest /tmp/out` against a live Atlassian Cloud page, confirmed the attachment downloaded successfully (byte-identical to the file fetched via `curl` directly against the REST API's `_links.download`).
- [x] End-to-end before the fix: same command against the same page returned `Error: Request failed with status code 404`, confirming the reproduction.