### PR TITLE
fix(config): harden CLI option and config-file parsing against bad input

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -235,7 +235,9 @@ function readConfigFile() {
     }
 
     return raw;
-  } catch {
+  } catch (error) {
+    console.error(chalk.yellow(`⚠ Failed to parse config file at ${CONFIG_FILE}: ${error.message}`));
+    console.error(chalk.yellow('  Run "confluence init" to recreate it.'));
     return null;
   }
 }
@@ -259,7 +261,7 @@ const validateCliOptions = (options) => {
     errors.push('--domain cannot be empty');
   }
 
-  if (options.token !== undefined && !options.token.trim()) {
+  if (options.token !== undefined && (typeof options.token !== 'string' || !options.token.trim())) {
     errors.push('--token cannot be empty');
   }
 
@@ -304,7 +306,7 @@ const validateCliOptions = (options) => {
     }
   }
 
-  if (normAuthType === 'cookie' && options.cookie !== undefined && !options.cookie.trim()) {
+  if (normAuthType === 'cookie' && options.cookie !== undefined && (typeof options.cookie !== 'string' || !options.cookie.trim())) {
     errors.push('--cookie cannot be empty when using cookie authentication');
   }
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,4 +1,4 @@
-const { getConfig } = require('../lib/config');
+const { getConfig, initConfig } = require('../lib/config');
 
 // Save and restore all relevant env vars around each test
 const ENV_KEYS = [
@@ -280,5 +280,73 @@ describe('getConfig env var aliases', () => {
       errorSpy.mockRestore();
       logSpy.mockRestore();
     }
+  });
+});
+
+describe('initConfig CLI option validation', () => {
+  let exitSpy;
+  let errorSpy;
+  let logSpy;
+
+  beforeEach(() => {
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  test('null --token surfaces a validation error instead of crashing', async () => {
+    await expect(initConfig({
+      domain: 'example.com',
+      token: null,
+      authType: 'bearer',
+    })).rejects.toThrow('process.exit called');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/--token cannot be empty/)
+    );
+  });
+
+  test('non-string --token surfaces a validation error instead of crashing', async () => {
+    await expect(initConfig({
+      domain: 'example.com',
+      token: 12345,
+      authType: 'bearer',
+    })).rejects.toThrow('process.exit called');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/--token cannot be empty/)
+    );
+  });
+
+  test('null --cookie with cookie auth surfaces a validation error instead of crashing', async () => {
+    await expect(initConfig({
+      domain: 'example.com',
+      authType: 'cookie',
+      cookie: null,
+    })).rejects.toThrow('process.exit called');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/--cookie cannot be empty/)
+    );
+  });
+
+  test('whitespace-only --token still flagged as empty (regression guard)', async () => {
+    await expect(initConfig({
+      domain: 'example.com',
+      token: '   ',
+      authType: 'bearer',
+    })).rejects.toThrow('process.exit called');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/--token cannot be empty/)
+    );
   });
 });

--- a/tests/profile.test.js
+++ b/tests/profile.test.js
@@ -486,4 +486,37 @@ describe('Profile management', () => {
       expect(fileChmod.mode).toBe(0o600);
     });
   });
+
+  describe('readConfigFile error reporting', () => {
+    test('logs a warning when the config file contains invalid JSON', () => {
+      fs.existsSync.mockImplementation((filePath) => {
+        if (filePath === CONFIG_FILE) return true;
+        return jest.requireActual('fs').existsSync(filePath);
+      });
+      fs.readFileSync.mockImplementation((filePath, encoding) => {
+        if (filePath === CONFIG_FILE) return '{ not valid json';
+        return jest.requireActual('fs').readFileSync(filePath, encoding);
+      });
+
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit called');
+      });
+
+      try {
+        expect(() => getConfig()).toThrow('process.exit called');
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringMatching(/Failed to parse config file/)
+        );
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringMatching(/Run "confluence init" to recreate it/)
+        );
+      } finally {
+        errorSpy.mockRestore();
+        logSpy.mockRestore();
+        exitSpy.mockRestore();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Description

Two small robustness fixes in `lib/config.js`:

1. **`--token` / `--cookie` no longer crash on non-string values.** `validateCliOptions` previously called `.trim()` after only an `!== undefined` guard, so `null` or numeric values produced a confusing `TypeError: Cannot read properties of null (reading 'trim')` instead of the intended `--token cannot be empty` validation error. Both fields now type-guard before trimming.
2. **Corrupted `~/.confluence-cli/config.json` now reports the actual parse error.** `readConfigFile()` previously caught any read/parse failure and returned `null`, which fell through to a generic "No configuration found! Please run \"confluence init\"" message — masking the real cause. We now log a yellow warning naming the file and the underlying error before returning `null`, so the next "No configuration found!" line still fires but the user can see *why*.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] `npm test` — 326/326 pass (5 new tests added)
- [x] `npm run lint` — clean
- [x] New tests cover: `--token null`, `--token` numeric, `--cookie null` with cookie auth, whitespace-only `--token` regression guard, and invalid-JSON config file warning path

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings

## Additional Context

Behavior is unchanged for valid inputs. `null` and non-string `--token` / `--cookie` now produce the same friendly `cannot be empty` message that whitespace-only strings already produced — programmatic callers no longer need to defensively coerce. The corrupted-config warning goes to stderr only when the file exists but cannot be parsed; the no-file case (`!fs.existsSync`) stays silent as before.