### PR TITLE
Add mTLS authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This creates `.claude/skills/confluence/SKILL.md` in your current directory. Cla
 confluence init
 ```
 
-The wizard helps you choose the right API endpoint and authentication method. It recommends `/wiki/rest/api` for Atlassian Cloud domains (e.g., `*.atlassian.net`) and `/rest/api` for self-hosted/Data Center instances, then prompts for Basic (email/username + token/password) or Bearer authentication.
+The wizard helps you choose the right API endpoint and authentication method. It recommends `/wiki/rest/api` for Atlassian Cloud domains (e.g., `*.atlassian.net`) and `/rest/api` for self-hosted/Data Center instances, then prompts for Basic (email/username + token/password), Bearer, or client-certificate (mTLS) authentication.
 
 ### Option 2: Non-interactive Setup (CLI Flags)
 
@@ -138,6 +138,17 @@ confluence --profile staging init \
   --token "your-personal-access-token"
 ```
 
+**mTLS profile** (self-hosted or reverse-proxied Confluence APIs):
+```bash
+confluence --profile corp init \
+  --domain "docs.example.com" \
+  --api-path "/confluence/rest/api" \
+  --auth-type "mtls" \
+  --tls-client-cert "/Users/you/.certs/client.pem" \
+  --tls-client-key "/Users/you/.certs/client.key" \
+  --tls-ca-cert "/Users/you/.certs/ca-chain.pem"
+```
+
 **Hybrid mode** (some fields provided, rest via prompts):
 ```bash
 # Domain and token provided, will prompt for auth method and email
@@ -150,9 +161,12 @@ confluence init --email "user@example.com" --token "your-api-token"
 **Available flags:**
 - `-d, --domain <domain>` - Confluence domain (e.g., `company.atlassian.net`)
 - `-p, --api-path <path>` - REST API path (e.g., `/wiki/rest/api`)
-- `-a, --auth-type <type>` - Authentication type: `basic` or `bearer`
+- `-a, --auth-type <type>` - Authentication type: `basic`, `bearer`, or `mtls`
 - `-e, --email <email>` - Email or username for basic authentication
 - `-t, --token <token>` - API token or password
+- `--tls-client-cert <path>` - Client certificate for mTLS authentication
+- `--tls-client-key <path>` - Client private key for mTLS authentication
+- `--tls-ca-cert <path>` - Optional CA certificate chain for mTLS authentication
 - `--read-only` - Enable read-only mode (blocks all write operations)
 
 ⚠️ **Security note:** While flags work, storing tokens in shell history is risky. Prefer environment variables (Option 3) for production environments.
@@ -169,6 +183,16 @@ export CONFLUENCE_AUTH_TYPE="basic"
 export CONFLUENCE_PROFILE="default"
 ```
 
+**mTLS environment variables**:
+```bash
+export CONFLUENCE_DOMAIN="docs.example.com"
+export CONFLUENCE_API_PATH="/confluence/rest/api"
+export CONFLUENCE_AUTH_TYPE="mtls"
+export CONFLUENCE_TLS_CLIENT_CERT="/Users/you/.certs/client.pem"
+export CONFLUENCE_TLS_CLIENT_KEY="/Users/you/.certs/client.key"
+export CONFLUENCE_TLS_CA_CERT="/Users/you/.certs/ca-chain.pem"  # optional
+```
+
 **Scoped API token** (recommended for agents):
 ```bash
 export CONFLUENCE_DOMAIN="api.atlassian.com"
@@ -178,7 +202,7 @@ export CONFLUENCE_EMAIL="user@example.com"
 export CONFLUENCE_API_TOKEN="your-scoped-token"
 ```
 
-`CONFLUENCE_API_PATH` defaults to `/wiki/rest/api` for Atlassian Cloud domains and `/rest/api` otherwise. Override it when your site lives under a custom reverse proxy or on-premises path. `CONFLUENCE_AUTH_TYPE` defaults to `basic` when an email is present and falls back to `bearer` otherwise.
+`CONFLUENCE_API_PATH` defaults to `/wiki/rest/api` for Atlassian Cloud domains and `/rest/api` otherwise. Override it when your site lives under a custom reverse proxy or on-premises path. `CONFLUENCE_AUTH_TYPE` defaults to `basic` when an email is present and falls back to `bearer` otherwise. For `mtls`, set `CONFLUENCE_TLS_CLIENT_CERT` and `CONFLUENCE_TLS_CLIENT_KEY`; `CONFLUENCE_TLS_CA_CERT` is optional.
 
 **Read-only mode** (recommended for AI agents):
 ```bash
@@ -223,6 +247,8 @@ When creating a scoped token, select the following [classic scopes](https://deve
 For **read-only** usage, select at minimum: `read:confluence-content.all`, `read:confluence-content.summary`, `read:confluence-space.summary`, and `search:confluence`.
 
 **On-premise / Data Center:** Use your Confluence username and password for basic authentication.
+
+**mTLS-protected Confluence APIs:** Some self-hosted or reverse-proxied deployments authenticate at the TLS layer with a client certificate instead of sending an application-level token. In these environments, configure `authType=mtls` and provide certificate paths via CLI flags or environment variables. No `Authorization` header will be sent in mTLS mode.
 
 ## Usage
 

--- a/bin/confluence.js
+++ b/bin/confluence.js
@@ -34,9 +34,12 @@ program
   .option('-d, --domain <domain>', 'Confluence domain')
   .option('--protocol <protocol>', 'Protocol (http or https)')
   .option('-p, --api-path <path>', 'REST API path')
-  .option('-a, --auth-type <type>', 'Authentication type (basic or bearer)')
+  .option('-a, --auth-type <type>', 'Authentication type (basic, bearer, or mtls)')
   .option('-e, --email <email>', 'Email or username for basic auth')
   .option('-t, --token <token>', 'API token')
+  .option('--tls-ca-cert <path>', 'CA certificate for mTLS connections')
+  .option('--tls-client-cert <path>', 'Client certificate for mTLS connections')
+  .option('--tls-client-key <path>', 'Client private key for mTLS connections')
   .option('--read-only', 'Set profile to read-only mode (blocks write operations)')
   .action(async (options) => {
     const profile = getProfileName();
@@ -1917,9 +1920,12 @@ profileCmd
   .option('-d, --domain <domain>', 'Confluence domain')
   .option('--protocol <protocol>', 'Protocol (http or https)')
   .option('-p, --api-path <path>', 'REST API path')
-  .option('-a, --auth-type <type>', 'Authentication type (basic or bearer)')
+  .option('-a, --auth-type <type>', 'Authentication type (basic, bearer, or mtls)')
   .option('-e, --email <email>', 'Email or username for basic auth')
   .option('-t, --token <token>', 'API token')
+  .option('--tls-ca-cert <path>', 'CA certificate for mTLS connections')
+  .option('--tls-client-cert <path>', 'Client certificate for mTLS connections')
+  .option('--tls-client-key <path>', 'Client private key for mTLS connections')
   .option('--read-only', 'Set profile to read-only mode (blocks write operations)')
   .action(async (name, options) => {
     if (!isValidProfileName(name)) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -10,7 +10,8 @@ const DEFAULT_PROFILE = 'default';
 
 const AUTH_CHOICES = [
   { name: 'Basic (credentials)', value: 'basic' },
-  { name: 'Bearer token', value: 'bearer' }
+  { name: 'Bearer token', value: 'bearer' },
+  { name: 'Client certificate (mTLS)', value: 'mtls' }
 ];
 
 const isValidProfileName = (name) => /^[a-zA-Z0-9_-]+$/.test(name);
@@ -37,10 +38,52 @@ const normalizeProtocol = (rawValue) => {
 
 const normalizeAuthType = (rawValue, hasEmail) => {
   const normalized = (rawValue || '').trim().toLowerCase();
-  if (normalized === 'basic' || normalized === 'bearer') {
+  if (normalized === 'basic' || normalized === 'bearer' || normalized === 'mtls') {
     return normalized;
   }
   return hasEmail ? 'basic' : 'bearer';
+};
+
+const trimOptional = (value) => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+};
+
+const normalizeMtlsConfig = (mtls) => {
+  if (!mtls) {
+    return undefined;
+  }
+
+  const normalized = {
+    caCert: trimOptional(mtls.caCert),
+    clientCert: trimOptional(mtls.clientCert),
+    clientKey: trimOptional(mtls.clientKey),
+  };
+
+  if (!normalized.caCert && !normalized.clientCert && !normalized.clientKey) {
+    return undefined;
+  }
+
+  return normalized;
+};
+
+const validateMtlsConfig = (mtls, labelPrefix = 'mTLS') => {
+  const normalized = normalizeMtlsConfig(mtls);
+  if (!normalized) {
+    return [`${labelPrefix} requires a client certificate and client key.`];
+  }
+
+  const errors = [];
+  if (!normalized.clientCert) {
+    errors.push(`${labelPrefix} requires a client certificate.`);
+  }
+  if (!normalized.clientKey) {
+    errors.push(`${labelPrefix} requires a client key.`);
+  }
+  return errors;
 };
 
 const inferApiPath = (domain) => {
@@ -89,6 +132,10 @@ function readConfigFile() {
         token: raw.token,
         authType: raw.authType
       };
+      const mtls = normalizeMtlsConfig(raw.mtls);
+      if (mtls) {
+        profile.mtls = mtls;
+      }
       if (raw.email) {
         profile.email = raw.email;
       }
@@ -123,7 +170,7 @@ const validateCliOptions = (options) => {
     errors.push('--domain cannot be empty');
   }
 
-  if (options.token && !options.token.trim()) {
+  if (options.token !== undefined && !options.token.trim()) {
     errors.push('--token cannot be empty');
   }
 
@@ -148,14 +195,20 @@ const validateCliOptions = (options) => {
     errors.push('--protocol must be "http" or "https"');
   }
 
-  if (options.authType && !['basic', 'bearer'].includes(options.authType.toLowerCase())) {
-    errors.push('--auth-type must be "basic" or "bearer"');
+  if (options.authType && !['basic', 'bearer', 'mtls'].includes(options.authType.toLowerCase())) {
+    errors.push('--auth-type must be "basic", "bearer", or "mtls"');
   }
 
   // Check if basic auth is provided with email
   const normAuthType = options.authType ? normalizeAuthType(options.authType, Boolean(options.email)) : null;
   if (normAuthType === 'basic' && !options.email) {
     errors.push('--email is required when using basic authentication (use your username for on-premise)');
+  }
+
+  if (normAuthType === 'mtls') {
+    validateMtlsConfig(options.mtls, '--auth-type mtls').forEach((error) => {
+      errors.push(error);
+    });
   }
 
   return errors;
@@ -167,12 +220,20 @@ const saveConfig = (configData, profileName) => {
     domain: configData.domain.trim(),
     protocol: normalizeProtocol(configData.protocol),
     apiPath: normalizeApiPath(configData.apiPath, configData.domain),
-    token: configData.token.trim(),
     authType: configData.authType
   };
 
+  if (configData.token) {
+    config.token = configData.token.trim();
+  }
+
   if (configData.authType === 'basic' && configData.email) {
     config.email = configData.email.trim();
+  }
+
+  const mtls = normalizeMtlsConfig(configData.mtls);
+  if (mtls) {
+    config.mtls = mtls;
   }
 
   if (configData.readOnly) {
@@ -283,6 +344,10 @@ const promptForMissingValues = async (providedValues) => {
       type: 'password',
       name: 'token',
       message: 'API token / password:',
+      when: (responses) => {
+        const authType = providedValues.authType || responses.authType;
+        return authType !== 'mtls';
+      },
       validate: requiredInput('API token / password')
     });
   }
@@ -313,7 +378,12 @@ async function initConfig(cliOptions = {}) {
     apiPath: cliOptions.apiPath,
     authType: cliOptions.authType,
     email: cliOptions.email,
-    token: cliOptions.token
+    token: cliOptions.token,
+    mtls: cliOptions.mtls || {
+      caCert: cliOptions.tlsCaCert,
+      clientCert: cliOptions.tlsClientCert,
+      clientKey: cliOptions.tlsClientKey,
+    }
   };
 
   // Check if any CLI options were provided
@@ -380,6 +450,7 @@ async function initConfig(cliOptions = {}) {
         type: 'password',
         name: 'token',
         message: 'API token / password:',
+        when: (responses) => responses.authType !== 'mtls',
         validate: requiredInput('API token / password')
       }
     ]);
@@ -403,8 +474,13 @@ async function initConfig(cliOptions = {}) {
   // Non-interactive requires: domain, token, and either authType or email (for inference)
   const hasRequiredValues = Boolean(
     providedValues.domain &&
-    providedValues.token &&
-    (providedValues.authType || providedValues.email)
+    (
+      providedValues.authType === 'mtls'
+      || (
+        providedValues.token &&
+        (providedValues.authType || providedValues.email)
+      )
+    )
   );
 
   if (hasRequiredValues) {
@@ -425,6 +501,11 @@ async function initConfig(cliOptions = {}) {
         process.exit(1);
       }
 
+      if (normalizedAuthType !== 'mtls' && !providedValues.token) {
+        console.error(chalk.red('❌ Token is required for basic or bearer authentication'));
+        process.exit(1);
+      }
+
       // Verify API path format if provided
       if (providedValues.apiPath) {
         normalizeApiPath(providedValues.apiPath, normalizedDomain);
@@ -437,6 +518,7 @@ async function initConfig(cliOptions = {}) {
         token: providedValues.token,
         authType: normalizedAuthType,
         email: providedValues.email,
+        mtls: providedValues.mtls,
         readOnly
       };
 
@@ -476,9 +558,14 @@ function getConfig(profileName) {
   const envApiPath = process.env.CONFLUENCE_API_PATH;
   const envProtocol = process.env.CONFLUENCE_PROTOCOL;
   const envReadOnly = process.env.CONFLUENCE_READ_ONLY;
+  const envMtls = normalizeMtlsConfig({
+    caCert: process.env.CONFLUENCE_TLS_CA_CERT,
+    clientCert: process.env.CONFLUENCE_TLS_CLIENT_CERT,
+    clientKey: process.env.CONFLUENCE_TLS_CLIENT_KEY,
+  });
 
-  if (envDomain && envToken) {
-    const authType = normalizeAuthType(envAuthType, Boolean(envEmail));
+  if (envDomain && (envToken || envAuthType === 'mtls' || envMtls)) {
+    const authType = normalizeAuthType(envAuthType || (envMtls && !envToken ? 'mtls' : envAuthType), Boolean(envEmail));
     let apiPath;
 
     try {
@@ -494,13 +581,28 @@ function getConfig(profileName) {
       process.exit(1);
     }
 
+    if (authType !== 'mtls' && !envToken) {
+      console.error(chalk.red('❌ Bearer/basic authentication requires CONFLUENCE_API_TOKEN or CONFLUENCE_PASSWORD.'));
+      process.exit(1);
+    }
+
+    if (authType === 'mtls') {
+      const mtlsErrors = validateMtlsConfig(envMtls, 'CONFLUENCE_AUTH_TYPE=mtls');
+      if (mtlsErrors.length > 0) {
+        console.error(chalk.red(`❌ ${mtlsErrors.join(' ')}`));
+        console.log(chalk.yellow('Set CONFLUENCE_TLS_CLIENT_CERT and CONFLUENCE_TLS_CLIENT_KEY. Optionally set CONFLUENCE_TLS_CA_CERT.'));
+        process.exit(1);
+      }
+    }
+
     return {
       domain: envDomain.trim(),
       protocol: normalizeProtocol(envProtocol),
       apiPath,
-      token: envToken.trim(),
+      token: envToken ? envToken.trim() : undefined,
       email: envEmail ? envEmail.trim() : undefined,
       authType,
+      mtls: envMtls,
       readOnly: envReadOnly === 'true'
     };
   }
@@ -534,12 +636,13 @@ function getConfig(profileName) {
 
   try {
     const trimmedDomain = (storedConfig.domain || '').trim();
-    const trimmedToken = (storedConfig.token || '').trim();
+    const trimmedToken = trimOptional(storedConfig.token);
     const trimmedEmail = storedConfig.email ? storedConfig.email.trim() : undefined;
     const authType = normalizeAuthType(storedConfig.authType, Boolean(trimmedEmail));
+    const mtls = normalizeMtlsConfig(storedConfig.mtls);
     let apiPath;
 
-    if (!trimmedDomain || !trimmedToken) {
+    if (!trimmedDomain || (authType !== 'mtls' && !trimmedToken)) {
       console.error(chalk.red('❌ Configuration file is missing required values.'));
       console.log(chalk.yellow('Run "confluence init" to refresh your settings.'));
       process.exit(1);
@@ -549,6 +652,15 @@ function getConfig(profileName) {
       console.error(chalk.red('❌ Basic authentication requires an email address or username.'));
       console.log(chalk.yellow('Please rerun "confluence init" to add your Confluence email or username.'));
       process.exit(1);
+    }
+
+    if (authType === 'mtls') {
+      const mtlsErrors = validateMtlsConfig(mtls, 'mTLS authentication');
+      if (mtlsErrors.length > 0) {
+        console.error(chalk.red(`❌ ${mtlsErrors.join(' ')}`));
+        console.log(chalk.yellow('Please rerun "confluence init" to add your mTLS certificate paths.'));
+        process.exit(1);
+      }
     }
 
     try {
@@ -570,6 +682,7 @@ function getConfig(profileName) {
       token: trimmedToken,
       email: trimmedEmail,
       authType,
+      mtls,
       readOnly
     };
   } catch (error) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -79,9 +79,16 @@ const validateMtlsConfig = (mtls, labelPrefix = 'mTLS') => {
   const errors = [];
   if (!normalized.clientCert) {
     errors.push(`${labelPrefix} requires a client certificate.`);
+  } else if (!fs.existsSync(normalized.clientCert)) {
+    errors.push(`${labelPrefix} client certificate file not found: ${normalized.clientCert}`);
   }
   if (!normalized.clientKey) {
     errors.push(`${labelPrefix} requires a client key.`);
+  } else if (!fs.existsSync(normalized.clientKey)) {
+    errors.push(`${labelPrefix} client key file not found: ${normalized.clientKey}`);
+  }
+  if (normalized.caCert && !fs.existsSync(normalized.caCert)) {
+    errors.push(`${labelPrefix} CA certificate file not found: ${normalized.caCert}`);
   }
   return errors;
 };
@@ -209,6 +216,9 @@ const validateCliOptions = (options) => {
     validateMtlsConfig(options.mtls, '--auth-type mtls').forEach((error) => {
       errors.push(error);
     });
+    if (options.protocol && options.protocol.toLowerCase() === 'http') {
+      errors.push('mTLS authentication requires HTTPS. --protocol http is not compatible with --auth-type mtls.');
+    }
   }
 
   return errors;
@@ -352,6 +362,69 @@ const promptForMissingValues = async (providedValues) => {
     });
   }
 
+  // mTLS certificate path questions
+  const mtls = normalizeMtlsConfig(providedValues.mtls);
+  if (!mtls || !mtls.clientCert) {
+    questions.push({
+      type: 'input',
+      name: 'tlsClientCert',
+      message: 'Path to client certificate file (PEM):',
+      when: (responses) => {
+        const authType = providedValues.authType || responses.authType;
+        return authType === 'mtls';
+      },
+      validate: (input) => {
+        const value = (input || '').trim();
+        if (!value) {
+          return 'Client certificate path is required for mTLS.';
+        }
+        if (!fs.existsSync(value)) {
+          return `File not found: ${value}`;
+        }
+        return true;
+      }
+    });
+  }
+  if (!mtls || !mtls.clientKey) {
+    questions.push({
+      type: 'input',
+      name: 'tlsClientKey',
+      message: 'Path to client key file (PEM):',
+      when: (responses) => {
+        const authType = providedValues.authType || responses.authType;
+        return authType === 'mtls';
+      },
+      validate: (input) => {
+        const value = (input || '').trim();
+        if (!value) {
+          return 'Client key path is required for mTLS.';
+        }
+        if (!fs.existsSync(value)) {
+          return `File not found: ${value}`;
+        }
+        return true;
+      }
+    });
+  }
+  if (!mtls || !mtls.caCert) {
+    questions.push({
+      type: 'input',
+      name: 'tlsCaCert',
+      message: 'Path to CA certificate file (PEM, optional):',
+      when: (responses) => {
+        const authType = providedValues.authType || responses.authType;
+        return authType === 'mtls';
+      },
+      validate: (input) => {
+        const value = (input || '').trim();
+        if (value && !fs.existsSync(value)) {
+          return `File not found: ${value}`;
+        }
+        return true;
+      }
+    });
+  }
+
   if (questions.length === 0) {
     return providedValues;
   }
@@ -452,10 +525,64 @@ async function initConfig(cliOptions = {}) {
         message: 'API token / password:',
         when: (responses) => responses.authType !== 'mtls',
         validate: requiredInput('API token / password')
+      },
+      {
+        type: 'input',
+        name: 'tlsClientCert',
+        message: 'Path to client certificate file (PEM):',
+        when: (responses) => responses.authType === 'mtls',
+        validate: (input) => {
+          const value = (input || '').trim();
+          if (!value) {
+            return 'Client certificate path is required for mTLS.';
+          }
+          if (!fs.existsSync(value)) {
+            return `File not found: ${value}`;
+          }
+          return true;
+        }
+      },
+      {
+        type: 'input',
+        name: 'tlsClientKey',
+        message: 'Path to client key file (PEM):',
+        when: (responses) => responses.authType === 'mtls',
+        validate: (input) => {
+          const value = (input || '').trim();
+          if (!value) {
+            return 'Client key path is required for mTLS.';
+          }
+          if (!fs.existsSync(value)) {
+            return `File not found: ${value}`;
+          }
+          return true;
+        }
+      },
+      {
+        type: 'input',
+        name: 'tlsCaCert',
+        message: 'Path to CA certificate file (PEM, optional):',
+        when: (responses) => responses.authType === 'mtls',
+        validate: (input) => {
+          const value = (input || '').trim();
+          if (value && !fs.existsSync(value)) {
+            return `File not found: ${value}`;
+          }
+          return true;
+        }
       }
     ]);
 
-    saveConfig({ ...answers, readOnly }, profileName);
+    const configData = { ...answers, readOnly };
+    if (answers.authType === 'mtls') {
+      configData.mtls = {
+        clientCert: answers.tlsClientCert,
+        clientKey: answers.tlsClientKey,
+        caCert: answers.tlsCaCert || undefined,
+      };
+    }
+
+    saveConfig(configData, profileName);
     return;
   }
 
@@ -543,6 +670,15 @@ async function initConfig(cliOptions = {}) {
     // Normalize auth type
     mergedValues.authType = normalizeAuthType(mergedValues.authType, Boolean(mergedValues.email));
 
+    // Build mTLS config from prompted values if needed
+    if (mergedValues.authType === 'mtls') {
+      mergedValues.mtls = normalizeMtlsConfig({
+        clientCert: mergedValues.tlsClientCert || (mergedValues.mtls && mergedValues.mtls.clientCert),
+        clientKey: mergedValues.tlsClientKey || (mergedValues.mtls && mergedValues.mtls.clientKey),
+        caCert: mergedValues.tlsCaCert || (mergedValues.mtls && mergedValues.mtls.caCert),
+      });
+    }
+
     saveConfig({ ...mergedValues, readOnly }, profileName);
   } catch (error) {
     console.error(chalk.red(`❌ ${error.message}`));
@@ -565,7 +701,8 @@ function getConfig(profileName) {
   });
 
   if (envDomain && (envToken || envAuthType === 'mtls' || envMtls)) {
-    const authType = normalizeAuthType(envAuthType || (envMtls && !envToken ? 'mtls' : envAuthType), Boolean(envEmail));
+    const inferredAuthType = envAuthType || (envMtls && !envToken ? 'mtls' : undefined);
+    const authType = normalizeAuthType(inferredAuthType, Boolean(envEmail));
     let apiPath;
 
     try {
@@ -591,6 +728,10 @@ function getConfig(profileName) {
       if (mtlsErrors.length > 0) {
         console.error(chalk.red(`❌ ${mtlsErrors.join(' ')}`));
         console.log(chalk.yellow('Set CONFLUENCE_TLS_CLIENT_CERT and CONFLUENCE_TLS_CLIENT_KEY. Optionally set CONFLUENCE_TLS_CA_CERT.'));
+        process.exit(1);
+      }
+      if (normalizeProtocol(envProtocol) === 'http') {
+        console.error(chalk.red('❌ mTLS authentication requires HTTPS. CONFLUENCE_PROTOCOL=http is not compatible with CONFLUENCE_AUTH_TYPE=mtls.'));
         process.exit(1);
       }
     }
@@ -659,6 +800,11 @@ function getConfig(profileName) {
       if (mtlsErrors.length > 0) {
         console.error(chalk.red(`❌ ${mtlsErrors.join(' ')}`));
         console.log(chalk.yellow('Please rerun "confluence init" to add your mTLS certificate paths.'));
+        process.exit(1);
+      }
+      if (normalizeProtocol(storedConfig.protocol) === 'http') {
+        console.error(chalk.red('❌ mTLS authentication requires HTTPS. Protocol "http" is not compatible with auth type "mtls".'));
+        console.log(chalk.yellow('Please rerun "confluence init" to update your protocol to HTTPS.'));
         process.exit(1);
       }
     }

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -1,5 +1,6 @@
 const axios = require('axios');
 const fs = require('fs');
+const https = require('https');
 const path = require('path');
 const FormData = require('form-data');
 const { convert } = require('html-to-text');
@@ -34,6 +35,7 @@ class ConfluenceClient {
     this.token = config.token;
     this.email = config.email;
     this.authType = (config.authType || (this.email ? 'basic' : 'bearer')).toLowerCase();
+    this.mtls = config.mtls;
     this.apiPath = this.sanitizeApiPath(config.apiPath);
     this.webUrlPrefix = this.apiPath.startsWith('/wiki/') ? '/wiki' : '';
     this.baseURL = `${this.protocol}://${this.domain}${this.apiPath}`;
@@ -41,14 +43,23 @@ class ConfluenceClient {
     this.setupConfluenceMarkdownExtensions();
 
     const headers = {
-      'Content-Type': 'application/json',
-      'Authorization': this.authType === 'basic' ? this.buildBasicAuthHeader() : `Bearer ${this.token}`
+      'Content-Type': 'application/json'
     };
+    const authHeader = this.buildAuthHeader();
+    if (authHeader) {
+      headers.Authorization = authHeader;
+    }
 
-    this.client = axios.create({
+    const clientOptions = {
       baseURL: this.baseURL,
       headers
-    });
+    };
+    const httpsAgent = this.buildHttpsAgent();
+    if (httpsAgent) {
+      clientOptions.httpsAgent = httpsAgent;
+    }
+
+    this.client = axios.create(clientOptions);
 
     this.client.interceptors.response.use(
       response => response,
@@ -71,6 +82,10 @@ class ConfluenceClient {
           } else if (this.authType === 'basic') {
             hints.push(
               'Please verify your username and password are correct.'
+            );
+          } else if (this.authType === 'mtls') {
+            hints.push(
+              'Please verify your client certificate, client key, and CA certificate are correct and trusted by the server.'
             );
           } else {
             hints.push(
@@ -113,6 +128,42 @@ class ConfluenceClient {
 
     const encodedCredentials = Buffer.from(`${this.email}:${this.token}`).toString('base64');
     return `Basic ${encodedCredentials}`;
+  }
+
+  buildAuthHeader() {
+    if (this.authType === 'mtls') {
+      return null;
+    }
+
+    if (!this.token) {
+      throw new Error(`Authentication type "${this.authType}" requires a token or password.`);
+    }
+
+    return this.authType === 'basic' ? this.buildBasicAuthHeader() : `Bearer ${this.token}`;
+  }
+
+  buildHttpsAgent() {
+    if (this.protocol !== 'https' || !this.mtls) {
+      return null;
+    }
+
+    const options = {};
+
+    if (this.mtls.caCert) {
+      options.ca = fs.readFileSync(this.mtls.caCert);
+    }
+    if (this.mtls.clientCert) {
+      options.cert = fs.readFileSync(this.mtls.clientCert);
+    }
+    if (this.mtls.clientKey) {
+      options.key = fs.readFileSync(this.mtls.clientKey);
+    }
+
+    if (Object.keys(options).length === 0) {
+      return null;
+    }
+
+    return new https.Agent(options);
   }
 
   /**

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -150,12 +150,21 @@ class ConfluenceClient {
     const options = {};
 
     if (this.mtls.caCert) {
+      if (!fs.existsSync(this.mtls.caCert)) {
+        throw new Error(`CA certificate file not found: ${this.mtls.caCert}`);
+      }
       options.ca = fs.readFileSync(this.mtls.caCert);
     }
     if (this.mtls.clientCert) {
+      if (!fs.existsSync(this.mtls.clientCert)) {
+        throw new Error(`Client certificate file not found: ${this.mtls.clientCert}`);
+      }
       options.cert = fs.readFileSync(this.mtls.clientCert);
     }
     if (this.mtls.clientKey) {
+      if (!fs.existsSync(this.mtls.clientKey)) {
+        throw new Error(`Client key file not found: ${this.mtls.clientKey}`);
+      }
       options.key = fs.readFileSync(this.mtls.clientKey);
     }
 

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -206,23 +206,25 @@ describe('ConfluenceClient', () => {
       fs.writeFileSync(keyPath, 'client-key');
       fs.writeFileSync(caPath, 'ca-cert');
 
-      const mtlsClient = new ConfluenceClient({
-        domain: 'api.collaborate.akamai.com',
-        authType: 'mtls',
-        apiPath: '/confluence/rest/api',
-        mtls: {
-          caCert: caPath,
-          clientCert: certPath,
-          clientKey: keyPath,
-        }
-      });
+      try {
+        const mtlsClient = new ConfluenceClient({
+          domain: 'api.collaborate.akamai.com',
+          authType: 'mtls',
+          apiPath: '/confluence/rest/api',
+          mtls: {
+            caCert: caPath,
+            clientCert: certPath,
+            clientKey: keyPath,
+          }
+        });
 
-      expect(mtlsClient.client.defaults.headers.Authorization).toBeUndefined();
-      expect(mtlsClient.client.defaults.httpsAgent.options.ca.toString()).toBe('ca-cert');
-      expect(mtlsClient.client.defaults.httpsAgent.options.cert.toString()).toBe('client-cert');
-      expect(mtlsClient.client.defaults.httpsAgent.options.key.toString()).toBe('client-key');
-
-      removeDirRecursive(tmpDir);
+        expect(mtlsClient.client.defaults.headers.Authorization).toBeUndefined();
+        expect(mtlsClient.client.defaults.httpsAgent.options.ca.toString()).toBe('ca-cert');
+        expect(mtlsClient.client.defaults.httpsAgent.options.cert.toString()).toBe('client-cert');
+        expect(mtlsClient.client.defaults.httpsAgent.options.key.toString()).toBe('client-key');
+      } finally {
+        removeDirRecursive(tmpDir);
+      }
     });
   });
 
@@ -287,21 +289,24 @@ describe('ConfluenceClient', () => {
       fs.writeFileSync(certPath, 'client-cert');
       fs.writeFileSync(keyPath, 'client-key');
 
-      const mtlsClient = new ConfluenceClient({
-        domain: 'api.collaborate.akamai.com',
-        authType: 'mtls',
-        apiPath: '/confluence/rest/api',
-        mtls: {
-          clientCert: certPath,
-          clientKey: keyPath,
-        }
-      });
-      const mock = new MockAdapter(mtlsClient.client);
-      mock.onGet(/\/content\/123/).reply(401);
+      try {
+        const mtlsClient = new ConfluenceClient({
+          domain: 'api.collaborate.akamai.com',
+          authType: 'mtls',
+          apiPath: '/confluence/rest/api',
+          mtls: {
+            clientCert: certPath,
+            clientKey: keyPath,
+          }
+        });
+        const mock = new MockAdapter(mtlsClient.client);
+        mock.onGet(/\/content\/123/).reply(401);
 
-      await expect(mtlsClient.readPage('123')).rejects.toThrow(/client certificate/);
-      mock.restore();
-      removeDirRecursive(tmpDir);
+        await expect(mtlsClient.readPage('123')).rejects.toThrow(/client certificate/);
+        mock.restore();
+      } finally {
+        removeDirRecursive(tmpDir);
+      }
     });
   });
 

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -196,6 +196,34 @@ describe('ConfluenceClient', () => {
         authType: 'basic'
       })).toThrow('Basic authentication requires an email address or username.');
     });
+
+    test('supports mtls auth without an Authorization header', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'confluence-mtls-'));
+      const certPath = path.join(tmpDir, 'client.pem');
+      const keyPath = path.join(tmpDir, 'client.key');
+      const caPath = path.join(tmpDir, 'ca.pem');
+      fs.writeFileSync(certPath, 'client-cert');
+      fs.writeFileSync(keyPath, 'client-key');
+      fs.writeFileSync(caPath, 'ca-cert');
+
+      const mtlsClient = new ConfluenceClient({
+        domain: 'api.collaborate.akamai.com',
+        authType: 'mtls',
+        apiPath: '/confluence/rest/api',
+        mtls: {
+          caCert: caPath,
+          clientCert: certPath,
+          clientKey: keyPath,
+        }
+      });
+
+      expect(mtlsClient.client.defaults.headers.Authorization).toBeUndefined();
+      expect(mtlsClient.client.defaults.httpsAgent.options.ca.toString()).toBe('ca-cert');
+      expect(mtlsClient.client.defaults.httpsAgent.options.cert.toString()).toBe('client-cert');
+      expect(mtlsClient.client.defaults.httpsAgent.options.key.toString()).toBe('client-key');
+
+      removeDirRecursive(tmpDir);
+    });
   });
 
   describe('401 error handling', () => {
@@ -250,6 +278,30 @@ describe('ConfluenceClient', () => {
 
       await expect(dcClient.readPage('123')).rejects.toThrow(/verify your username and password/);
       mock.restore();
+    });
+
+    test('provides certificate hints for mtls auth', async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'confluence-mtls-'));
+      const certPath = path.join(tmpDir, 'client.pem');
+      const keyPath = path.join(tmpDir, 'client.key');
+      fs.writeFileSync(certPath, 'client-cert');
+      fs.writeFileSync(keyPath, 'client-key');
+
+      const mtlsClient = new ConfluenceClient({
+        domain: 'api.collaborate.akamai.com',
+        authType: 'mtls',
+        apiPath: '/confluence/rest/api',
+        mtls: {
+          clientCert: certPath,
+          clientKey: keyPath,
+        }
+      });
+      const mock = new MockAdapter(mtlsClient.client);
+      mock.onGet(/\/content\/123/).reply(401);
+
+      await expect(mtlsClient.readPage('123')).rejects.toThrow(/client certificate/);
+      mock.restore();
+      removeDirRecursive(tmpDir);
     });
   });
 

--- a/tests/profile.test.js
+++ b/tests/profile.test.js
@@ -198,6 +198,17 @@ describe('Profile management', () => {
       process.env.CONFLUENCE_TLS_CLIENT_CERT = '/Users/test/.certs/user-client.pem';
       process.env.CONFLUENCE_TLS_CLIENT_KEY = '/Users/test/.certs/user.key';
 
+      // Mock existsSync to return true for the cert paths
+      const certPaths = [
+        '/Users/test/.certs/akamai-ca-chain.pem',
+        '/Users/test/.certs/user-client.pem',
+        '/Users/test/.certs/user.key',
+      ];
+      fs.existsSync.mockImplementation((filePath) => {
+        if (certPaths.includes(filePath)) return true;
+        return jest.requireActual('fs').existsSync(filePath);
+      });
+
       const config = getConfig();
       expect(config.domain).toBe('api.collaborate.akamai.com');
       expect(config.authType).toBe('mtls');
@@ -268,6 +279,11 @@ describe('Profile management', () => {
     });
 
     test('returns mtls config stored in a profile', () => {
+      const certPaths = [
+        '/Users/test/.certs/akamai-ca-chain.pem',
+        '/Users/test/.certs/user-client.pem',
+        '/Users/test/.certs/user.key',
+      ];
       mockConfigFile({
         activeProfile: 'default',
         profiles: {
@@ -283,6 +299,12 @@ describe('Profile management', () => {
             },
           },
         },
+      });
+      // Also mock existsSync for cert paths
+      const originalMock = fs.existsSync.getMockImplementation();
+      fs.existsSync.mockImplementation((filePath) => {
+        if (certPaths.includes(filePath)) return true;
+        return originalMock(filePath);
       });
 
       const config = getConfig();

--- a/tests/profile.test.js
+++ b/tests/profile.test.js
@@ -29,6 +29,7 @@ const ENV_KEYS = [
   'CONFLUENCE_EMAIL', 'CONFLUENCE_USERNAME',
   'CONFLUENCE_AUTH_TYPE', 'CONFLUENCE_API_PATH',
   'CONFLUENCE_PROTOCOL', 'CONFLUENCE_PROFILE',
+  'CONFLUENCE_TLS_CA_CERT', 'CONFLUENCE_TLS_CLIENT_CERT', 'CONFLUENCE_TLS_CLIENT_KEY',
 ];
 
 // Helper to create a multi-profile config
@@ -189,6 +190,43 @@ describe('Profile management', () => {
       expect(config.token).toBe('env-token');
     });
 
+    test('supports mtls-only auth from environment variables', () => {
+      process.env.CONFLUENCE_DOMAIN = 'api.collaborate.akamai.com';
+      process.env.CONFLUENCE_AUTH_TYPE = 'mtls';
+      process.env.CONFLUENCE_API_PATH = '/confluence/rest/api';
+      process.env.CONFLUENCE_TLS_CA_CERT = '/Users/test/.certs/akamai-ca-chain.pem';
+      process.env.CONFLUENCE_TLS_CLIENT_CERT = '/Users/test/.certs/user-client.pem';
+      process.env.CONFLUENCE_TLS_CLIENT_KEY = '/Users/test/.certs/user.key';
+
+      const config = getConfig();
+      expect(config.domain).toBe('api.collaborate.akamai.com');
+      expect(config.authType).toBe('mtls');
+      expect(config.token).toBeUndefined();
+      expect(config.mtls).toEqual({
+        caCert: '/Users/test/.certs/akamai-ca-chain.pem',
+        clientCert: '/Users/test/.certs/user-client.pem',
+        clientKey: '/Users/test/.certs/user.key',
+      });
+    });
+
+    test('exits when mtls env config is missing a client key', () => {
+      process.env.CONFLUENCE_DOMAIN = 'api.collaborate.akamai.com';
+      process.env.CONFLUENCE_AUTH_TYPE = 'mtls';
+      process.env.CONFLUENCE_TLS_CLIENT_CERT = '/Users/test/.certs/user-client.pem';
+
+      const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit');
+      });
+      const mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+      expect(() => getConfig()).toThrow('process.exit');
+
+      mockExit.mockRestore();
+      mockError.mockRestore();
+      mockLog.mockRestore();
+    });
+
     test('CONFLUENCE_PROFILE env var selects profile', () => {
       process.env.CONFLUENCE_PROFILE = 'staging';
       mockConfigFile(multiProfileConfig());
@@ -227,6 +265,30 @@ describe('Profile management', () => {
       expect(config.token).toBe('old-token');
       expect(config.authType).toBe('bearer');
       expect(config.protocol).toBe('https');
+    });
+
+    test('returns mtls config stored in a profile', () => {
+      mockConfigFile({
+        activeProfile: 'default',
+        profiles: {
+          default: {
+            domain: 'api.collaborate.akamai.com',
+            protocol: 'https',
+            apiPath: '/confluence/rest/api',
+            authType: 'mtls',
+            mtls: {
+              caCert: '/Users/test/.certs/akamai-ca-chain.pem',
+              clientCert: '/Users/test/.certs/user-client.pem',
+              clientKey: '/Users/test/.certs/user.key',
+            },
+          },
+        },
+      });
+
+      const config = getConfig();
+      expect(config.authType).toBe('mtls');
+      expect(config.token).toBeUndefined();
+      expect(config.mtls.clientCert).toBe('/Users/test/.certs/user-client.pem');
     });
 
     test('exits with error for empty config file', () => {


### PR DESCRIPTION
## Summary

This adds support for Confluence deployments that authenticate at the TLS layer with client certificates instead of Basic or Bearer credentials.

## Changes

- add `mtls` as a supported `--auth-type`
- add CLI flags for `--tls-client-cert`, `--tls-client-key`, and `--tls-ca-cert`
- support mTLS config in saved profiles and environment variables
- configure the HTTP client with an `https.Agent` using the provided cert/key/CA files
- skip the `Authorization` header in mTLS mode
- validate that mTLS mode has the required client certificate and key
- document mTLS usage in the README
- add tests covering profile/env parsing and client setup

## Validation

- `npm test -- --runInBand`
- `npm run lint`