### PR TITLE
feat: support Confluence tiny links (/wiki/x/<code>) as pageId input

### DIFF
--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -136,6 +136,26 @@ class ConfluenceClient {
         return prettyMatch[1];
       }
 
+      // Handle tiny links (/wiki/x/<code>)
+      const tinyLinkMatch = pageIdOrUrl.match(/\/wiki\/x\/([A-Za-z0-9_-]+)/);
+      if (tinyLinkMatch) {
+        try {
+          const response = await this.client.get(pageIdOrUrl, {
+            maxRedirects: 0,
+            validateStatus: (status) => status >= 300 && status < 400
+          });
+          const redirectUrl = response.headers.location;
+          if (redirectUrl) {
+            return this.extractPageId(redirectUrl);
+          }
+        } catch (error) {
+          if (error.response && error.response.headers && error.response.headers.location) {
+            return this.extractPageId(error.response.headers.location);
+          }
+        }
+        throw new Error(`Could not resolve page ID from tiny link: ${pageIdOrUrl}`);
+      }
+
       // Handle display URLs - search by space and title
       const displayMatch = pageIdOrUrl.match(/\/display\/([^/]+)\/(.+)/);
       if (displayMatch) {

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -318,6 +318,30 @@ describe('ConfluenceClient', () => {
 
       mock.restore();
     });
+
+    test('should resolve tiny links via redirect', async () => {
+      const mock = new MockAdapter(client.client);
+
+      mock.onGet(/\/wiki\/x\//).reply(302, null, {
+        location: 'https://test.atlassian.net/wiki/spaces/TEST/pages/123456789/Page+Title'
+      });
+
+      const tinyUrl = 'https://test.atlassian.net/wiki/x/aBcDeFg';
+      expect(await client.extractPageId(tinyUrl)).toBe('123456789');
+
+      mock.restore();
+    });
+
+    test('should throw error when tiny link cannot be resolved', async () => {
+      const mock = new MockAdapter(client.client);
+
+      mock.onGet(/\/wiki\/x\//).reply(404);
+
+      const tinyUrl = 'https://test.atlassian.net/wiki/x/invalidCode';
+      await expect(client.extractPageId(tinyUrl)).rejects.toThrow(/Could not resolve page ID from tiny link/);
+
+      mock.restore();
+    });
   });
 
   describe('markdownToStorage', () => {


### PR DESCRIPTION
## Pull Request Template

### Description
Support Confluence tiny links (`/wiki/x/<code>`) as `pageId` input in `extractPageId`.

When Confluence's "Copy link" or "Share" button is used, it generates a tiny link (e.g., `https://example.atlassian.net/wiki/x/aBcDeFg`). Previously, this format was not recognized by the CLI. This PR resolves tiny links by following the HTTP 302 redirect to obtain the actual page URL, then extracts the page ID using existing logic.

Closes #100

### Type of Change
- [x] New feature (non-breaking change which adds functionality)

### Testing
- [x] Tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings