### PR TITLE
test: add coverage for analytics and html-to-markdown modules

### DIFF
--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -1,0 +1,180 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ORIGINAL_ANALYTICS_ENV = process.env.CONFLUENCE_CLI_ANALYTICS;
+
+const removeDirRecursive = (dir) => {
+  if (!dir || !fs.existsSync(dir)) return;
+  if (fs.rmSync) {
+    fs.rmSync(dir, { recursive: true, force: true });
+    return;
+  }
+  fs.readdirSync(dir).forEach((entry) => {
+    const entryPath = path.join(dir, entry);
+    if (fs.lstatSync(entryPath).isDirectory()) {
+      removeDirRecursive(entryPath);
+    } else {
+      fs.unlinkSync(entryPath);
+    }
+  });
+  fs.rmdirSync(dir);
+};
+
+describe('Analytics', () => {
+  let tempHome;
+  let originalHomedir;
+  let Analytics;
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'confluence-cli-analytics-'));
+    originalHomedir = os.homedir;
+    os.homedir = () => tempHome;
+
+    delete process.env.CONFLUENCE_CLI_ANALYTICS;
+
+    jest.resetModules();
+    Analytics = require('../lib/analytics');
+  });
+
+  afterEach(() => {
+    os.homedir = originalHomedir;
+    removeDirRecursive(tempHome);
+
+    if (ORIGINAL_ANALYTICS_ENV === undefined) {
+      delete process.env.CONFLUENCE_CLI_ANALYTICS;
+    } else {
+      process.env.CONFLUENCE_CLI_ANALYTICS = ORIGINAL_ANALYTICS_ENV;
+    }
+  });
+
+  describe('track', () => {
+    test('creates the stats directory and file on first run', () => {
+      const analytics = new Analytics();
+      const expectedFile = path.join(tempHome, '.confluence-cli', 'stats.json');
+
+      analytics.track('create-page');
+
+      expect(fs.existsSync(expectedFile)).toBe(true);
+      const stats = JSON.parse(fs.readFileSync(expectedFile, 'utf8'));
+      expect(stats.commands['create-page_success']).toBe(1);
+      expect(stats.firstUsed).toBeDefined();
+      expect(stats.lastUsed).toBeDefined();
+    });
+
+    test('increments the counter for repeated commands', () => {
+      const analytics = new Analytics();
+
+      analytics.track('search');
+      analytics.track('search');
+      analytics.track('search');
+
+      expect(analytics.getStats().commands['search_success']).toBe(3);
+    });
+
+    test('separates success and error counters for the same command', () => {
+      const analytics = new Analytics();
+
+      analytics.track('update-page', true);
+      analytics.track('update-page', false);
+      analytics.track('update-page', false);
+
+      const stats = analytics.getStats();
+      expect(stats.commands['update-page_success']).toBe(1);
+      expect(stats.commands['update-page_error']).toBe(2);
+    });
+
+    test('preserves firstUsed across writes but advances lastUsed', () => {
+      const analytics = new Analytics();
+
+      analytics.track('first');
+      const after1 = analytics.getStats();
+
+      // Force lastUsed to differ
+      const earlier = new Date(Date.now() - 60_000).toISOString();
+      const file = path.join(tempHome, '.confluence-cli', 'stats.json');
+      const tampered = { ...after1, firstUsed: earlier, lastUsed: earlier };
+      fs.writeFileSync(file, JSON.stringify(tampered));
+
+      analytics.track('second');
+      const after2 = analytics.getStats();
+
+      expect(after2.firstUsed).toBe(earlier);
+      expect(new Date(after2.lastUsed).getTime()).toBeGreaterThan(new Date(earlier).getTime());
+    });
+
+    test('does nothing when CONFLUENCE_CLI_ANALYTICS=false', () => {
+      process.env.CONFLUENCE_CLI_ANALYTICS = 'false';
+      jest.resetModules();
+      const DisabledAnalytics = require('../lib/analytics');
+      const analytics = new DisabledAnalytics();
+
+      analytics.track('search');
+
+      expect(fs.existsSync(path.join(tempHome, '.confluence-cli', 'stats.json'))).toBe(false);
+    });
+
+    test('does not throw when the stats file is corrupted JSON', () => {
+      const dir = path.join(tempHome, '.confluence-cli');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'stats.json'), '{not valid json');
+
+      const analytics = new Analytics();
+
+      expect(() => analytics.track('search')).not.toThrow();
+    });
+  });
+
+  describe('getStats', () => {
+    test('returns null when the stats file does not exist', () => {
+      const analytics = new Analytics();
+      expect(analytics.getStats()).toBeNull();
+    });
+
+    test('returns null when the stats file contains malformed JSON', () => {
+      const dir = path.join(tempHome, '.confluence-cli');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'stats.json'), '{broken');
+
+      const analytics = new Analytics();
+      expect(analytics.getStats()).toBeNull();
+    });
+
+    test('returns parsed stats when the file is valid', () => {
+      const analytics = new Analytics();
+      analytics.track('list-pages');
+
+      const stats = analytics.getStats();
+      expect(stats).not.toBeNull();
+      expect(stats.commands['list-pages_success']).toBe(1);
+    });
+  });
+
+  describe('showStats', () => {
+    test('prints "No usage statistics available." when no stats exist', () => {
+      const analytics = new Analytics();
+      const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+      analytics.showStats();
+
+      expect(spy).toHaveBeenCalledWith('No usage statistics available.');
+      spy.mockRestore();
+    });
+
+    test('prints command counts when stats exist', () => {
+      const analytics = new Analytics();
+      analytics.track('search');
+      analytics.track('search', false);
+
+      const messages = [];
+      const spy = jest.spyOn(console, 'log').mockImplementation((msg) => messages.push(msg));
+
+      analytics.showStats();
+      spy.mockRestore();
+
+      const joined = messages.join('\n');
+      expect(joined).toContain('search_success: 1 times');
+      expect(joined).toContain('search_error: 1 times');
+    });
+  });
+});

--- a/tests/html-to-markdown.test.js
+++ b/tests/html-to-markdown.test.js
@@ -1,0 +1,152 @@
+const { htmlToMarkdown, NAMED_ENTITIES } = require('../lib/html-to-markdown');
+
+describe('htmlToMarkdown', () => {
+  describe('inline formatting', () => {
+    test('converts <strong> to **bold**', () => {
+      expect(htmlToMarkdown('<p><strong>hello</strong></p>')).toBe('**hello**');
+    });
+
+    test('converts <em> to *italic*', () => {
+      expect(htmlToMarkdown('<p><em>hi</em></p>')).toBe('*hi*');
+    });
+
+    test('converts <code> to backticks', () => {
+      expect(htmlToMarkdown('<p>use <code>npm install</code> first</p>'))
+        .toBe('use `npm install` first');
+    });
+
+    test('preserves attributes-laden tags via stripped wrappers', () => {
+      expect(htmlToMarkdown('<p><strong class="x">bold</strong></p>'))
+        .toBe('**bold**');
+    });
+  });
+
+  describe('headings', () => {
+    test.each([1, 2, 3, 4, 5, 6])('converts <h%i> to # heading', (level) => {
+      const html = `<h${level}>Title</h${level}>`;
+      expect(htmlToMarkdown(html)).toBe(`${'#'.repeat(level)} Title`);
+    });
+
+    test('ensures a blank line follows headings', () => {
+      const result = htmlToMarkdown('<h2>Heading</h2><p>body</p>');
+      expect(result).toBe('## Heading\n\nbody');
+    });
+  });
+
+  describe('lists', () => {
+    test('converts <ul> to a bullet list', () => {
+      const html = '<ul><li>one</li><li>two</li><li>three</li></ul>';
+      expect(htmlToMarkdown(html)).toBe('- one\n- two\n- three');
+    });
+
+    test('converts <ol> to a numbered list', () => {
+      const html = '<ol><li>first</li><li>second</li></ol>';
+      expect(htmlToMarkdown(html)).toBe('1. first\n2. second');
+    });
+
+    test('skips empty <li> entries', () => {
+      const html = '<ul><li>kept</li><li>   </li><li>also kept</li></ul>';
+      expect(htmlToMarkdown(html)).toBe('- kept\n- also kept');
+    });
+  });
+
+  describe('tables', () => {
+    test('converts a simple table to GFM markdown with header separator', () => {
+      const html = '<table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>';
+      const result = htmlToMarkdown(html);
+      expect(result).toBe('| A | B |\n| --- | --- |\n| 1 | 2 |');
+    });
+
+    test('replaces empty cells with a placeholder so the row stays well-formed', () => {
+      const html = '<table><tr><td>x</td><td></td></tr></table>';
+      const result = htmlToMarkdown(html);
+      // Empty cells collapse to a single space, so the joined row becomes "| x | |"
+      expect(result).toContain('| x | |');
+    });
+  });
+
+  describe('block elements', () => {
+    test('converts <br> to a newline', () => {
+      expect(htmlToMarkdown('line1<br>line2')).toBe('line1\nline2');
+      expect(htmlToMarkdown('line1<br/>line2')).toBe('line1\nline2');
+      expect(htmlToMarkdown('line1<br />line2')).toBe('line1\nline2');
+    });
+
+    test('converts <hr> to a markdown rule', () => {
+      expect(htmlToMarkdown('above<hr>below')).toBe('above\n---\nbelow');
+    });
+
+    test('keeps <details>/<summary> tags', () => {
+      const html = '<details><summary>Click</summary><p>hidden</p></details>';
+      const result = htmlToMarkdown(html);
+      expect(result).toContain('<details>');
+      expect(result).toContain('<summary>');
+      expect(result).toContain('Click');
+      expect(result).toContain('hidden');
+    });
+
+    test('extracts datetime from <time> elements', () => {
+      expect(htmlToMarkdown('<p>at <time datetime="2024-05-01T12:00:00Z"></time> sharp</p>'))
+        .toBe('at 2024-05-01T12:00:00Z sharp');
+    });
+  });
+
+  describe('numeric and named HTML entities', () => {
+    test('decodes decimal entities like &#65;', () => {
+      expect(htmlToMarkdown('<p>&#65;&#66;&#67;</p>')).toBe('ABC');
+    });
+
+    test('decodes hexadecimal entities like &#x41;', () => {
+      expect(htmlToMarkdown('<p>&#x41;&#x42;</p>')).toBe('AB');
+    });
+
+    test('decodes the basic XML entities', () => {
+      expect(htmlToMarkdown('<p>&lt;tag&gt; &amp; &quot;q&quot; &apos;a&apos;</p>'))
+        .toBe('<tag> & "q" \'a\'');
+    });
+
+    test('decodes typographic punctuation entities', () => {
+      const html = '<p>&ldquo;hi&rdquo; &lsquo;a&rsquo; &mdash; &ndash; &hellip;</p>';
+      expect(htmlToMarkdown(html)).toBe('"hi" \'a\' — – ...');
+    });
+
+    test('decodes non-breaking space and bullet entities', () => {
+      expect(htmlToMarkdown('<p>a&nbsp;b &bull; c</p>')).toBe('a b • c');
+    });
+
+    test('decodes accented Latin named entities from the table', () => {
+      expect(htmlToMarkdown('<p>caf&eacute; na&iuml;ve &ntilde;</p>'))
+        .toBe('café naïve ñ');
+    });
+
+    test('preserves unknown named entities verbatim', () => {
+      expect(htmlToMarkdown('<p>&unknownentity;</p>')).toBe('&unknownentity;');
+    });
+
+    test('NAMED_ENTITIES exports a non-empty mapping for all uppercase variants', () => {
+      expect(typeof NAMED_ENTITIES).toBe('object');
+      expect(NAMED_ENTITIES.eacute).toBe('é');
+      expect(NAMED_ENTITIES.Eacute).toBe('É');
+    });
+  });
+
+  describe('whitespace cleanup', () => {
+    test('collapses three or more consecutive newlines to a blank line', () => {
+      expect(htmlToMarkdown('<p>a</p>\n\n\n\n<p>b</p>')).toBe('a\n\nb');
+    });
+
+    test('strips trailing whitespace on each line', () => {
+      expect(htmlToMarkdown('<p>hello   </p>')).toBe('hello');
+    });
+
+    test('collapses runs of spaces to a single space', () => {
+      expect(htmlToMarkdown('<p>a    b</p>')).toBe('a b');
+    });
+  });
+
+  describe('regression: unknown tags are dropped', () => {
+    test('removes generic unknown elements but keeps text content', () => {
+      expect(htmlToMarkdown('<p><span class="x">visible</span></p>')).toBe('visible');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `lib/analytics.js` and `lib/html-to-markdown.js` previously had **no dedicated tests** — silent failures in either module would have gone undetected on regression.
- Adds **11 tests for `analytics`** (track / getStats / showStats happy paths, success vs error counters, `CONFLUENCE_CLI_ANALYTICS=false` opt-out, corrupted `stats.json` handling). The user home directory is redirected to a tempdir per test so the suite is hermetic.
- Adds **32 tests for `html-to-markdown`** covering inline tags, headings, lists (ul/ol incl. empty `<li>`), GFM tables, `<br>`/`<hr>`/`<details>`/`<time>`, numeric (`&#65;` / `&#x41;`) and named HTML entities (incl. unknown-entity passthrough), and the whitespace cleanup pass.

## Test plan
- [x] `npm test` — 316/316 passing locally (43 of those are new in this PR)
- [x] `npm run lint` — clean