### PR TITLE
feat(converter): round-trip anchor macros and same-page anchor links

### DIFF
--- a/lib/macro-converter.js
+++ b/lib/macro-converter.js
@@ -261,6 +261,14 @@ class MacroConverter {
       return `[!note]\n${cleanContent}`;
     });
 
+    // anchor macro → **ANCHOR: id** marker (round-trip with markdownToStorage).
+    // Must run before the generic <ac:structured-macro> catch-all below, which
+    // would otherwise drop the anchor entirely.
+    markdown = markdown.replace(
+      /<ac:structured-macro ac:name="anchor"[^>]*>[\s\S]*?<ac:parameter ac:name="">([\s\S]*?)<\/ac:parameter>[\s\S]*?<\/ac:structured-macro>/g,
+      '\n**ANCHOR: $1**\n'
+    );
+
     markdown = markdown.replace(/<ac:task-list>([\s\S]*?)<\/ac:task-list>/g, (_, content) => {
       const tasks = [];
       const taskRegex = /<ac:task>[\s\S]*?<ac:task-status>([^<]*)<\/ac:task-status>[\s\S]*?<ac:task-body>([\s\S]*?)<\/ac:task-body>[\s\S]*?<\/ac:task>/g;
@@ -316,6 +324,14 @@ class MacroConverter {
     markdown = markdown.replace(/<\/ac:layout-cell>/g, '');
 
     markdown = markdown.replace(/<ac:structured-macro[^>]*>[\s\S]*?<\/ac:structured-macro>/g, '');
+
+    // ac:link with ac:anchor → [text](#id) (round-trip with markdownToStorage).
+    // Must run before the <ac:link[^>]*>…</ac:link> catch-all below, which
+    // would otherwise drop the anchor link entirely.
+    markdown = markdown.replace(
+      /<ac:link ac:anchor="([^"]*)">\s*<ac:plain-text-link-body><!\[CDATA\[([\s\S]*?)\]\]><\/ac:plain-text-link-body>\s*<\/ac:link>/g,
+      '[$2](#$1)'
+    );
 
     markdown = markdown.replace(/<ac:link><ri:url ri:value="([^"]*)" \/><ac:plain-text-link-body><!\[CDATA\[([^\]]*)\]\]><\/ac:plain-text-link-body><\/ac:link>/g, '[$2]($1)');
 

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -117,3 +117,40 @@ describe('MacroConverter markdownToStorage marker conventions', () => {
   });
 
 });
+
+describe('MacroConverter storageToMarkdown anchor round-trip', () => {
+  const converter = new MacroConverter({ isCloud: true });
+
+  test('anchor macro converts back to **ANCHOR: id** marker', () => {
+    const storage = '<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">my-section</ac:parameter></ac:structured-macro>';
+    const result = converter.storageToMarkdown(storage);
+    expect(result).toContain('**ANCHOR: my-section**');
+  });
+
+  test('anchor macro with extra attributes (e.g. ac:macro-id) still converts', () => {
+    const storage = '<ac:structured-macro ac:name="anchor" ac:macro-id="abc-123"><ac:parameter ac:name="">section-2</ac:parameter></ac:structured-macro>';
+    const result = converter.storageToMarkdown(storage);
+    expect(result).toContain('**ANCHOR: section-2**');
+  });
+
+  test('ac:link with ac:anchor converts back to [text](#id)', () => {
+    const storage = '<ac:link ac:anchor="my-section"><ac:plain-text-link-body><![CDATA[Jump]]></ac:plain-text-link-body></ac:link>';
+    const result = converter.storageToMarkdown(storage);
+    expect(result).toContain('[Jump](#my-section)');
+  });
+
+  test('anchor link is not consumed by the generic <ac:link> catch-all', () => {
+    const storage = '<p><ac:link ac:anchor="x"><ac:plain-text-link-body><![CDATA[A]]></ac:plain-text-link-body></ac:link> and <ac:link><ri:url ri:value="https://example.com" /><ac:plain-text-link-body><![CDATA[Ext]]></ac:plain-text-link-body></ac:link></p>';
+    const result = converter.storageToMarkdown(storage);
+    expect(result).toContain('[A](#x)');
+    expect(result).toContain('[Ext](https://example.com)');
+  });
+
+  test('full round-trip: markdown → storage → markdown preserves anchor and link', () => {
+    const original = '**ANCHOR: section-a**\n\nSee [details](#section-a) below.';
+    const storage = converter.markdownToStorage(original);
+    const back = converter.storageToMarkdown(storage);
+    expect(back).toContain('**ANCHOR: section-a**');
+    expect(back).toContain('[details](#section-a)');
+  });
+});


### PR DESCRIPTION
## Pull Request Template

### Description

Follow-up to #118. The forward direction added `**ANCHOR: id**` and `[text](#id)` conversions in `markdownToStorage`, but the reverse direction was still dropping them — `storageToMarkdown`'s generic `<ac:structured-macro>` and `<ac:link>` catch-alls would strip the anchor macro and the anchor link entirely.

This adds two explicit patterns in `storageToMarkdown` before each catch-all:

- `<ac:structured-macro ac:name="anchor">…<ac:parameter ac:name="">id</ac:parameter>…</ac:structured-macro>` → `**ANCHOR: id**`
- `<ac:link ac:anchor="id">…<![CDATA[text]]>…</ac:link>` → `[text](#id)`

A `markdown → storage → markdown` round-trip now preserves both, matching the existing `INFO` / `WARNING` / `NOTE` round-trip behavior. The `**TOC**` round-trip is intentionally out of scope here — the TOC macro can carry parameters (`minLevel`, `maxLevel`, etc.) that have no markdown equivalent, so its round-trip is inherently lossy and warrants a separate discussion if we want to take it on.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

### Testing

- [x] Tests pass locally with my changes (341 passing, was 336)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

New tests cover: anchor macro conversion, anchor macro with extra attributes (e.g. `ac:macro-id`), `ac:link ac:anchor` conversion, regression guard that the anchor link is not consumed by the generic `<ac:link>` catch-all, and a full markdown→storage→markdown round-trip.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

### Additional Context

The two new replacements are placed *before* the existing catch-all patterns at `lib/macro-converter.js:318` and `lib/macro-converter.js:327` respectively — the comments on each new block call out that ordering invariant so the reason isn't lost in future refactors.

Docs note: same as #118, the marker conventions (INFO/WARNING/NOTE/TOC/ANCHOR) are still only discoverable from the code. Happy to add a single "marker conventions" section to README/SKILL.md as a separate docs-only follow-up if useful.