### PR TITLE
Follow-up improvements from mTLS PR review

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ confluence --profile corp init \
   --domain "docs.example.com" \
   --api-path "/confluence/rest/api" \
   --auth-type "mtls" \
-  --tls-client-cert "/Users/you/.certs/client.pem" \
-  --tls-client-key "/Users/you/.certs/client.key" \
-  --tls-ca-cert "/Users/you/.certs/ca-chain.pem"
+  --tls-client-cert "~/.certs/client.pem" \
+  --tls-client-key "~/.certs/client.key" \
+  --tls-ca-cert "~/.certs/ca-chain.pem"
 ```
 
 **Hybrid mode** (some fields provided, rest via prompts):
@@ -188,9 +188,9 @@ export CONFLUENCE_PROFILE="default"
 export CONFLUENCE_DOMAIN="docs.example.com"
 export CONFLUENCE_API_PATH="/confluence/rest/api"
 export CONFLUENCE_AUTH_TYPE="mtls"
-export CONFLUENCE_TLS_CLIENT_CERT="/Users/you/.certs/client.pem"
-export CONFLUENCE_TLS_CLIENT_KEY="/Users/you/.certs/client.key"
-export CONFLUENCE_TLS_CA_CERT="/Users/you/.certs/ca-chain.pem"  # optional
+export CONFLUENCE_TLS_CLIENT_CERT="~/.certs/client.pem"
+export CONFLUENCE_TLS_CLIENT_KEY="~/.certs/client.key"
+export CONFLUENCE_TLS_CA_CERT="~/.certs/ca-chain.pem"  # optional
 ```
 
 **Scoped API token** (recommended for agents):

--- a/lib/config.js
+++ b/lib/config.js
@@ -93,6 +93,37 @@ const validateMtlsConfig = (mtls, labelPrefix = 'mTLS') => {
   return errors;
 };
 
+const validateMtlsProtocol = (protocol) => {
+  if (normalizeProtocol(protocol) === 'http') {
+    return 'mTLS authentication requires HTTPS and is not compatible with HTTP.';
+  }
+  return null;
+};
+
+/**
+ * Build an inquirer question for an mTLS file path prompt.
+ * @param {string} name       - answer key (e.g. 'tlsClientCert')
+ * @param {string} message    - prompt text
+ * @param {boolean} required  - whether the field is mandatory
+ * @param {Function} [whenFn] - optional custom `when` predicate; defaults to authType === 'mtls'
+ */
+const mtlsCertQuestion = (name, message, required, whenFn) => ({
+  type: 'input',
+  name,
+  message,
+  when: whenFn || ((responses) => responses.authType === 'mtls'),
+  validate: (input) => {
+    const value = (input || '').trim();
+    if (!value) {
+      return required ? `${message.replace(/:$/, '')} is required for mTLS.` : true;
+    }
+    if (!fs.existsSync(value)) {
+      return `File not found: ${value}`;
+    }
+    return true;
+  }
+});
+
 const inferApiPath = (domain) => {
   if (!domain) {
     return '/rest/api';
@@ -216,8 +247,9 @@ const validateCliOptions = (options) => {
     validateMtlsConfig(options.mtls, '--auth-type mtls').forEach((error) => {
       errors.push(error);
     });
-    if (options.protocol && options.protocol.toLowerCase() === 'http') {
-      errors.push('mTLS authentication requires HTTPS. --protocol http is not compatible with --auth-type mtls.');
+    const protocolError = validateMtlsProtocol(options.protocol);
+    if (protocolError) {
+      errors.push(protocolError);
     }
   }
 
@@ -364,65 +396,18 @@ const promptForMissingValues = async (providedValues) => {
 
   // mTLS certificate path questions
   const mtls = normalizeMtlsConfig(providedValues.mtls);
+  const mtlsWhen = (responses) => {
+    const authType = providedValues.authType || responses.authType;
+    return authType === 'mtls';
+  };
   if (!mtls || !mtls.clientCert) {
-    questions.push({
-      type: 'input',
-      name: 'tlsClientCert',
-      message: 'Path to client certificate file (PEM):',
-      when: (responses) => {
-        const authType = providedValues.authType || responses.authType;
-        return authType === 'mtls';
-      },
-      validate: (input) => {
-        const value = (input || '').trim();
-        if (!value) {
-          return 'Client certificate path is required for mTLS.';
-        }
-        if (!fs.existsSync(value)) {
-          return `File not found: ${value}`;
-        }
-        return true;
-      }
-    });
+    questions.push(mtlsCertQuestion('tlsClientCert', 'Path to client certificate file (PEM):', true, mtlsWhen));
   }
   if (!mtls || !mtls.clientKey) {
-    questions.push({
-      type: 'input',
-      name: 'tlsClientKey',
-      message: 'Path to client key file (PEM):',
-      when: (responses) => {
-        const authType = providedValues.authType || responses.authType;
-        return authType === 'mtls';
-      },
-      validate: (input) => {
-        const value = (input || '').trim();
-        if (!value) {
-          return 'Client key path is required for mTLS.';
-        }
-        if (!fs.existsSync(value)) {
-          return `File not found: ${value}`;
-        }
-        return true;
-      }
-    });
+    questions.push(mtlsCertQuestion('tlsClientKey', 'Path to client key file (PEM):', true, mtlsWhen));
   }
   if (!mtls || !mtls.caCert) {
-    questions.push({
-      type: 'input',
-      name: 'tlsCaCert',
-      message: 'Path to CA certificate file (PEM, optional):',
-      when: (responses) => {
-        const authType = providedValues.authType || responses.authType;
-        return authType === 'mtls';
-      },
-      validate: (input) => {
-        const value = (input || '').trim();
-        if (value && !fs.existsSync(value)) {
-          return `File not found: ${value}`;
-        }
-        return true;
-      }
-    });
+    questions.push(mtlsCertQuestion('tlsCaCert', 'Path to CA certificate file (PEM, optional):', false, mtlsWhen));
   }
 
   if (questions.length === 0) {
@@ -526,51 +511,9 @@ async function initConfig(cliOptions = {}) {
         when: (responses) => responses.authType !== 'mtls',
         validate: requiredInput('API token / password')
       },
-      {
-        type: 'input',
-        name: 'tlsClientCert',
-        message: 'Path to client certificate file (PEM):',
-        when: (responses) => responses.authType === 'mtls',
-        validate: (input) => {
-          const value = (input || '').trim();
-          if (!value) {
-            return 'Client certificate path is required for mTLS.';
-          }
-          if (!fs.existsSync(value)) {
-            return `File not found: ${value}`;
-          }
-          return true;
-        }
-      },
-      {
-        type: 'input',
-        name: 'tlsClientKey',
-        message: 'Path to client key file (PEM):',
-        when: (responses) => responses.authType === 'mtls',
-        validate: (input) => {
-          const value = (input || '').trim();
-          if (!value) {
-            return 'Client key path is required for mTLS.';
-          }
-          if (!fs.existsSync(value)) {
-            return `File not found: ${value}`;
-          }
-          return true;
-        }
-      },
-      {
-        type: 'input',
-        name: 'tlsCaCert',
-        message: 'Path to CA certificate file (PEM, optional):',
-        when: (responses) => responses.authType === 'mtls',
-        validate: (input) => {
-          const value = (input || '').trim();
-          if (value && !fs.existsSync(value)) {
-            return `File not found: ${value}`;
-          }
-          return true;
-        }
-      }
+      mtlsCertQuestion('tlsClientCert', 'Path to client certificate file (PEM):', true),
+      mtlsCertQuestion('tlsClientKey', 'Path to client key file (PEM):', true),
+      mtlsCertQuestion('tlsCaCert', 'Path to CA certificate file (PEM, optional):', false)
     ]);
 
     const configData = { ...answers, readOnly };
@@ -731,7 +674,8 @@ function getConfig(profileName) {
         process.exit(1);
       }
       if (normalizeProtocol(envProtocol) === 'http') {
-        console.error(chalk.red('❌ mTLS authentication requires HTTPS. CONFLUENCE_PROTOCOL=http is not compatible with CONFLUENCE_AUTH_TYPE=mtls.'));
+        const protocolError = validateMtlsProtocol(envProtocol);
+        console.error(chalk.red(`❌ ${protocolError}`));
         process.exit(1);
       }
     }
@@ -803,7 +747,8 @@ function getConfig(profileName) {
         process.exit(1);
       }
       if (normalizeProtocol(storedConfig.protocol) === 'http') {
-        console.error(chalk.red('❌ mTLS authentication requires HTTPS. Protocol "http" is not compatible with auth type "mtls".'));
+        const protocolError = validateMtlsProtocol(storedConfig.protocol);
+        console.error(chalk.red(`❌ ${protocolError}`));
         console.log(chalk.yellow('Please rerun "confluence init" to update your protocol to HTTPS.'));
         process.exit(1);
       }

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -165,6 +165,22 @@ class ConfluenceClient {
       if (!fs.existsSync(this.mtls.clientKey)) {
         throw new Error(`Client key file not found: ${this.mtls.clientKey}`);
       }
+      // Warn if private key file is readable by others (Unix only)
+      if (process.platform !== 'win32') {
+        try {
+          const keyStats = fs.statSync(this.mtls.clientKey);
+          const keyMode = keyStats.mode & 0o777;
+          if (keyMode & 0o077) {
+            console.error(
+              `Warning: Client key file "${this.mtls.clientKey}" has mode ${keyMode.toString(8)}. ` +
+              'Private keys should not be readable by other users (recommended: 0600). ' +
+              `Fix with: chmod 600 "${this.mtls.clientKey}"`
+            );
+          }
+        } catch {
+          // Ignore stat errors — the read below will surface them
+        }
+      }
       options.key = fs.readFileSync(this.mtls.clientKey);
     }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2684,9 +2684,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",


### PR DESCRIPTION
## Summary

Follow-up to #102, addressing the post-merge review suggestions from @pchuri.

- Warn when client key file permissions are more permissive than `0600` on Unix systems (private key security risk)
- Extract `mtlsCertQuestion()` helper to eliminate duplicated prompt definitions across `initConfig` interactive mode and `promptForMissingValues`
- Extract `validateMtlsProtocol()` helper to share the http+mTLS incompatibility check across CLI validation, env config, and profile config
- Update README mTLS examples to use platform-neutral paths (`~/.certs/`) instead of macOS-specific `/Users/you/.certs/`

## Validation

- `npm test -- --runInBand` — 178 tests passing
- `npm run lint` — clean