### PR TITLE
feat: add json metadata and storage read support

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,9 @@ For **read-only** usage, select at minimum: `read:confluence-content.all`, `read
 # Read by page ID
 confluence read 123456789
 
+# Read native Confluence storage content
+confluence read 123456789 --format storage
+
 # Read in markdown format
 confluence read 123456789 --format markdown
 
@@ -311,9 +314,28 @@ confluence read 123456789 --format markdown
 confluence read "https://your-domain.atlassian.net/wiki/viewpage.action?pageId=123456789"
 ```
 
+Use `--format storage` when you need Confluence's native storage representation, especially for macros and other Confluence-specific markup.
+
 ### Get Page Information
 ```bash
 confluence info 123456789
+
+# Emit machine-readable metadata
+confluence info 123456789 --format json
+```
+
+Example JSON shape:
+```json
+{
+  "id": "123456789",
+  "title": "Architecture Overview",
+  "type": "page",
+  "status": "current",
+  "spaceKey": "ENG",
+  "parentId": "100200300",
+  "version": 7,
+  "url": "https://your-domain.atlassian.net/wiki/spaces/ENG/pages/123456789/Architecture+Overview"
+}
 ```
 
 ### Search Pages
@@ -442,6 +464,36 @@ confluence children 123456789 --recursive --max-depth 3
 
 # Output as JSON for scripting
 confluence children 123456789 --recursive --format json > children.json
+```
+
+`children --format json` returns structured metadata for each page, including `id`, `title`, `type`, `status`, `spaceKey`, `parentId`, `version`, and `url`. Recursive output also includes `depth`, and when available, `ancestors`.
+
+Example recursive JSON item:
+```json
+{
+  "pageId": "123456789",
+  "childCount": 2,
+  "children": [
+    {
+      "id": "200300400",
+      "title": "Child Page",
+      "type": "page",
+      "status": "current",
+      "spaceKey": "ENG",
+      "parentId": "123456789",
+      "version": 4,
+      "url": "https://your-domain.atlassian.net/wiki/spaces/ENG/pages/200300400/Child+Page",
+      "depth": 1,
+      "ancestors": [
+        {
+          "id": "123456789",
+          "type": "page",
+          "title": "Architecture Overview"
+        }
+      ]
+    }
+  ]
+}
 ```
 
 ### Find a Page by Title
@@ -612,8 +664,8 @@ confluence stats
 | Command | Description | Options |
 |---|---|---|
 | `init` | Initialize CLI configuration | `--read-only` |
-| `read <pageId_or_url>` | Read page content | `--format <html\|text\|markdown>` |
-| `info <pageId_or_url>` | Get page information | |
+| `read <pageId_or_url>` | Read page content | `--format <html\|text\|storage\|markdown>` |
+| `info <pageId_or_url>` | Get page information | `--format <text\|json>` |
 | `search <query>` | Search for pages | `--limit <number>` |
 | `spaces` | List all available spaces | |
 | `find <title>` | Find a page by its title | `--space <spaceKey>` |

--- a/bin/confluence.js
+++ b/bin/confluence.js
@@ -1754,7 +1754,11 @@ program
       let children;
       if (options.recursive) {
         const maxDepth = parseInt(options.maxDepth) || 10;
-        children = await client.getAllDescendantPages(resolvedPageId, maxDepth);
+        children = await client.getAllDescendantPages(
+          resolvedPageId,
+          maxDepth,
+          { includeAncestors: format === 'json' }
+        );
       } else {
         children = await client.getChildPages(resolvedPageId);
       }

--- a/bin/confluence.js
+++ b/bin/confluence.js
@@ -63,7 +63,7 @@ program
 program
   .command('read <pageId>')
   .description('Read a Confluence page by ID or URL')
-  .option('-f, --format <format>', 'Output format (html, text, markdown)', 'text')
+  .option('-f, --format <format>', 'Output format (html, text, storage, markdown)', 'text')
   .action(async (pageId, options) => {
     const analytics = new Analytics();
     try {
@@ -80,18 +80,24 @@ program
 program
   .command('info <pageId>')
   .description('Get information about a Confluence page')
-  .action(async (pageId) => {
+  .option('-f, --format <format>', 'Output format (text, json)', 'text')
+  .action(async (pageId, options) => {
     const analytics = new Analytics();
     try {
       const client = new ConfluenceClient(getConfig(getProfileName()));
       const info = await client.getPageInfo(pageId);
-      console.log(chalk.blue('Page Information:'));
-      console.log(`Title: ${chalk.green(info.title)}`);
-      console.log(`ID: ${chalk.green(info.id)}`);
-      console.log(`Type: ${chalk.green(info.type)}`);
-      console.log(`Status: ${chalk.green(info.status)}`);
-      if (info.space) {
-        console.log(`Space: ${chalk.green(info.space.name)} (${info.space.key})`);
+
+      if ((options.format || 'text').toLowerCase() === 'json') {
+        console.log(JSON.stringify(info, null, 2));
+      } else {
+        console.log(chalk.blue('Page Information:'));
+        console.log(`Title: ${chalk.green(info.title)}`);
+        console.log(`ID: ${chalk.green(info.id)}`);
+        console.log(`Type: ${chalk.green(info.type)}`);
+        console.log(`Status: ${chalk.green(info.status)}`);
+        if (info.space) {
+          console.log(`Space: ${chalk.green(info.space.name)} (${info.space.key})`);
+        }
       }
       analytics.track('info', true);
     } catch (error) {
@@ -1739,6 +1745,7 @@ program
     try {
       const config = getConfig(getProfileName());
       const client = new ConfluenceClient(config);
+      const format = (options.format || 'list').toLowerCase();
       
       // Extract page ID from URL if needed
       const resolvedPageId = await client.extractPageId(pageId);
@@ -1753,28 +1760,46 @@ program
       }
       
       if (children.length === 0) {
-        console.log(chalk.yellow('No child pages found.'));
+        if (format === 'json') {
+          console.log(JSON.stringify({
+            pageId: String(resolvedPageId),
+            childCount: 0,
+            children: []
+          }, null, 2));
+        } else {
+          console.log(chalk.yellow('No child pages found.'));
+        }
         analytics.track('children', true);
         return;
       }
       
-      // Format output
-      const format = options.format.toLowerCase();
-      
       if (format === 'json') {
         // JSON output
         const output = {
-          pageId: resolvedPageId,
+          pageId: String(resolvedPageId),
           childCount: children.length,
-          children: children.map(page => ({
-            id: page.id,
-            title: page.title,
-            type: page.type,
-            status: page.status,
-            spaceKey: page.space?.key,
-            url: `${client.buildUrl(`${client.webUrlPrefix}/spaces/${page.space?.key}/pages/${page.id}`)}`,
-            parentId: page.parentId || resolvedPageId
-          }))
+          children: children.map(page => {
+            const record = {
+              id: page.id,
+              title: page.title,
+              type: page.type,
+              status: page.status,
+              spaceKey: page.spaceKey || page.space?.key || null,
+              parentId: page.parentId || String(resolvedPageId),
+              version: page.version ?? null,
+              url: page.url || null
+            };
+
+            if (options.recursive && page.depth !== undefined) {
+              record.depth = page.depth;
+            }
+
+            if (options.recursive && Array.isArray(page.ancestors) && page.ancestors.length > 0) {
+              record.ancestors = page.ancestors;
+            }
+
+            return record;
+          })
         };
         console.log(JSON.stringify(output, null, 2));
       } else if (format === 'tree' && options.recursive) {

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -1418,12 +1418,13 @@ class ConfluenceClient {
   /**
    * Get child pages of a given page
    */
-  async getChildPages(pageId, limit = 500) {
+  async getChildPages(pageId, limit = 500, options = {}) {
+    const includeAncestors = Boolean(options.includeAncestors);
     const response = await this.client.get(`/content/${pageId}/child/page`, {
       params: {
         limit: limit,
         // Fetch lightweight payload; content fetched on-demand when copying
-        expand: 'space,version,ancestors'
+        expand: includeAncestors ? 'space,version,ancestors' : 'space,version'
       }
     });
 
@@ -1436,12 +1437,16 @@ class ConfluenceClient {
   /**
    * Get all descendant pages recursively
    */
-  async getAllDescendantPages(pageId, maxDepth = 10, currentDepth = 0) {
+  async getAllDescendantPages(pageId, maxDepth = 10, currentDepth = 0, options = {}) {
+    if (typeof currentDepth === 'object' && currentDepth !== null) {
+      options = currentDepth;
+      currentDepth = 0;
+    }
     const semaphore = createSemaphore(10);
-    return this._collectDescendants(pageId, maxDepth, currentDepth, semaphore);
+    return this._collectDescendants(pageId, maxDepth, currentDepth, semaphore, options);
   }
 
-  async _collectDescendants(pageId, maxDepth, currentDepth, semaphore) {
+  async _collectDescendants(pageId, maxDepth, currentDepth, semaphore, options = {}) {
     if (currentDepth >= maxDepth) {
       return [];
     }
@@ -1449,7 +1454,7 @@ class ConfluenceClient {
     await semaphore.acquire();
     let children;
     try {
-      children = await this.getChildPages(pageId);
+      children = await this.getChildPages(pageId, 500, options);
     } finally {
       semaphore.release();
     }
@@ -1463,7 +1468,7 @@ class ConfluenceClient {
 
     const grandChildrenLists = await Promise.all(
       children.map(child =>
-        this._collectDescendants(child.id, maxDepth, currentDepth + 1, semaphore)
+        this._collectDescendants(child.id, maxDepth, currentDepth + 1, semaphore, options)
       )
     );
 
@@ -1716,6 +1721,17 @@ class ConfluenceClient {
     }).filter((ancestor) => ancestor.id);
   }
 
+  normalizeSpace(space) {
+    if (!space) {
+      return null;
+    }
+
+    return {
+      key: space.key || null,
+      name: space.name || null
+    };
+  }
+
   getPageParentId(ancestors = []) {
     if (!Array.isArray(ancestors) || ancestors.length === 0) {
       return null;
@@ -1725,7 +1741,9 @@ class ConfluenceClient {
   }
 
   normalizePage(raw, overrides = {}) {
-    const space = raw?.space || null;
+    const space = overrides.space === undefined
+      ? this.normalizeSpace(raw?.space)
+      : this.normalizeSpace(overrides.space);
     const ancestors = overrides.ancestors || this.normalizeAncestors(raw?.ancestors);
     const spaceKey = overrides.spaceKey || space?.key || null;
     const id = raw?.id !== undefined && raw?.id !== null ? String(raw.id) : null;

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -41,7 +41,7 @@ class ConfluenceClient {
     this.forceCloud = !!config.forceCloud;
     this.mtls = config.mtls;
     this.apiPath = this.sanitizeApiPath(config.apiPath);
-    this.webUrlPrefix = this.apiPath.startsWith('/wiki/') ? '/wiki' : '';
+    this.webUrlPrefix = this.apiPath.includes('/wiki/') ? '/wiki' : '';
     this.baseURL = `${this.protocol}://${this.domain}${this.apiPath}`;
     this.converter = new MacroConverter({
       isCloud: this.isCloud(),
@@ -324,7 +324,7 @@ class ConfluenceClient {
   /**
    * Read a Confluence page content
    * @param {string} pageIdOrUrl - Page ID or URL
-   * @param {string} format - Output format: 'text', 'html', or 'markdown'
+   * @param {string} format - Output format: 'text', 'html', 'storage', or 'markdown'
    * @param {object} options - Additional options
    * @param {boolean} options.resolveUsers - Whether to resolve userkeys to display names (default: true for markdown)
    * @param {boolean} options.extractReferencedAttachments - Whether to extract referenced attachments (default: false)
@@ -345,7 +345,7 @@ class ConfluenceClient {
       this._referencedAttachments = this.extractReferencedAttachments(htmlContent);
     }
     
-    if (format === 'html') {
+    if (format === 'html' || format === 'storage') {
       return htmlContent;
     }
     
@@ -389,17 +389,11 @@ class ConfluenceClient {
     
     const response = await this.client.get(`/content/${pageId}`, {
       params: {
-        expand: 'space'
+        expand: 'space,history,version,ancestors'
       }
     });
 
-    return {
-      title: response.data.title,
-      id: response.data.id,
-      type: response.data.type,
-      status: response.data.status,
-      space: response.data.space
-    };
+    return this.normalizePage(response.data);
   }
 
   /**
@@ -546,7 +540,7 @@ class ConfluenceClient {
         const webui = page._links?.webui || '';
         return {
           title: page.title,
-          url: webui ? this.buildUrl(`${this.webUrlPrefix}${webui}`) : ''
+          url: webui ? this.toAbsoluteUrl(webui, page._links?.base) : ''
         };
       }
       return null;
@@ -640,7 +634,7 @@ class ConfluenceClient {
       // Format: - [Page Title](URL)
       const childPagesList = childPages.map(page => {
         const webui = page._links?.webui || '';
-        const url = webui ? this.buildUrl(`${this.webUrlPrefix}${webui}`) : '';
+        const url = webui ? this.toAbsoluteUrl(webui, page._links?.base) : '';
         if (url) {
           return `- [${page.title}](${url})`;
         } else {
@@ -1429,17 +1423,13 @@ class ConfluenceClient {
       params: {
         limit: limit,
         // Fetch lightweight payload; content fetched on-demand when copying
-        expand: 'space,version'
+        expand: 'space,version,ancestors'
       }
     });
 
-    return response.data.results.map(page => ({
-      id: page.id,
-      title: page.title,
-      type: page.type,
-      status: page.status,
-      space: page.space,
-      version: page.version?.number || 1
+    return response.data.results.map(page => this.normalizePage(page, {
+      parentId: pageId,
+      depth: 1
     }));
   }
 
@@ -1464,8 +1454,12 @@ class ConfluenceClient {
       semaphore.release();
     }
 
-    // Attach parentId so we can later reconstruct hierarchy if needed
-    const childrenWithParent = children.map(child => ({ ...child, parentId: pageId }));
+    // Track depth for recursive JSON output while preserving direct parent linkage.
+    const childrenWithDepth = children.map(child => ({
+      ...child,
+      parentId: child.parentId || String(pageId),
+      depth: currentDepth + 1
+    }));
 
     const grandChildrenLists = await Promise.all(
       children.map(child =>
@@ -1473,7 +1467,7 @@ class ConfluenceClient {
       )
     );
 
-    return childrenWithParent.concat(...grandChildrenLists);
+    return childrenWithDepth.concat(...grandChildrenLists);
   }
 
   /**
@@ -1693,18 +1687,101 @@ class ConfluenceClient {
     };
   }
 
+  normalizeUser(user) {
+    if (!user) {
+      return null;
+    }
+
+    return {
+      displayName: user.displayName || user.publicName || user.username || user.userKey || user.accountId || 'Unknown',
+      accountId: user.accountId,
+      userKey: user.userKey,
+      username: user.username,
+      email: user.email
+    };
+  }
+
+  normalizeAncestors(rawAncestors = []) {
+    if (!Array.isArray(rawAncestors)) {
+      return [];
+    }
+
+    return rawAncestors.map((ancestor) => {
+      const id = ancestor?.id ?? ancestor;
+      return {
+        id: id !== undefined && id !== null ? String(id) : null,
+        type: ancestor?.type || null,
+        title: ancestor?.title || null
+      };
+    }).filter((ancestor) => ancestor.id);
+  }
+
+  getPageParentId(ancestors = []) {
+    if (!Array.isArray(ancestors) || ancestors.length === 0) {
+      return null;
+    }
+
+    return ancestors[ancestors.length - 1].id || null;
+  }
+
+  normalizePage(raw, overrides = {}) {
+    const space = raw?.space || null;
+    const ancestors = overrides.ancestors || this.normalizeAncestors(raw?.ancestors);
+    const spaceKey = overrides.spaceKey || space?.key || null;
+    const id = raw?.id !== undefined && raw?.id !== null ? String(raw.id) : null;
+    const webui = raw?._links?.webui || null;
+    const linksBase = raw?._links?.base || null;
+    const fallbackUrl = (spaceKey && id)
+      ? `${this.webUrlPrefix}/spaces/${spaceKey}/pages/${id}`
+      : null;
+
+    return {
+      id,
+      title: raw?.title || '',
+      type: raw?.type || null,
+      status: raw?.status || null,
+      space,
+      spaceKey,
+      parentId: overrides.parentId === undefined
+        ? this.getPageParentId(ancestors)
+        : (overrides.parentId === null ? null : String(overrides.parentId)),
+      version: overrides.version !== undefined ? overrides.version : (raw?.version?.number || null),
+      url: overrides.url || this.toAbsoluteUrl(webui, linksBase) || (fallbackUrl ? this.buildUrl(fallbackUrl) : null),
+      ancestors,
+      depth: overrides.depth,
+      author: overrides.author !== undefined ? overrides.author : this.normalizeUser(raw?.history?.createdBy),
+      lastUpdatedBy: overrides.lastUpdatedBy !== undefined ? overrides.lastUpdatedBy : this.normalizeUser(raw?.version?.by),
+      createdAt: overrides.createdAt !== undefined ? overrides.createdAt : (raw?.history?.createdDate || null),
+      updatedAt: overrides.updatedAt !== undefined ? overrides.updatedAt : (raw?.version?.when || null)
+    };
+  }
+
   buildUrl(path) {
     const normalized = path && !path.startsWith('/') ? `/${path}` : (path || '');
     return `${this.protocol}://${this.domain}${normalized}`;
   }
 
-  toAbsoluteUrl(pathOrUrl) {
+  joinBaseUrl(baseUrl, path) {
+    if (!baseUrl) {
+      return null;
+    }
+
+    const normalizedBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+    return `${normalizedBase}${normalizedPath}`;
+  }
+
+  toAbsoluteUrl(pathOrUrl, baseUrl = null) {
     if (!pathOrUrl) {
       return null;
     }
 
     if (pathOrUrl.startsWith('http://') || pathOrUrl.startsWith('https://')) {
       return pathOrUrl;
+    }
+
+    if (baseUrl) {
+      return this.joinBaseUrl(baseUrl, pathOrUrl);
     }
 
     const pathWithPrefix = this.webUrlPrefix && !pathOrUrl.startsWith(this.webUrlPrefix)

--- a/plugins/confluence/skills/confluence/SKILL.md
+++ b/plugins/confluence/skills/confluence/SKILL.md
@@ -149,15 +149,16 @@ confluence --profile staging init --domain "staging.example.com" --auth-type bea
 Read page content. Outputs to stdout.
 
 ```sh
-confluence read <pageId> [--format html|text|markdown]
+confluence read <pageId> [--format html|text|storage|markdown]
 ```
 
 | Option | Default | Description |
 |---|---|---|
-| `--format` | `text` | Output format: `html`, `text`, or `markdown` |
+| `--format` | `text` | Output format: `html`, `text`, `storage`, or `markdown` |
 
 ```sh
 confluence read 123456789
+confluence read 123456789 --format storage
 confluence read 123456789 --format markdown
 ```
 
@@ -165,14 +166,15 @@ confluence read 123456789 --format markdown
 
 ### `info <pageId>`
 
-Get page metadata (title, ID, type, status, space).
+Get page metadata. Use `--format json` for machine-readable output.
 
 ```sh
-confluence info <pageId>
+confluence info <pageId> [--format text|json]
 ```
 
 ```sh
 confluence info 123456789
+confluence info 123456789 --format json
 ```
 
 ---

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -166,6 +166,16 @@ describe('ConfluenceClient', () => {
       expect(clientWithMissingSlash.webUrlPrefix).toBe('/wiki');
     });
 
+    test('sets webUrlPrefix to /wiki for scoped token api paths that include /wiki/rest/api', () => {
+      const scopedClient = new ConfluenceClient({
+        domain: 'api.atlassian.com',
+        token: 'scoped-token',
+        apiPath: '/ex/confluence/cloud-id/wiki/rest/api'
+      });
+
+      expect(scopedClient.webUrlPrefix).toBe('/wiki');
+    });
+
     test('toAbsoluteUrl prepends /wiki context path on Atlassian Cloud', () => {
       const cloudClient = new ConfluenceClient({
         domain: 'test.atlassian.net',
@@ -197,6 +207,17 @@ describe('ConfluenceClient', () => {
 
       expect(serverClient.toAbsoluteUrl('/download/attachments/123/file.png'))
         .toBe('https://confluence.example.com/download/attachments/123/file.png');
+    });
+
+    test('toAbsoluteUrl prefers the API-provided base URL when available', () => {
+      const scopedClient = new ConfluenceClient({
+        domain: 'api.atlassian.com',
+        token: 'scoped-token',
+        apiPath: '/ex/confluence/cloud-id/wiki/rest/api'
+      });
+
+      expect(scopedClient.toAbsoluteUrl('/spaces/ENG/pages/123/Architecture+Overview', 'https://tenant.atlassian.net/wiki'))
+        .toBe('https://tenant.atlassian.net/wiki/spaces/ENG/pages/123/Architecture+Overview');
     });
   });
 
@@ -400,6 +421,155 @@ describe('ConfluenceClient', () => {
       } finally {
         removeDirRecursive(tmpDir);
       }
+    });
+  });
+
+  describe('page metadata and storage reads', () => {
+    test('readPage should return storage content when format is storage', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123').reply(200, {
+        body: {
+          storage: {
+            value: '<p>Storage body</p>'
+          }
+        }
+      });
+
+      await expect(client.readPage('123', 'storage')).resolves.toBe('<p>Storage body</p>');
+
+      mock.restore();
+    });
+
+    test('getPageInfo should normalize machine-readable metadata', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123').reply(config => {
+        expect(config.params.expand).toContain('space');
+        expect(config.params.expand).toContain('history');
+        expect(config.params.expand).toContain('version');
+        expect(config.params.expand).toContain('ancestors');
+        return [200, {
+          id: '123',
+          title: 'Architecture Overview',
+          type: 'page',
+          status: 'current',
+          space: { key: 'ENG', name: 'Engineering' },
+          history: {
+            createdBy: { displayName: 'Ada Lovelace', accountId: 'acct-1' },
+            createdDate: '2025-01-01T10:00:00.000Z'
+          },
+          version: {
+            number: 7,
+            when: '2025-01-02T12:00:00.000Z',
+            by: { displayName: 'Grace Hopper', accountId: 'acct-2' }
+          },
+          ancestors: [
+            { id: '100', type: 'page', title: 'Parent Page' }
+          ],
+          _links: {
+            webui: '/spaces/ENG/pages/123/Architecture+Overview'
+          }
+        }];
+      });
+
+      const info = await client.getPageInfo('123');
+      expect(info).toMatchObject({
+        id: '123',
+        title: 'Architecture Overview',
+        type: 'page',
+        status: 'current',
+        spaceKey: 'ENG',
+        parentId: '100',
+        version: 7,
+        url: 'https://test.atlassian.net/spaces/ENG/pages/123/Architecture+Overview',
+        createdAt: '2025-01-01T10:00:00.000Z',
+        updatedAt: '2025-01-02T12:00:00.000Z',
+        ancestors: [{ id: '100', type: 'page', title: 'Parent Page' }],
+        author: { displayName: 'Ada Lovelace', accountId: 'acct-1' },
+        lastUpdatedBy: { displayName: 'Grace Hopper', accountId: 'acct-2' }
+      });
+      expect(info.space).toEqual({ key: 'ENG', name: 'Engineering' });
+
+      mock.restore();
+    });
+
+    test('normalizePage should prefer _links.base for scoped token browser URLs', () => {
+      const scopedClient = new ConfluenceClient({
+        domain: 'api.atlassian.com',
+        email: 'user@example.com',
+        token: 'scoped-token',
+        apiPath: '/ex/confluence/cloud-id/wiki/rest/api'
+      });
+
+      const info = scopedClient.normalizePage({
+        id: '123',
+        title: 'Architecture Overview',
+        type: 'page',
+        status: 'current',
+        space: { key: 'ENG', name: 'Engineering' },
+        _links: {
+          base: 'https://tenant.atlassian.net/wiki',
+          webui: '/spaces/ENG/pages/123/Architecture+Overview'
+        }
+      });
+
+      expect(info.url).toBe('https://tenant.atlassian.net/wiki/spaces/ENG/pages/123/Architecture+Overview');
+    });
+
+    test('getPageInfo should handle missing parent cleanly', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/555').reply(200, {
+        id: '555',
+        title: 'Root Page',
+        type: 'page',
+        status: 'current',
+        space: { key: 'ROOT', name: 'Root Space' },
+        version: { number: 1 },
+        ancestors: [],
+        _links: {}
+      });
+
+      const info = await client.getPageInfo('555');
+      expect(info.parentId).toBeNull();
+      expect(info.ancestors).toEqual([]);
+      expect(info.url).toBe('https://test.atlassian.net/spaces/ROOT/pages/555');
+
+      mock.restore();
+    });
+
+    test('getChildPages should include structured metadata for JSON output', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123/child/page').reply(config => {
+        expect(config.params.expand).toContain('ancestors');
+        return [200, {
+          results: [
+            {
+              id: '200',
+              title: 'Child Page',
+              type: 'page',
+              status: 'current',
+              space: { key: 'ENG', name: 'Engineering' },
+              version: { number: 4 },
+              ancestors: [{ id: '123', type: 'page', title: 'Parent Page' }],
+              _links: { webui: '/spaces/ENG/pages/200/Child+Page' }
+            }
+          ]
+        }];
+      });
+
+      const pages = await client.getChildPages('123');
+      expect(pages).toEqual([expect.objectContaining({
+        id: '200',
+        title: 'Child Page',
+        type: 'page',
+        status: 'current',
+        spaceKey: 'ENG',
+        parentId: '123',
+        version: 4,
+        url: 'https://test.atlassian.net/spaces/ENG/pages/200/Child+Page',
+        ancestors: [{ id: '123', type: 'page', title: 'Parent Page' }]
+      })]);
+
+      mock.restore();
     });
   });
 

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -492,6 +492,30 @@ describe('ConfluenceClient', () => {
       mock.restore();
     });
 
+    test('getPageInfo should normalize space to a stable shape', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/321').reply(200, {
+        id: '321',
+        title: 'Runbook',
+        type: 'page',
+        status: 'current',
+        space: {
+          key: 'OPS',
+          name: 'Operations',
+          id: 42,
+          type: 'global',
+          metadata: { labels: ['internal'] }
+        },
+        version: { number: 1 },
+        ancestors: []
+      });
+
+      const info = await client.getPageInfo('321');
+      expect(info.space).toEqual({ key: 'OPS', name: 'Operations' });
+
+      mock.restore();
+    });
+
     test('normalizePage should prefer _links.base for scoped token browser URLs', () => {
       const scopedClient = new ConfluenceClient({
         domain: 'api.atlassian.com',
@@ -539,7 +563,7 @@ describe('ConfluenceClient', () => {
     test('getChildPages should include structured metadata for JSON output', async () => {
       const mock = new MockAdapter(client.client);
       mock.onGet('/content/123/child/page').reply(config => {
-        expect(config.params.expand).toContain('ancestors');
+        expect(config.params.expand).toBe('space,version');
         return [200, {
           results: [
             {
@@ -565,9 +589,34 @@ describe('ConfluenceClient', () => {
         spaceKey: 'ENG',
         parentId: '123',
         version: 4,
-        url: 'https://test.atlassian.net/spaces/ENG/pages/200/Child+Page',
-        ancestors: [{ id: '123', type: 'page', title: 'Parent Page' }]
+        url: 'https://test.atlassian.net/spaces/ENG/pages/200/Child+Page'
       })]);
+
+      mock.restore();
+    });
+
+    test('getChildPages should fetch ancestors only when requested', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123/child/page').reply(config => {
+        expect(config.params.expand).toBe('space,version,ancestors');
+        return [200, {
+          results: [
+            {
+              id: '200',
+              title: 'Child Page',
+              type: 'page',
+              status: 'current',
+              space: { key: 'ENG', name: 'Engineering' },
+              version: { number: 4 },
+              ancestors: [{ id: '123', type: 'page', title: 'Parent Page' }],
+              _links: { webui: '/spaces/ENG/pages/200/Child+Page' }
+            }
+          ]
+        }];
+      });
+
+      const pages = await client.getChildPages('123', 500, { includeAncestors: true });
+      expect(pages[0].ancestors).toEqual([{ id: '123', type: 'page', title: 'Parent Page' }]);
 
       mock.restore();
     });

--- a/tests/metadata-cli.test.js
+++ b/tests/metadata-cli.test.js
@@ -1,0 +1,268 @@
+describe('CLI metadata and storage output', () => {
+  function stripAnsi(value) {
+    if (typeof value !== 'string') {
+      return value;
+    }
+
+    let output = '';
+    for (let index = 0; index < value.length; index += 1) {
+      if (value.charCodeAt(index) === 27 && value[index + 1] === '[') {
+        index += 2;
+        while (index < value.length && value[index] !== 'm') {
+          index += 1;
+        }
+        continue;
+      }
+      output += value[index];
+    }
+
+    return output;
+  }
+
+  async function loadCli(clientOverrides = {}) {
+    jest.resetModules();
+
+    const client = {
+      readPage: jest.fn(),
+      getPageInfo: jest.fn(),
+      extractPageId: jest.fn(async (pageId) => String(pageId)),
+      getChildPages: jest.fn(),
+      getAllDescendantPages: jest.fn(),
+      buildUrl: jest.fn((value) => value),
+      webUrlPrefix: '/wiki',
+      ...clientOverrides
+    };
+
+    const ConfluenceClient = jest.fn(() => client);
+    const getConfig = jest.fn(() => ({
+      domain: 'test.atlassian.net',
+      token: 'test-token'
+    }));
+    const track = jest.fn();
+
+    jest.doMock('../lib/confluence-client', () => ConfluenceClient);
+    jest.doMock('../lib/config', () => ({
+      getConfig,
+      initConfig: jest.fn(),
+      listProfiles: jest.fn(),
+      setActiveProfile: jest.fn(),
+      deleteProfile: jest.fn(),
+      isValidProfileName: jest.fn(() => true)
+    }));
+    jest.doMock('../lib/analytics', () => {
+      return class Analytics {
+        track(...args) {
+          track(...args);
+        }
+      };
+    });
+
+    let cli;
+    jest.isolateModules(() => {
+      cli = require('../bin/confluence.js');
+    });
+
+    return {
+      program: cli.program,
+      client,
+      getConfig,
+      track
+    };
+  }
+
+  async function runCli(program, args) {
+    return program.parseAsync(args, { from: 'user' });
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  test('info --format json prints structured metadata', async () => {
+    const { program } = await loadCli({
+      getPageInfo: jest.fn(async () => ({
+        id: '123',
+        title: 'Architecture Overview',
+        type: 'page',
+        status: 'current',
+        spaceKey: 'ENG',
+        parentId: '100',
+        version: 7,
+        url: 'https://test.atlassian.net/wiki/spaces/ENG/pages/123/Architecture+Overview',
+        ancestors: [{ id: '100', type: 'page', title: 'Parent' }],
+        createdAt: '2025-01-01T10:00:00.000Z',
+        updatedAt: '2025-01-02T12:00:00.000Z',
+        author: { displayName: 'Ada Lovelace' },
+        lastUpdatedBy: { displayName: 'Grace Hopper' }
+      }))
+    });
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runCli(program, ['info', '123', '--format', 'json']);
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(output).toMatchObject({
+      id: '123',
+      title: 'Architecture Overview',
+      type: 'page',
+      status: 'current',
+      spaceKey: 'ENG',
+      parentId: '100',
+      version: 7,
+      url: 'https://test.atlassian.net/wiki/spaces/ENG/pages/123/Architecture+Overview'
+    });
+  });
+
+  test('info default text output remains human-readable', async () => {
+    const { program, client } = await loadCli({
+      getPageInfo: jest.fn(async () => ({
+        id: '123',
+        title: 'Architecture Overview',
+        type: 'page',
+        status: 'current',
+        space: { key: 'ENG', name: 'Engineering' }
+      }))
+    });
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runCli(program, ['info', '123']);
+
+    const lines = logSpy.mock.calls.map((call) => stripAnsi(call[0]));
+    expect(lines).toContain('Page Information:');
+    expect(lines).toContain('Title: Architecture Overview');
+    expect(lines).toContain('ID: 123');
+    expect(lines).toContain('Type: page');
+    expect(lines).toContain('Status: current');
+    expect(lines).toContain('Space: Engineering (ENG)');
+    expect(client.getPageInfo).toHaveBeenCalledWith('123');
+  });
+
+  test('info exits non-zero on invalid page IDs', async () => {
+    const { program } = await loadCli({
+      getPageInfo: jest.fn(async () => {
+        throw new Error('Page not found');
+      })
+    });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+
+    await expect(runCli(program, ['info', '999', '--format', 'json'])).rejects.toThrow('process.exit called');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0].map((value) => stripAnsi(value))).toEqual(['Error:', 'Page not found']);
+  });
+
+  test('read --format storage prints storage content', async () => {
+    const { program, client } = await loadCli({
+      readPage: jest.fn(async () => '<ac:structured-macro ac:name="info" />')
+    });
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runCli(program, ['read', '123', '--format', 'storage']);
+
+    expect(client.readPage).toHaveBeenCalledWith('123', 'storage');
+    expect(logSpy).toHaveBeenCalledWith('<ac:structured-macro ac:name="info" />');
+  });
+
+  test('children --format json returns structured direct children', async () => {
+    const { program } = await loadCli({
+      getChildPages: jest.fn(async () => ([
+        {
+          id: '200',
+          title: 'Child Page',
+          type: 'page',
+          status: 'current',
+          spaceKey: 'ENG',
+          parentId: '123',
+          version: 4,
+          url: 'https://test.atlassian.net/wiki/spaces/ENG/pages/200/Child+Page',
+          depth: 1,
+          ancestors: [{ id: '123', type: 'page', title: 'Parent Page' }]
+        }
+      ]))
+    });
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runCli(program, ['children', '123', '--format', 'json']);
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(output).toEqual({
+      pageId: '123',
+      childCount: 1,
+      children: [
+        {
+          id: '200',
+          title: 'Child Page',
+          type: 'page',
+          status: 'current',
+          spaceKey: 'ENG',
+          parentId: '123',
+          version: 4,
+          url: 'https://test.atlassian.net/wiki/spaces/ENG/pages/200/Child+Page'
+        }
+      ]
+    });
+    expect(output.children[0].depth).toBeUndefined();
+    expect(output.children[0].ancestors).toBeUndefined();
+  });
+
+  test('children --recursive --format json includes depth and ancestors', async () => {
+    const { program } = await loadCli({
+      getAllDescendantPages: jest.fn(async () => ([
+        {
+          id: '200',
+          title: 'Child Page',
+          type: 'page',
+          status: 'current',
+          spaceKey: 'ENG',
+          parentId: '123',
+          version: 4,
+          depth: 1,
+          url: 'https://test.atlassian.net/wiki/spaces/ENG/pages/200/Child+Page',
+          ancestors: [{ id: '123', type: 'page', title: 'Parent' }]
+        },
+        {
+          id: '300',
+          title: 'Nested Page',
+          type: 'page',
+          status: 'current',
+          spaceKey: 'ENG',
+          parentId: '200',
+          version: 2,
+          depth: 2,
+          url: 'https://test.atlassian.net/wiki/spaces/ENG/pages/300/Nested+Page',
+          ancestors: [
+            { id: '123', type: 'page', title: 'Parent' },
+            { id: '200', type: 'page', title: 'Child Page' }
+          ]
+        }
+      ]))
+    });
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runCli(program, ['children', '123', '--recursive', '--format', 'json']);
+
+    const output = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(output.childCount).toBe(2);
+    expect(output.children[0]).toMatchObject({
+      id: '200',
+      depth: 1,
+      parentId: '123',
+      version: 4,
+      ancestors: [{ id: '123', type: 'page', title: 'Parent' }]
+    });
+    expect(output.children[1]).toMatchObject({
+      id: '300',
+      depth: 2,
+      parentId: '200',
+      version: 2,
+      ancestors: [
+        { id: '123', type: 'page', title: 'Parent' },
+        { id: '200', type: 'page', title: 'Child Page' }
+      ]
+    });
+  });
+});

--- a/tests/metadata-cli.test.js
+++ b/tests/metadata-cli.test.js
@@ -86,6 +86,7 @@ describe('CLI metadata and storage output', () => {
         title: 'Architecture Overview',
         type: 'page',
         status: 'current',
+        space: { key: 'ENG', name: 'Engineering' },
         spaceKey: 'ENG',
         parentId: '100',
         version: 7,
@@ -107,6 +108,7 @@ describe('CLI metadata and storage output', () => {
       title: 'Architecture Overview',
       type: 'page',
       status: 'current',
+      space: { key: 'ENG', name: 'Engineering' },
       spaceKey: 'ENG',
       parentId: '100',
       version: 7,
@@ -210,36 +212,37 @@ describe('CLI metadata and storage output', () => {
   });
 
   test('children --recursive --format json includes depth and ancestors', async () => {
+    const getAllDescendantPages = jest.fn(async () => ([
+      {
+        id: '200',
+        title: 'Child Page',
+        type: 'page',
+        status: 'current',
+        spaceKey: 'ENG',
+        parentId: '123',
+        version: 4,
+        depth: 1,
+        url: 'https://test.atlassian.net/wiki/spaces/ENG/pages/200/Child+Page',
+        ancestors: [{ id: '123', type: 'page', title: 'Parent' }]
+      },
+      {
+        id: '300',
+        title: 'Nested Page',
+        type: 'page',
+        status: 'current',
+        spaceKey: 'ENG',
+        parentId: '200',
+        version: 2,
+        depth: 2,
+        url: 'https://test.atlassian.net/wiki/spaces/ENG/pages/300/Nested+Page',
+        ancestors: [
+          { id: '123', type: 'page', title: 'Parent' },
+          { id: '200', type: 'page', title: 'Child Page' }
+        ]
+      }
+    ]));
     const { program } = await loadCli({
-      getAllDescendantPages: jest.fn(async () => ([
-        {
-          id: '200',
-          title: 'Child Page',
-          type: 'page',
-          status: 'current',
-          spaceKey: 'ENG',
-          parentId: '123',
-          version: 4,
-          depth: 1,
-          url: 'https://test.atlassian.net/wiki/spaces/ENG/pages/200/Child+Page',
-          ancestors: [{ id: '123', type: 'page', title: 'Parent' }]
-        },
-        {
-          id: '300',
-          title: 'Nested Page',
-          type: 'page',
-          status: 'current',
-          spaceKey: 'ENG',
-          parentId: '200',
-          version: 2,
-          depth: 2,
-          url: 'https://test.atlassian.net/wiki/spaces/ENG/pages/300/Nested+Page',
-          ancestors: [
-            { id: '123', type: 'page', title: 'Parent' },
-            { id: '200', type: 'page', title: 'Child Page' }
-          ]
-        }
-      ]))
+      getAllDescendantPages
     });
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -264,5 +267,6 @@ describe('CLI metadata and storage output', () => {
         { id: '200', type: 'page', title: 'Child Page' }
       ]
     });
+    expect(getAllDescendantPages).toHaveBeenCalledWith('123', 10, { includeAncestors: true });
   });
 });


### PR DESCRIPTION
### Description
  Add machine-readable metadata and native storage read support to improve `confluence-cli` for automation and scripting use cases.

  This PR:
  - adds `confluence info --format json`
  - adds `confluence read <pageId> --format storage`
  - enriches `confluence children --format json` with stable metadata fields such as `id`, `title`, `type`, `status`, `spaceKey`, `parentId`, `version`, and `url`
  - adds tests and README/help updates
  - preserves existing human-readable output for current users

  ### Type of Change
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] Documentation update
  - [ ] Performance improvement
  - [ ] Code refactoring

  ### Testing
  - [x] Tests pass locally with my changes
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes

  ### Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] Any dependent changes have been merged and published in downstream modules

  ### Screenshots (if applicable)
  Not applicable.

  ### Additional Context
  Local verification:
  - `npm run lint -- --quiet`
  - `npm test -- --runInBand`

  Notes:
  - existing default text output for `info`, `read`, and `children` remains unchanged
  - `info --format json` returns a single structured object
  - `read --format storage` returns the page body in Confluence storage representation through the normal read path
  - `children --format json` now returns structured metadata records for direct and recursive listings