### PR TITLE
fix: preserve href on <a> tags during markdown conversion

### DIFF
--- a/lib/html-to-markdown.js
+++ b/lib/html-to-markdown.js
@@ -22,6 +22,14 @@ function htmlToMarkdown(html) {
 
   markdown = markdown.replace(/<time\s+datetime="([^"]+)"[^>]*(?:\/>|>\s*<\/time>)/g, '$1');
 
+  // Convert <a href="url">text</a> to [text](url) before generic attribute stripping.
+  // Allows attributes anywhere in the opening tag so smart links / inline cards
+  // (e.g. <a href="..." data-card-appearance="inline">) are preserved.
+  markdown = markdown.replace(
+    /<a\s+[^>]*?href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/g,
+    (_, href, text) => `[${text}](${href})`
+  );
+
   markdown = markdown.replace(/<strong[^>]*>(.*?)<\/strong>/g, '**$1**');
 
   markdown = markdown.replace(/<em[^>]*>(.*?)<\/em>/g, '*$1*');

--- a/tests/html-to-markdown.test.js
+++ b/tests/html-to-markdown.test.js
@@ -21,6 +21,37 @@ describe('htmlToMarkdown', () => {
     });
   });
 
+  describe('anchor links', () => {
+    test('converts plain <a href> to markdown link', () => {
+      expect(htmlToMarkdown('<p><a href="https://example.com">Example</a></p>'))
+        .toBe('[Example](https://example.com)');
+    });
+
+    test('preserves URL on smart-link / inline-card anchors (data-card-appearance)', () => {
+      const html = '<p><a href="https://example.atlassian.net/wiki/spaces/X/pages/123" data-card-appearance="inline">Linked Page</a></p>';
+      expect(htmlToMarkdown(html))
+        .toBe('[Linked Page](https://example.atlassian.net/wiki/spaces/X/pages/123)');
+    });
+
+    test('preserves URL on anchors carrying smart-link metadata attributes', () => {
+      const html = '<p><a data-linked-resource-id="123" href="https://example.com/page" data-linked-resource-type="page">Title</a></p>';
+      expect(htmlToMarkdown(html))
+        .toBe('[Title](https://example.com/page)');
+    });
+
+    test('preserves anchor links inside table cells', () => {
+      const html = '<table><tr><th>Doc</th></tr><tr><td><a href="https://example.com/a" data-card-appearance="inline">A</a></td></tr></table>';
+      expect(htmlToMarkdown(html))
+        .toContain('[A](https://example.com/a)');
+    });
+
+    test('preserves anchor links inside list items', () => {
+      const html = '<ul><li><a href="https://example.com/x" data-card-appearance="inline">X</a></li></ul>';
+      expect(htmlToMarkdown(html))
+        .toBe('- [X](https://example.com/x)');
+    });
+  });
+
   describe('headings', () => {
     test.each([1, 2, 3, 4, 5, 6])('converts <h%i> to # heading', (level) => {
       const html = `<h${level}>Title</h${level}>`;


### PR DESCRIPTION
### Description

Internal page links rendered as smart links / inline cards (`<a href="..." data-card-appearance="inline">...</a>`) were silently losing their URL during `htmlToMarkdown` conversion. Only the display text survived, breaking round-trip workflows where authors read markdown, edit it, and push it back.

The `htmlToMarkdown` converter had no handler for `<a href>` at all. Anchor tags were stripped of their attributes by the generic attribute-strip regex on line 31, then dropped entirely by the catch-all on line 113, leaving only the display text.

This PR adds an explicit handler that converts `<a href="url">text</a>` to `[text](url)` before the generic attribute strip. The regex permits attributes anywhere in the opening tag so smart-link metadata (`data-card-appearance`, `data-linked-resource-id`, …) does not block the match.

Closes #122

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

### Testing

- [x] Tests pass locally with my changes (326/326)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

### Additional Context

**Root cause:** `htmlToMarkdown` lacks an `<a href>` handler entirely. Smart links and inline cards — the default cross-page link format on modern Confluence Cloud — went through the generic attribute strip and the unknown-tag catch-all, so the URL was discarded.

**Asymmetry:** The push direction (`confluence update --format markdown`) correctly converts `[text](url)` back to `<a href="url" data-card-appearance="inline">text</a>` in storage format. The bug was only on the read/export side.

**Changes:**
- Added an `<a href>` regex handler in `htmlToMarkdown` ahead of the generic attribute-strip step
- Added 5 test cases covering plain anchors, smart-link `<a>` (`data-card-appearance="inline"`), anchors with `data-linked-resource-id` and varying attribute order, anchors inside table cells, and anchors inside list items

**Related:** Sibling fix to #104 / #105, which fixed the equivalent bug for `<ac:link>` / `<ac:link-body>`. After #104, modern Confluence pages still lost their cross-page navigation because Confluence Cloud now stores most internal references as smart-link `<a>` tags rather than `<ac:link>` macros.
