### PR TITLE
fix(config): type-guard remaining CLI option validation against non-strings

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -257,7 +257,7 @@ function saveConfigFile(data) {
 const validateCliOptions = (options) => {
   const errors = [];
 
-  if (options.domain && !options.domain.trim()) {
+  if (options.domain && (typeof options.domain !== 'string' || !options.domain.trim())) {
     errors.push('--domain cannot be empty');
   }
 
@@ -265,12 +265,12 @@ const validateCliOptions = (options) => {
     errors.push('--token cannot be empty');
   }
 
-  if (options.email && !options.email.trim()) {
+  if (options.email && (typeof options.email !== 'string' || !options.email.trim())) {
     errors.push('--email cannot be empty');
   }
 
   if (options.apiPath) {
-    if (!options.apiPath.startsWith('/')) {
+    if (typeof options.apiPath !== 'string' || !options.apiPath.startsWith('/')) {
       errors.push('--api-path must start with "/"');
     } else {
       // Validate API path format
@@ -282,16 +282,18 @@ const validateCliOptions = (options) => {
     }
   }
 
-  if (options.protocol && !['http', 'https'].includes(options.protocol.toLowerCase())) {
+  if (options.protocol && (typeof options.protocol !== 'string' || !['http', 'https'].includes(options.protocol.toLowerCase()))) {
     errors.push('--protocol must be "http" or "https"');
   }
 
-  if (options.authType && !AUTH_TYPES.includes(options.authType.toLowerCase())) {
+  if (options.authType && (typeof options.authType !== 'string' || !AUTH_TYPES.includes(options.authType.toLowerCase()))) {
     errors.push('--auth-type must be "basic", "bearer", "mtls", or "cookie"');
   }
 
   // Check if basic auth is provided with email
-  const normAuthType = options.authType ? normalizeAuthType(options.authType, Boolean(options.email)) : null;
+  const normAuthType = (typeof options.authType === 'string' && options.authType)
+    ? normalizeAuthType(options.authType, Boolean(options.email))
+    : null;
   if (normAuthType === 'basic' && !options.email) {
     errors.push('--email is required when using basic authentication (use your username for on-premise)');
   }
@@ -512,7 +514,9 @@ async function initConfig(cliOptions = {}) {
     protocol: cliOptions.protocol,
     domain: cliOptions.domain,
     apiPath: cliOptions.apiPath,
-    authType: cliOptions.authType ? cliOptions.authType.trim().toLowerCase() : undefined,
+    authType: (typeof cliOptions.authType === 'string' && cliOptions.authType)
+      ? cliOptions.authType.trim().toLowerCase()
+      : cliOptions.authType,
     email: cliOptions.email,
     token: cliOptions.token,
     cookie: cliOptions.cookie,

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -349,4 +349,54 @@ describe('initConfig CLI option validation', () => {
       expect.stringMatching(/--token cannot be empty/)
     );
   });
+
+  test('non-string --domain surfaces a validation error instead of crashing', async () => {
+    await expect(initConfig({
+      domain: 12345,
+      token: 'valid-token',
+      authType: 'bearer',
+    })).rejects.toThrow('process.exit called');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/--domain cannot be empty/)
+    );
+  });
+
+  test('non-string --api-path surfaces a validation error instead of crashing', async () => {
+    await expect(initConfig({
+      domain: 'example.com',
+      apiPath: 12345,
+      token: 'valid-token',
+      authType: 'bearer',
+    })).rejects.toThrow('process.exit called');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/--api-path must start with/)
+    );
+  });
+
+  test('non-string --protocol surfaces a validation error instead of crashing', async () => {
+    await expect(initConfig({
+      domain: 'example.com',
+      protocol: 12345,
+      token: 'valid-token',
+      authType: 'bearer',
+    })).rejects.toThrow('process.exit called');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/--protocol must be/)
+    );
+  });
+
+  test('non-string --auth-type surfaces a validation error instead of crashing', async () => {
+    await expect(initConfig({
+      domain: 'example.com',
+      token: 'valid-token',
+      authType: 12345,
+    })).rejects.toThrow('process.exit called');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/--auth-type must be/)
+    );
+  });
 });


### PR DESCRIPTION
## Description

Follow-up to #124. The previous PR fixed `--token` and `--cookie` against the same crash, but the same pattern (truthy gate, then unguarded string method) lived on for the rest of `validateCliOptions` and one earlier-running line in `initConfig`. This PR applies the established type-guard pattern uniformly so non-string values from programmatic callers surface a clean validation error instead of a `TypeError`.

### What changes

In `lib/config.js`:

- `--domain`, `--email`: type-check before `.trim()`
- `--api-path`: type-check before `.startsWith('/')`
- `--protocol`, `--auth-type`: type-check before `.toLowerCase()`
- `normAuthType` calculation: only call `normalizeAuthType` when authType is a non-empty string (otherwise the helper itself crashes on numeric input)
- `initConfig`'s upfront `authType.trim().toLowerCase()` (which runs **before** `validateCliOptions`) is also guarded — without this, the crash would happen before validation could surface it

### What was caught during review

While writing tests for the above, the `--auth-type` test exposed exactly the early-crash issue at [lib/config.js:517](lib/config.js#L517). Without the second fix, the auth-type validation error would never be reachable. Test was added first, fix derived from the failure.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] `npm test` — 350/350 pass (4 new regression tests added: non-string domain / api-path / protocol / auth-type)
- [x] `npm run lint` — clean
- [x] Existing valid-input behavior unchanged (token, cookie tests from #124 still pass)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings

## Additional Context

Behavior for valid string inputs is unchanged. Null/undefined are still treated as "not provided" (consistent with the rest of the function). The only observable difference is: numeric/object/etc. inputs that previously crashed with `TypeError` now produce the matching `cannot be empty` / `must be ...` validation error.