### PR TITLE
fix: preserve internal page links with custom display text in markdown conversion

### DIFF
--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -1499,9 +1499,12 @@ class ConfluenceClient {
     // Format: <ac:link><ri:page ri:space-key="xxx" ri:content-title="Page Title" /></ac:link>
     markdown = markdown.replace(/<ac:link>\s*<ri:page[^>]*ri:content-title="([^"]*)"[^>]*\/>\s*<\/ac:link>/g, '[$1]');
     markdown = markdown.replace(/<ac:link>\s*<ri:page[^>]*ri:content-title="([^"]*)"[^>]*>\s*<\/ri:page>\s*<\/ac:link>/g, '[$1]');
-    
-    // Remove any remaining ac:link tags that weren't matched
-    markdown = markdown.replace(/<ac:link>[\s\S]*?<\/ac:link>/g, '');
+
+    // Convert internal page links with custom display text (ac:link-body)
+    markdown = markdown.replace(/<ac:link[^>]*>[\s\S]*?<ac:link-body>([\s\S]*?)<\/ac:link-body>[\s\S]*?<\/ac:link>/g, '$1');
+
+    // Remove any remaining ac:link tags that weren't matched (including those with attributes)
+    markdown = markdown.replace(/<ac:link[^>]*>[\s\S]*?<\/ac:link>/g, '');
     
     // Convert remaining HTML to markdown
     markdown = this.htmlToMarkdown(markdown);

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -573,8 +573,32 @@ describe('ConfluenceClient', () => {
     test('should convert Confluence links to markdown', () => {
       const storage = '<ac:link><ri:url ri:value="https://example.com" /><ac:plain-text-link-body><![CDATA[Example]]></ac:plain-text-link-body></ac:link>';
       const result = client.storageToMarkdown(storage);
-      
+
       expect(result).toContain('[Example](https://example.com)');
+    });
+
+    test('should convert internal page links to markdown', () => {
+      const storage = '<ac:link><ri:page ri:space-key="DEV" ri:content-title="Page Title" /></ac:link>';
+      const result = client.storageToMarkdown(storage);
+      expect(result).toContain('[Page Title]');
+    });
+
+    test('should preserve display text from internal page links with ac:link-body', () => {
+      const storage = '<ac:link><ri:page ri:content-title="Some Long Page Title" ri:version-at-save="28" /><ac:link-body>Short Name</ac:link-body></ac:link>';
+      const result = client.storageToMarkdown(storage);
+      expect(result).toContain('Short Name');
+    });
+
+    test('should remove ac:link tags with attributes', () => {
+      const storage = '<p>Before</p><ac:link ac:anchor="section"><ri:page ri:content-title="Page" /></ac:link><p>After</p>';
+      const result = client.storageToMarkdown(storage);
+      expect(result).not.toContain('ac:link');
+    });
+
+    test('should preserve internal link text in table cells', () => {
+      const storage = '<table><tr><th><p>Name</p></th></tr><tr><td><p><ac:link><ri:page ri:content-title="Long Title" /><ac:link-body>Display</ac:link-body></ac:link></p></td></tr></table>';
+      const result = client.storageToMarkdown(storage);
+      expect(result).toContain('Display');
     });
   });
 


### PR DESCRIPTION
## Pull Request Template

### Description
Internal page links with `<ac:link-body>` (custom display text) were silently removed during `storageToMarkdown` conversion. This PR adds a regex to extract the display text and widens the catch-all to also handle `<ac:link>` tags with attributes.

Closes #104

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

### Testing
- [x] Tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

### Additional Context
**Root cause:** `storageToMarkdown` handled two `<ac:link>` patterns (external URL links and internal links without a link body) but missed the `<ac:link-body>` variant. Unmatched links fell through to a catch-all regex that only matched `<ac:link>` without attributes.

**Changes:**
- Added regex to extract display text from `<ac:link-body>` before the catch-all
- Widened catch-all from `<ac:link>` to `<ac:link[^>]*>` to also clean up attribute-bearing tags
- Added 4 test cases covering internal links, custom display text, attributed tags, and table cell links