### PR TITLE
chore: drop unused ora dep and bump Node minimum to 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     
     steps:
     - uses: actions/checkout@v3

--- a/bin/index.js
+++ b/bin/index.js
@@ -12,7 +12,7 @@
 
 // Make sure we're using a supported Node.js version
 const nodeVersion = process.version;
-const requiredVersion = '14.0.0';
+const requiredVersion = '18.0.0';
 
 if (!nodeVersion.startsWith('v') || 
     parseInt(nodeVersion.slice(1).split('.')[0]) < parseInt(requiredVersion.split('.')[0])) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "form-data": "^4.0.5",
         "html-to-text": "^9.0.5",
         "inquirer": "^8.2.6",
-        "markdown-it": "^14.1.0",
-        "ora": "^5.4.1"
+        "markdown-it": "^14.1.0"
       },
       "bin": {
         "confluence": "bin/index.js",
@@ -29,7 +28,7 @@
         "jest": "^29.7.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "form-data": "^4.0.5",
     "html-to-text": "^9.0.5",
     "inquirer": "^8.2.6",
-    "markdown-it": "^14.1.0",
-    "ora": "^5.4.1"
+    "markdown-it": "^14.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",
@@ -45,7 +44,7 @@
     }
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- `ora` is declared as a direct dependency but never `require()`d in `lib/` or `bin/`; it is only pulled in transitively by `inquirer`, so removing it from `package.json` has zero functional impact.
- Node 14 (EOL April 2023) and Node 16 (EOL September 2023) are no longer supported upstream. Bump the `engines` field and the runtime guard in `bin/index.js` to require Node 18+, and update the CI matrix to the currently-supported 18/20/22 LTS lines.

## Test plan
- [x] `npm install` — lockfile no longer lists `ora` as a top-level dependency
- [x] `npm run lint` — clean
- [x] `npm test` — 316/316 passing
- [ ] CI matrix runs on 18.x / 20.x / 22.x