### PR TITLE
fix: escape regex metacharacters in userkey before replacement

### DIFF
--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -478,12 +478,12 @@ class ConfluenceClient {
     // Replace userkey references with display names in HTML
     let resolvedHtml = html;
     userMap.forEach((displayName, userKey) => {
-      // Replace <ac:link><ri:user ri:userkey="xxx" /></ac:link> with @displayName
+      const escapedKey = userKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       const userLinkRegex = new RegExp(
-        `<ac:link>\\s*<ri:user\\s+ri:userkey="${userKey}"\\s*/>\\s*</ac:link>`,
+        `<ac:link>\\s*<ri:user\\s+ri:userkey="${escapedKey}"\\s*/>\\s*</ac:link>`,
         'g'
       );
-      resolvedHtml = resolvedHtml.replace(userLinkRegex, `@${displayName}`);
+      resolvedHtml = resolvedHtml.replace(userLinkRegex, () => `@${displayName}`);
     });
 
     return { html: resolvedHtml, userMap };

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -809,6 +809,53 @@ describe('ConfluenceClient', () => {
     });
   });
 
+  describe('resolveUserKeysInHtml', () => {
+    test('should replace ri:user link with @displayName', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/user').reply(200, { displayName: 'Jane Doe', username: 'jdoe' });
+
+      const html = '<p>cc <ac:link><ri:user ri:userkey="abc123" /></ac:link></p>';
+      const { html: resolved, userMap } = await client.resolveUserKeysInHtml(html);
+
+      expect(resolved).toBe('<p>cc @Jane Doe</p>');
+      expect(userMap.get('abc123')).toBe('Jane Doe');
+
+      mock.restore();
+    });
+
+    test('should handle userkey containing regex metacharacters', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/user').reply(200, { displayName: 'Jane Doe', username: 'jdoe' });
+
+      const html = '<p><ac:link><ri:user ri:userkey="a.b+c*d" /></ac:link></p>';
+      const { html: resolved } = await client.resolveUserKeysInHtml(html);
+
+      expect(resolved).toBe('<p>@Jane Doe</p>');
+
+      mock.restore();
+    });
+
+    test('should not interpret $ in displayName as replacement pattern', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/user').reply(200, { displayName: '$1 money $$', username: 'user' });
+
+      const html = '<p><ac:link><ri:user ri:userkey="xyz" /></ac:link></p>';
+      const { html: resolved } = await client.resolveUserKeysInHtml(html);
+
+      expect(resolved).toBe('<p>@$1 money $$</p>');
+
+      mock.restore();
+    });
+
+    test('should return html unchanged when no userkeys present', async () => {
+      const html = '<p>plain content</p>';
+      const { html: resolved, userMap } = await client.resolveUserKeysInHtml(html);
+
+      expect(resolved).toBe(html);
+      expect(userMap.size).toBe(0);
+    });
+  });
+
   describe('page creation and updates', () => {
     test('should have required methods for page management', () => {
       expect(typeof client.createPage).toBe('function');


### PR DESCRIPTION
## Description

`resolveUserKeysInHtml` in `lib/confluence-client.js` interpolated the extracted `userKey` directly into a `new RegExp(...)` without escaping. Any `userKey` containing regex metacharacters (`.`, `+`, `*`, `(`, `)`, etc.) would either match the wrong span or fail to match at all, silently leaving `<ac:link><ri:user ri:userkey="..."/></ac:link>` in the rendered output.

While touching the same two lines, also switched `.replace(regex, \`@${displayName}\`)` to a function callback so that `$` sequences in the fetched `displayName` (e.g. `$1`, `$&`, `$$`) are no longer interpreted as replacement patterns.

### Before
```js
const userLinkRegex = new RegExp(
  `<ac:link>\\s*<ri:user\\s+ri:userkey="${userKey}"\\s*/>\\s*</ac:link>`,
  'g'
);
resolvedHtml = resolvedHtml.replace(userLinkRegex, `@${displayName}`);
```

### After
```js
const escapedKey = userKey.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
const userLinkRegex = new RegExp(
  `<ac:link>\\s*<ri:user\\s+ri:userkey="${escapedKey}"\\s*/>\\s*</ac:link>`,
  'g'
);
resolvedHtml = resolvedHtml.replace(userLinkRegex, () => `@${displayName}`);
```

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Tests pass locally with my changes
- [x] Added new tests that prove the fix is effective
- [x] New and existing unit tests pass locally (193/193)

New `resolveUserKeysInHtml` describe block covers:
- baseline `ri:user` → `@displayName` replacement
- userkey containing regex metacharacters (`a.b+c*d`) — regression guard for the main fix
- displayName containing `$1` / `$$` — regression guard for the replacement-pattern fix
- HTML with no userkeys returns unchanged

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (lint clean)