### PR TITLE
perf: parallelize getAllDescendantPages sibling fetches

### DIFF
--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -1966,18 +1966,20 @@ class ConfluenceClient {
     const children = await this.getChildPages(pageId);
     // Attach parentId so we can later reconstruct hierarchy if needed
     const childrenWithParent = children.map(child => ({ ...child, parentId: pageId }));
-    let allDescendants = [...childrenWithParent];
 
-    for (const child of children) {
-      const grandChildren = await this.getAllDescendantPages(
-        child.id, 
-        maxDepth, 
-        currentDepth + 1
+    const SIBLING_CONCURRENCY = 10;
+    const grandChildrenLists = [];
+    for (let i = 0; i < children.length; i += SIBLING_CONCURRENCY) {
+      const chunk = children.slice(i, i + SIBLING_CONCURRENCY);
+      const chunkResults = await Promise.all(
+        chunk.map(child =>
+          this.getAllDescendantPages(child.id, maxDepth, currentDepth + 1)
+        )
       );
-      allDescendants = allDescendants.concat(grandChildren);
+      grandChildrenLists.push(...chunkResults);
     }
 
-    return allDescendants;
+    return childrenWithParent.concat(...grandChildrenLists);
   }
 
   /**

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -27,6 +27,28 @@ const NAMED_ENTITIES = {
   Eth: 'Ð', Thorn: 'Þ'
 };
 
+function createSemaphore(limit) {
+  let active = 0;
+  const waiters = [];
+  return {
+    async acquire() {
+      if (active < limit) {
+        active++;
+        return;
+      }
+      await new Promise(resolve => waiters.push(resolve));
+    },
+    release() {
+      if (waiters.length > 0) {
+        const next = waiters.shift();
+        next();
+      } else {
+        active--;
+      }
+    }
+  };
+}
+
 class ConfluenceClient {
   constructor(config) {
     this.domain = config.domain;
@@ -1959,25 +1981,31 @@ class ConfluenceClient {
    * Get all descendant pages recursively
    */
   async getAllDescendantPages(pageId, maxDepth = 10, currentDepth = 0) {
+    const semaphore = createSemaphore(10);
+    return this._collectDescendants(pageId, maxDepth, currentDepth, semaphore);
+  }
+
+  async _collectDescendants(pageId, maxDepth, currentDepth, semaphore) {
     if (currentDepth >= maxDepth) {
       return [];
     }
 
-    const children = await this.getChildPages(pageId);
+    await semaphore.acquire();
+    let children;
+    try {
+      children = await this.getChildPages(pageId);
+    } finally {
+      semaphore.release();
+    }
+
     // Attach parentId so we can later reconstruct hierarchy if needed
     const childrenWithParent = children.map(child => ({ ...child, parentId: pageId }));
 
-    const SIBLING_CONCURRENCY = 10;
-    const grandChildrenLists = [];
-    for (let i = 0; i < children.length; i += SIBLING_CONCURRENCY) {
-      const chunk = children.slice(i, i + SIBLING_CONCURRENCY);
-      const chunkResults = await Promise.all(
-        chunk.map(child =>
-          this.getAllDescendantPages(child.id, maxDepth, currentDepth + 1)
-        )
-      );
-      grandChildrenLists.push(...chunkResults);
-    }
+    const grandChildrenLists = await Promise.all(
+      children.map(child =>
+        this._collectDescendants(child.id, maxDepth, currentDepth + 1, semaphore)
+      )
+    );
 
     return childrenWithParent.concat(...grandChildrenLists);
   }

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -1233,6 +1233,36 @@ describe('ConfluenceClient', () => {
       expect(typeof client.shouldExcludePage).toBe('function');
     });
 
+    test('getAllDescendantPages caps concurrent getChildPages across the whole traversal', async () => {
+      let inFlight = 0;
+      let maxInFlight = 0;
+
+      const branchingFactor = 15;
+      const rootChildren = Array.from({ length: branchingFactor }, (_, i) => ({ id: `c${i}`, title: `child${i}` }));
+      const grandChildrenFor = (parentId) =>
+        Array.from({ length: branchingFactor }, (_, i) => ({ id: `${parentId}g${i}`, title: `${parentId}-gc${i}` }));
+
+      client.getChildPages = jest.fn(async (id) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise(resolve => setImmediate(resolve));
+        try {
+          if (id === 'root') return rootChildren;
+          if (/^c\d+$/.test(id)) return grandChildrenFor(id);
+          return [];
+        } finally {
+          inFlight -= 1;
+        }
+      });
+
+      const descendants = await client.getAllDescendantPages('root');
+
+      expect(maxInFlight).toBeLessThanOrEqual(10);
+      expect(descendants).toHaveLength(branchingFactor + branchingFactor * branchingFactor);
+      expect(descendants.slice(0, branchingFactor).map(d => d.id)).toEqual(rootChildren.map(c => c.id));
+      expect(descendants.slice(0, branchingFactor).every(d => d.parentId === 'root')).toBe(true);
+    });
+
     test('should correctly exclude pages based on patterns', () => {
       const patterns = ['temp*', 'test*', '*draft*'];
 


### PR DESCRIPTION
## Pull Request Template

### Description
`getAllDescendantPages` previously awaited each child's recursive fetch sequentially, producing N sequential API calls for an N-node subtree (a classic N+1 pattern). For deep or wide page trees this dominates wall-clock time on `export`, `copy`, and tree-traversal commands.

This PR introduces a **single semaphore shared across the entire traversal** that caps concurrent `getChildPages` requests at 10, regardless of tree shape.

**Revision after review (commit f6e637c):** an earlier version of this PR placed the concurrency cap inside each recursive frame, so the limit only applied per parent. For a tree with branching factor B and depth D, concurrent requests could grow to `min(B, 10)^D` — exactly the request flood the cap was meant to prevent. The fix threads a single `createSemaphore(10)` instance through a private `_collectDescendants` helper; every `getChildPages` call in the traversal acquires against that one semaphore, giving a hard global cap.

Preserved behavior:
- Public method signature (`getAllDescendantPages(pageId, maxDepth, currentDepth)`)
- Return order: DFS pre-order (current-level children first, then each child's descendants in original order)
- `parentId` attachment on each descendant
- `maxDepth` short-circuit
- Total API call count

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

### Testing
- [x] Tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Added `getAllDescendantPages caps concurrent getChildPages across the whole traversal` in `tests/confluence-client.test.js`: builds a 15-wide, 2-deep tree (240 descendants), instruments `getChildPages` with an in-flight counter, and asserts the observed peak stays ≤ 10. This test would have failed on the previous per-parent implementation (peak ~100) and passes on the current one.

Full suite: `npx jest` → 236 tests pass.

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

### Additional Context
**Why a semaphore instead of a library like `p-limit`?** `createSemaphore` is ~15 lines of zero-dependency code and is the only place in this codebase that needs a limiter. A dependency seemed like overreach.

**Why not switch to a single CQL `ancestor = X` query?** That's a larger behavior change (different pagination semantics, loss of per-level `parentId` attribution without a second pass) and deserves its own PR. This change is the minimal fix for the N+1 pattern.