### PR TITLE
Add forceCloud option for Cloud instances with custom domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,27 @@ export CONFLUENCE_API_TOKEN="your-scoped-token"
 
 `CONFLUENCE_API_PATH` defaults to `/wiki/rest/api` for Atlassian Cloud domains and `/rest/api` otherwise. Override it when your site lives under a custom reverse proxy or on-premises path. `CONFLUENCE_AUTH_TYPE` defaults to `basic` when an email is present and falls back to `bearer` otherwise. For `mtls`, set `CONFLUENCE_TLS_CLIENT_CERT` and `CONFLUENCE_TLS_CLIENT_KEY`; `CONFLUENCE_TLS_CA_CERT` is optional.
 
+**Custom domains on Confluence Cloud:**
+
+If your Confluence Cloud instance uses a custom domain (e.g., `wiki.example.org` instead of `*.atlassian.net`), the CLI may misidentify it as a Server/Data Center instance and produce broken link formats. Set `CONFLUENCE_FORCE_CLOUD=true` to override the automatic detection:
+
+```bash
+export CONFLUENCE_FORCE_CLOUD=true
+```
+
+Or add `"forceCloud": true` to your profile in `~/.confluence-cli/config.json`:
+
+```json
+{
+  "profiles": {
+    "default": {
+      "domain": "wiki.example.org",
+      "forceCloud": true
+    }
+  }
+}
+```
+
 **Read-only mode** (recommended for AI agents):
 ```bash
 export CONFLUENCE_READ_ONLY=true

--- a/lib/config.js
+++ b/lib/config.js
@@ -637,6 +637,7 @@ function getConfig(profileName) {
   const envApiPath = process.env.CONFLUENCE_API_PATH;
   const envProtocol = process.env.CONFLUENCE_PROTOCOL;
   const envReadOnly = process.env.CONFLUENCE_READ_ONLY;
+  const envForceCloud = process.env.CONFLUENCE_FORCE_CLOUD;
   const envMtls = normalizeMtlsConfig({
     caCert: process.env.CONFLUENCE_TLS_CA_CERT,
     clientCert: process.env.CONFLUENCE_TLS_CLIENT_CERT,
@@ -688,7 +689,8 @@ function getConfig(profileName) {
       email: envEmail ? envEmail.trim() : undefined,
       authType,
       mtls: envMtls,
-      readOnly: envReadOnly === 'true'
+      readOnly: envReadOnly === 'true',
+      forceCloud: envForceCloud === 'true'
     };
   }
 
@@ -766,6 +768,10 @@ function getConfig(profileName) {
       ? envReadOnly === 'true'
       : Boolean(storedConfig.readOnly);
 
+    const forceCloud = envForceCloud !== undefined
+      ? envForceCloud === 'true'
+      : Boolean(storedConfig.forceCloud);
+
     return {
       domain: trimmedDomain,
       protocol: normalizeProtocol(storedConfig.protocol),
@@ -774,7 +780,8 @@ function getConfig(profileName) {
       email: trimmedEmail,
       authType,
       mtls,
-      readOnly
+      readOnly,
+      forceCloud
     };
   } catch (error) {
     console.error(chalk.red('❌ Error reading configuration file:'), error.message);

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -35,6 +35,7 @@ class ConfluenceClient {
     this.token = config.token;
     this.email = config.email;
     this.authType = (config.authType || (this.email ? 'basic' : 'bearer')).toLowerCase();
+    this.forceCloud = !!config.forceCloud;
     this.mtls = config.mtls;
     this.apiPath = this.sanitizeApiPath(config.apiPath);
     this.webUrlPrefix = this.apiPath.startsWith('/wiki/') ? '/wiki' : '';
@@ -100,7 +101,7 @@ class ConfluenceClient {
   }
 
   isCloud() {
-    return this.isScopedToken() || (this.domain && this.domain.trim().toLowerCase().endsWith('.atlassian.net'));
+    return this.isScopedToken() || (this.domain && this.domain.trim().toLowerCase().endsWith('.atlassian.net')) || this.forceCloud;
   }
 
   isScopedToken() {

--- a/plugins/confluence/skills/confluence/SKILL.md
+++ b/plugins/confluence/skills/confluence/SKILL.md
@@ -29,6 +29,7 @@ confluence --version   # verify install
 | `CONFLUENCE_API_TOKEN` | API token or personal access token | `ATATT3x...` |
 | `CONFLUENCE_PROFILE` | Named profile to use (optional) | `staging` |
 | `CONFLUENCE_READ_ONLY` | Block all write operations when `true` | `true` |
+| `CONFLUENCE_FORCE_CLOUD` | Force Cloud link format for custom domains | `true` |
 
 **Global `--profile` flag (use a named profile for any command):**
 
@@ -53,6 +54,7 @@ confluence init \
 
 **Cloud vs Server/DC:**
 - Atlassian Cloud (`*.atlassian.net`): use `--api-path "/wiki/rest/api"`, auth type `basic` with email + API token
+- Atlassian Cloud (custom domain): if your Cloud instance uses a custom domain (e.g., `wiki.example.org`), set `CONFLUENCE_FORCE_CLOUD=true` or add `"forceCloud": true` to your profile in `~/.confluence-cli/config.json`. Without this, links will render incorrectly.
 - Atlassian Cloud (scoped token): use `--domain "api.atlassian.com"`, `--api-path "/ex/confluence/<your-cloud-id>/wiki/rest/api"`, auth type `basic` with email + scoped token. Get your Cloud ID from `https://<your-site>.atlassian.net/_edge/tenant_info`. Recommended for agents (least privilege).
 - Self-hosted / Data Center: use `--api-path "/rest/api"`, auth type `bearer` with a personal access token (no email needed)
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -6,7 +6,7 @@ const ENV_KEYS = [
   'CONFLUENCE_API_TOKEN', 'CONFLUENCE_PASSWORD',
   'CONFLUENCE_EMAIL', 'CONFLUENCE_USERNAME',
   'CONFLUENCE_AUTH_TYPE', 'CONFLUENCE_API_PATH',
-  'CONFLUENCE_PROTOCOL'
+  'CONFLUENCE_PROTOCOL', 'CONFLUENCE_FORCE_CLOUD'
 ];
 
 describe('getConfig env var aliases', () => {
@@ -102,5 +102,22 @@ describe('getConfig env var aliases', () => {
 
     const config = getConfig();
     expect(config.protocol).toBe('https');
+  });
+
+  test('CONFLUENCE_FORCE_CLOUD=true sets forceCloud in config', () => {
+    process.env.CONFLUENCE_DOMAIN = 'wiki.example.org';
+    process.env.CONFLUENCE_API_TOKEN = 'token';
+    process.env.CONFLUENCE_FORCE_CLOUD = 'true';
+
+    const config = getConfig();
+    expect(config.forceCloud).toBe(true);
+  });
+
+  test('forceCloud defaults to false when CONFLUENCE_FORCE_CLOUD is not set', () => {
+    process.env.CONFLUENCE_DOMAIN = 'wiki.example.org';
+    process.env.CONFLUENCE_API_TOKEN = 'token';
+
+    const config = getConfig();
+    expect(config.forceCloud).toBe(false);
   });
 });

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -478,6 +478,55 @@ describe('ConfluenceClient', () => {
       expect(result).toContain('Example Link');
       expect(result).not.toContain('data-card-appearance');
     });
+
+    test('should convert links to smart link format when forceCloud is set on a custom domain', () => {
+      const customDomainClient = new ConfluenceClient({
+        domain: 'wiki.example.org',
+        token: 'test-token',
+        forceCloud: true
+      });
+      const markdown = '[Example Link](https://example.com)';
+      const result = customDomainClient.markdownToStorage(markdown);
+
+      expect(result).toContain('<a href="https://example.com" data-card-appearance="inline">Example Link</a>');
+      expect(result).not.toContain('<ac:link>');
+    });
+  });
+
+  describe('forceCloud', () => {
+    test('isCloud returns false for custom domains without forceCloud', () => {
+      const customClient = new ConfluenceClient({
+        domain: 'wiki.example.org',
+        token: 'test-token'
+      });
+      expect(customClient.isCloud()).toBe(false);
+    });
+
+    test('isCloud returns true for custom domains with forceCloud', () => {
+      const customClient = new ConfluenceClient({
+        domain: 'wiki.example.org',
+        token: 'test-token',
+        forceCloud: true
+      });
+      expect(customClient.isCloud()).toBe(true);
+    });
+
+    test('isCloud returns true for atlassian.net domains without forceCloud', () => {
+      const cloudClient = new ConfluenceClient({
+        domain: 'company.atlassian.net',
+        token: 'test-token'
+      });
+      expect(cloudClient.isCloud()).toBe(true);
+    });
+
+    test('forceCloud defaults to false when not specified', () => {
+      const defaultClient = new ConfluenceClient({
+        domain: 'example.com',
+        token: 'test-token'
+      });
+      expect(defaultClient.forceCloud).toBe(false);
+      expect(defaultClient.isCloud()).toBe(false);
+    });
   });
 
   describe('markdownToNativeStorage', () => {


### PR DESCRIPTION
## Summary

Confluence Cloud instances with custom domains (e.g., `wiki.example.org` instead of `*.atlassian.net`) are misidentified as Server/Data Center by the `isCloud()` check. This causes links to render using the `<ac:link><ri:url>` storage format, which Confluence Cloud does not support — resulting in broken links on every uploaded page.

This PR adds a `forceCloud` config option that overrides the domain-based detection:

- **`lib/confluence-client.js`** — reads `forceCloud` from config and includes it in `isCloud()`
- **`lib/config.js`** — passes `forceCloud` through from both env-var and profile-based config paths
- **Environment variable**: `CONFLUENCE_FORCE_CLOUD=true`
- **Profile config**: `"forceCloud": true` in `~/.confluence-cli/config.json`

### The problem

| Detected as | Link format produced | Works on Cloud? |
| --- | --- | --- |
| Cloud (`*.atlassian.net`) | `<a href="url" data-card-appearance="inline">text</a>` | Yes |
| Server/DC (everything else) | `<ac:link><ri:url ri:value="url" />...</ac:link>` | **No** |

Custom domain Cloud instances fall into the "everything else" bucket.

### The fix

```js
// confluence-client.js constructor
this.forceCloud = !!config.forceCloud;

// isCloud() — 3 characters added
isCloud() {
  return this.isScopedToken()
    || (this.domain && this.domain.trim().toLowerCase().endsWith('.atlassian.net'))
    || this.forceCloud;
}
```

## Test plan

- [x] Added unit tests for `isCloud()` with `forceCloud: true` on custom domains
- [x] Added unit test verifying `forceCloud` produces Cloud link format (smart links) instead of `ac:link`
- [x] Added config tests for `CONFLUENCE_FORCE_CLOUD` env var
- [x] All 189 existing tests continue to pass
- [x] Updated README.md with custom domain documentation
- [x] Updated Claude Code skill documentation