### PR TITLE
feat!: change blockquote default from info macro to plain <blockquote>

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,6 +770,55 @@ echo "# Hello" | confluence convert --input-format markdown --output-format stor
 confluence convert -i page.xml -o page.md --input-format storage --output-format markdown
 ```
 
+## Markdown Marker Conventions
+
+When converting markdown to Confluence storage format (via `confluence convert`, `create`, or `update`), the following paragraph-level markers produce native Confluence macros. Each marker round-trips back to its markdown form when going storage → markdown.
+
+### Callout macros — `INFO`, `WARNING`, `NOTE`
+
+A blockquote whose first line is `**INFO**`, `**WARNING**`, or `**NOTE**` becomes the corresponding Confluence macro:
+
+```markdown
+> **INFO**
+> Heads up — this is an info box.
+
+> **WARNING**
+> Watch out for this.
+
+> **NOTE**
+> Side note for the reader.
+```
+
+The reverse direction emits the equivalent shorthand (`[!info]` / `[!warning]` / `[!note]` followed by the body), which markdown→storage then re-expands.
+
+A blockquote without one of these markers stays a **plain blockquote** (`<blockquote>…</blockquote>`) — `> …` is treated as a quotation, not an alert. Use the markers above when you want a callout.
+
+### `**TOC**` — Table of Contents
+
+A paragraph containing only `**TOC**` becomes a Confluence Table of Contents macro using the macro's default heading levels:
+
+```markdown
+**TOC**
+```
+
+### `**ANCHOR: id**` — anchor
+
+A paragraph containing only `**ANCHOR: my-section**` becomes a Confluence anchor macro with the given id:
+
+```markdown
+**ANCHOR: my-section**
+```
+
+### `[text](#id)` — same-page anchor link
+
+A standard markdown link whose href starts with `#` becomes an `ac:link` with `ac:anchor`, rendering as an in-page jump in Confluence:
+
+```markdown
+See [the anchor](#my-section) above.
+```
+
+This works under all three `linkStyle` modes (`smart`, `wiki`, `plain`) — the anchor-link conversion runs before the general `<a href>` handling.
+
 ## Development
 
 ```bash

--- a/lib/macro-converter.js
+++ b/lib/macro-converter.js
@@ -105,9 +105,10 @@ class MacroConverter {
           <ac:rich-text-body>${cleanContent}</ac:rich-text-body>
         </ac:structured-macro>`;
       } else {
-        return `<ac:structured-macro ac:name="info">
-          <ac:rich-text-body>${content}</ac:rich-text-body>
-        </ac:structured-macro>`;
+        // Plain blockquote — `> …` is a quotation, not an alert. Use the
+        // `> **INFO**` / `> **WARNING**` / `> **NOTE**` markers above to
+        // produce a Confluence info / warning / note macro instead.
+        return `<blockquote>${content}</blockquote>`;
       }
     });
 

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -116,6 +116,41 @@ describe('MacroConverter markdownToStorage marker conventions', () => {
     });
   });
 
+  describe('blockquote default', () => {
+    test('unmarked blockquote becomes a plain <blockquote> (not an info macro)', () => {
+      const result = converter.markdownToStorage('> Just a quote');
+      expect(result).toContain('<blockquote>');
+      expect(result).toContain('Just a quote');
+      expect(result).not.toContain('ac:name="info"');
+    });
+
+    test('multi-line unmarked blockquote stays plain', () => {
+      const result = converter.markdownToStorage('> first line\n> second line');
+      expect(result).toContain('<blockquote>');
+      expect(result).toContain('first line');
+      expect(result).toContain('second line');
+      expect(result).not.toContain('ac:structured-macro');
+    });
+
+    test('> **INFO** marker still produces an info macro', () => {
+      const result = converter.markdownToStorage('> **INFO**\n> Heads up.');
+      expect(result).toContain('<ac:structured-macro ac:name="info">');
+      expect(result).toContain('Heads up.');
+    });
+
+    test('> **WARNING** marker still produces a warning macro', () => {
+      const result = converter.markdownToStorage('> **WARNING**\n> Be careful.');
+      expect(result).toContain('<ac:structured-macro ac:name="warning">');
+      expect(result).toContain('Be careful.');
+    });
+
+    test('> **NOTE** marker still produces a note macro', () => {
+      const result = converter.markdownToStorage('> **NOTE**\n> Side note.');
+      expect(result).toContain('<ac:structured-macro ac:name="note">');
+      expect(result).toContain('Side note.');
+    });
+  });
+
 });
 
 describe('MacroConverter storageToMarkdown anchor round-trip', () => {


### PR DESCRIPTION
## Pull Request Template

### Description

Closes #125.

Until now, an unmarked markdown blockquote (`> …`) was silently wrapped in a Confluence **info macro** by `MacroConverter`. That default was never documented, never tested, and conflated quotations with alert callouts. The intuitive mapping is `> …` → `<blockquote>`; users who want a callout should opt in via the existing `**INFO**` / `**WARNING**` / `**NOTE**` markers.

This PR:

- Switches the default `else` branch in the `markdownToStorage` blockquote handler to emit a plain `<blockquote>${content}</blockquote>`.
- Adds tests for the new default plus regression guards proving `**INFO**` / `**WARNING**` / `**NOTE**` markers still produce their respective macros.
- Adds a new **"Markdown Marker Conventions"** section to README documenting the full set: `INFO`, `WARNING`, `NOTE`, `TOC`, `ANCHOR`, and same-page anchor links. None of these were documented before — closing a long-standing doc gap noted in #118 and #126.

### Impact assessment

Audited before deciding (per #125):

| Area | Depended on the old default? |
|---|---|
| README / CHANGELOG / docs | No mention anywhere |
| Tests | No tests asserted the default behavior |
| `examples/` | No blockquote usage |
| CLI help text / man pages | No mention |
| Round-trip: existing pages with info macros | **Unaffected** — `storageToMarkdown` still emits `[!info]`, which `markdownToStorage` re-expands |

The only path that changes is markdown sources that relied on the implicit `> …` → info macro mapping. Migration is one line: prefix with `> **INFO**`.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

### Testing

- [x] Tests pass locally with my changes (346 passing, was 341)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

New tests cover: unmarked single-line blockquote → plain `<blockquote>`, multi-line unmarked blockquote stays plain, and explicit `**INFO**` / `**WARNING**` / `**NOTE**` markers still produce their respective macros (regression guard).

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

### Additional Context

The commit uses `feat!:` plus a `BREAKING CHANGE:` footer so semantic-release will produce a **major version bump** (1.34.x → 2.0.0). That is the semver-correct call for any observable behavior change at the conversion layer; the audit above shows the practical blast radius is small, but `2.0.0` gives downstream users an unambiguous signal to re-test.