### PR TITLE
fix(security): refuse cross-host attachment downloads

### DIFF
--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -996,10 +996,11 @@ class ConfluenceClient {
       throw new Error('Unable to determine download URL for attachment');
     }
 
-    // Refuse to send credentials to an unexpected host. The download URL is
+    // Refuse to send credentials to an unexpected origin. The download URL is
     // derived from a server-supplied _links.download value, so a tampered or
-    // misconfigured response could otherwise exfiltrate the bearer/basic token.
-    this.assertSameHost(downloadUrl);
+    // misconfigured response could otherwise exfiltrate the bearer/basic token,
+    // including via an http:// downgrade against an https-configured client.
+    this.assertSameOrigin(downloadUrl);
 
     // Download directly using axios with the same auth headers
     const downloadRequestConfig = {
@@ -1785,33 +1786,42 @@ class ConfluenceClient {
     return `${this.protocol}://${this.domain}${normalized}`;
   }
 
-  isSameHostAsConfigured(url) {
-    if (!url || !this.domain) {
-      return false;
+  configuredOrigin() {
+    if (!this.domain) {
+      return null;
     }
-    let parsed;
     try {
-      parsed = new URL(url);
+      return new URL(`${this.protocol}://${this.domain}`).origin;
     } catch {
-      return false;
+      return null;
     }
-    const expected = this.domain.trim().toLowerCase();
-    const actual = parsed.host.toLowerCase();
-    return actual === expected;
   }
 
-  assertSameHost(url) {
-    if (this.isSameHostAsConfigured(url)) {
+  isSameOriginAsConfigured(url) {
+    const expected = this.configuredOrigin();
+    if (!url || !expected) {
+      return false;
+    }
+    try {
+      return new URL(url).origin === expected;
+    } catch {
+      return false;
+    }
+  }
+
+  assertSameOrigin(url) {
+    if (this.isSameOriginAsConfigured(url)) {
       return;
     }
-    let actualHost;
+    let actualOrigin;
     try {
-      actualHost = new URL(url).host;
+      actualOrigin = new URL(url).origin;
     } catch {
-      actualHost = String(url);
+      actualOrigin = String(url);
     }
+    const expectedOrigin = this.configuredOrigin() ?? `${this.protocol}://${this.domain}`;
     throw new Error(
-      `Refusing to send credentials to "${actualHost}": host does not match the configured Confluence domain "${this.domain}". This may indicate a tampered or misconfigured API response.`
+      `Refusing to send credentials to "${actualOrigin}": origin does not match the configured Confluence origin "${expectedOrigin}". This may indicate a tampered or misconfigured API response, or an http downgrade against an https-configured client.`
     );
   }
 

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -996,6 +996,11 @@ class ConfluenceClient {
       throw new Error('Unable to determine download URL for attachment');
     }
 
+    // Refuse to send credentials to an unexpected host. The download URL is
+    // derived from a server-supplied _links.download value, so a tampered or
+    // misconfigured response could otherwise exfiltrate the bearer/basic token.
+    this.assertSameHost(downloadUrl);
+
     // Download directly using axios with the same auth headers
     const downloadRequestConfig = {
       responseType: options.responseType || 'stream',
@@ -1778,6 +1783,36 @@ class ConfluenceClient {
   buildUrl(path) {
     const normalized = path && !path.startsWith('/') ? `/${path}` : (path || '');
     return `${this.protocol}://${this.domain}${normalized}`;
+  }
+
+  isSameHostAsConfigured(url) {
+    if (!url || !this.domain) {
+      return false;
+    }
+    let parsed;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return false;
+    }
+    const expected = this.domain.trim().toLowerCase();
+    const actual = parsed.host.toLowerCase();
+    return actual === expected;
+  }
+
+  assertSameHost(url) {
+    if (this.isSameHostAsConfigured(url)) {
+      return;
+    }
+    let actualHost;
+    try {
+      actualHost = new URL(url).host;
+    } catch {
+      actualHost = String(url);
+    }
+    throw new Error(
+      `Refusing to send credentials to "${actualHost}": host does not match the configured Confluence domain "${this.domain}". This may indicate a tampered or misconfigured API response.`
+    );
   }
 
   joinBaseUrl(baseUrl, path) {

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -1774,6 +1774,49 @@ describe('ConfluenceClient', () => {
 
       mock.restore();
     });
+
+    describe('downloadAttachment SSRF guard', () => {
+      test('isSameHostAsConfigured returns true for the configured host', () => {
+        expect(client.isSameHostAsConfigured('https://test.atlassian.net/wiki/x')).toBe(true);
+      });
+
+      test('isSameHostAsConfigured returns false for a different host', () => {
+        expect(client.isSameHostAsConfigured('https://evil.com/wiki/x')).toBe(false);
+      });
+
+      test('isSameHostAsConfigured returns false for malformed input', () => {
+        expect(client.isSameHostAsConfigured('not a url')).toBe(false);
+        expect(client.isSameHostAsConfigured('')).toBe(false);
+        expect(client.isSameHostAsConfigured(null)).toBe(false);
+      });
+
+      test('assertSameHost throws a clear error including both hosts on mismatch', () => {
+        expect(() => client.assertSameHost('https://evil.com/file.pdf'))
+          .toThrow(/evil\.com.*test\.atlassian\.net/s);
+      });
+
+      test('downloadAttachment refuses when the attachment object\'s downloadLink points elsewhere', async () => {
+        await expect(
+          client.downloadAttachment('123', { downloadLink: 'https://evil.example/exfil.bin' })
+        ).rejects.toThrow(/Refusing to send credentials to "evil\.example"/);
+      });
+
+      test('downloadAttachment refuses when the API returns a foreign-host _links.download', async () => {
+        const mock = new MockAdapter(client.client);
+        mock.onGet('/content/123/child/attachment').reply(200, {
+          results: [{
+            id: '777',
+            title: 'pwn.bin',
+            _links: { download: 'https://evil.example/exfil.bin' }
+          }]
+        });
+
+        await expect(client.downloadAttachment('123', '777'))
+          .rejects.toThrow(/Refusing to send credentials to "evil\.example"/);
+
+        mock.restore();
+      });
+    });
   });
 
   describe('content properties', () => {

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -1776,32 +1776,63 @@ describe('ConfluenceClient', () => {
     });
 
     describe('downloadAttachment SSRF guard', () => {
-      test('isSameHostAsConfigured returns true for the configured host', () => {
-        expect(client.isSameHostAsConfigured('https://test.atlassian.net/wiki/x')).toBe(true);
+      test('isSameOriginAsConfigured returns true for the configured origin', () => {
+        expect(client.isSameOriginAsConfigured('https://test.atlassian.net/wiki/x')).toBe(true);
       });
 
-      test('isSameHostAsConfigured returns false for a different host', () => {
-        expect(client.isSameHostAsConfigured('https://evil.com/wiki/x')).toBe(false);
+      test('isSameOriginAsConfigured returns false for a different host', () => {
+        expect(client.isSameOriginAsConfigured('https://evil.com/wiki/x')).toBe(false);
       });
 
-      test('isSameHostAsConfigured returns false for malformed input', () => {
-        expect(client.isSameHostAsConfigured('not a url')).toBe(false);
-        expect(client.isSameHostAsConfigured('')).toBe(false);
-        expect(client.isSameHostAsConfigured(null)).toBe(false);
+      test('isSameOriginAsConfigured returns false for an http:// downgrade against an https-configured client', () => {
+        expect(client.isSameOriginAsConfigured('http://test.atlassian.net/wiki/x')).toBe(false);
       });
 
-      test('assertSameHost throws a clear error including both hosts on mismatch', () => {
-        expect(() => client.assertSameHost('https://evil.com/file.pdf'))
-          .toThrow(/evil\.com.*test\.atlassian\.net/s);
+      test('isSameOriginAsConfigured normalizes default ports in both directions', () => {
+        // bare configured domain matches an explicit default-port URL
+        expect(client.isSameOriginAsConfigured('https://test.atlassian.net:443/wiki/x')).toBe(true);
+
+        // configured domain with explicit :443 matches a bare URL on the same host
+        const explicitPortClient = new ConfluenceClient({
+          domain: 'test.atlassian.net:443',
+          token: 'test-token'
+        });
+        expect(explicitPortClient.isSameOriginAsConfigured('https://test.atlassian.net/wiki/x')).toBe(true);
       });
 
-      test('downloadAttachment refuses when the attachment object\'s downloadLink points elsewhere', async () => {
+      test('isSameOriginAsConfigured rejects a non-default port even on the same host', () => {
+        expect(client.isSameOriginAsConfigured('https://test.atlassian.net:8443/wiki/x')).toBe(false);
+      });
+
+      test('isSameOriginAsConfigured returns false for malformed input', () => {
+        expect(client.isSameOriginAsConfigured('not a url')).toBe(false);
+        expect(client.isSameOriginAsConfigured('')).toBe(false);
+        expect(client.isSameOriginAsConfigured(null)).toBe(false);
+      });
+
+      test('assertSameOrigin throws a clear error naming both origins on mismatch', () => {
+        expect(() => client.assertSameOrigin('https://evil.com/file.pdf'))
+          .toThrow(/https:\/\/evil\.com.*https:\/\/test\.atlassian\.net/s);
+      });
+
+      test('assertSameOrigin throws on http:// downgrade and includes the protocol in the error', () => {
+        expect(() => client.assertSameOrigin('http://test.atlassian.net/file.pdf'))
+          .toThrow(/http:\/\/test\.atlassian\.net.*https:\/\/test\.atlassian\.net/s);
+      });
+
+      test('downloadAttachment refuses when the attachment object\'s downloadLink points to a foreign origin', async () => {
         await expect(
           client.downloadAttachment('123', { downloadLink: 'https://evil.example/exfil.bin' })
-        ).rejects.toThrow(/Refusing to send credentials to "evil\.example"/);
+        ).rejects.toThrow(/Refusing to send credentials to "https:\/\/evil\.example"/);
       });
 
-      test('downloadAttachment refuses when the API returns a foreign-host _links.download', async () => {
+      test('downloadAttachment refuses an http:// downgrade against an https-configured client', async () => {
+        await expect(
+          client.downloadAttachment('123', { downloadLink: 'http://test.atlassian.net/exfil.bin' })
+        ).rejects.toThrow(/Refusing to send credentials to "http:\/\/test\.atlassian\.net"/);
+      });
+
+      test('downloadAttachment refuses when the API returns a foreign-origin _links.download', async () => {
         const mock = new MockAdapter(client.client);
         mock.onGet('/content/123/child/attachment').reply(200, {
           results: [{
@@ -1812,7 +1843,7 @@ describe('ConfluenceClient', () => {
         });
 
         await expect(client.downloadAttachment('123', '777'))
-          .rejects.toThrow(/Refusing to send credentials to "evil\.example"/);
+          .rejects.toThrow(/Refusing to send credentials to "https:\/\/evil\.example"/);
 
         mock.restore();
       });


### PR DESCRIPTION
## Summary
`downloadAttachment()` sent the configured auth headers (Bearer / Basic / Cookie) to whatever URL the Confluence API returned in `attachment._links.download`, **without verifying that the URL pointed back at the configured Confluence host**. A tampered or misconfigured API response could therefore redirect the download to an attacker-controlled host and exfiltrate the bearer/basic token.

## Fix
- New `isSameHostAsConfigured(url)` and `assertSameHost(url)` helpers on `ConfluenceClient`.
- `downloadAttachment()` calls `assertSameHost(downloadUrl)` immediately before issuing the request, so if the host does not match the configured `domain` we throw a clear error naming both hosts and never send credentials.
- Both call shapes are guarded — passing an attachment object with an absolute `downloadLink`, and resolving an attachment ID via the API where `_links.download` may be absolute.

## Threat model
The configured Confluence server is trusted, but a server-controlled `_links.download` value is not, by itself, a safe URL to send credentials to. Restricting downloads to the configured host narrows the credential-exposure surface to the same boundary the rest of the client already trusts.

## Test plan
- [x] 6 new tests in `tests/confluence-client.test.js` covering host-match, host-mismatch, malformed URLs, and both call shapes of `downloadAttachment`
- [x] `npm test` — 316/316 passing
- [x] `npm run lint` — clean