### PR TITLE
fix(client): isolate per-userkey failures in resolveUserKeysInHtml

### DIFF
--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -496,14 +496,23 @@ class ConfluenceClient {
       return { html, userMap: new Map() };
     }
 
-    // Fetch user info for all keys in parallel
-    const userPromises = Array.from(userKeys).map(key => this.getUserByKey(key));
-    const users = await Promise.all(userPromises);
+    // Fetch user info for all keys in parallel; isolate per-key failures so a
+    // single rejection doesn't drop display names for the rest of the page.
+    const keysArray = Array.from(userKeys);
+    const results = await Promise.allSettled(
+      keysArray.map(key => this.getUserByKey(key))
+    );
 
-    // Build userkey -> displayName map
+    // Build userkey -> displayName map. On rejection, fall back to the raw
+    // userkey (mirrors getUserByKey's own caught-error fallback).
     const userMap = new Map();
-    users.forEach(user => {
-      userMap.set(user.key, user.displayName);
+    results.forEach((result, i) => {
+      const key = keysArray[i];
+      if (result.status === 'fulfilled') {
+        userMap.set(result.value.key, result.value.displayName);
+      } else {
+        userMap.set(key, key);
+      }
     });
 
     // Replace userkey references with display names in HTML

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -1268,6 +1268,26 @@ describe('ConfluenceClient', () => {
       expect(resolved).toBe(html);
       expect(userMap.size).toBe(0);
     });
+
+    test('should isolate per-key failures: one rejection does not drop other resolutions', async () => {
+      const spy = jest.spyOn(client, 'getUserByKey').mockImplementation(async (key) => {
+        if (key === 'good') {
+          return { key, displayName: 'Good User', username: 'good' };
+        }
+        throw new Error('synthetic failure');
+      });
+
+      const html =
+        '<p><ac:link><ri:user ri:userkey="good" /></ac:link> and ' +
+        '<ac:link><ri:user ri:userkey="bad" /></ac:link></p>';
+      const { html: resolved, userMap } = await client.resolveUserKeysInHtml(html);
+
+      expect(resolved).toBe('<p>@Good User and @bad</p>');
+      expect(userMap.get('good')).toBe('Good User');
+      expect(userMap.get('bad')).toBe('bad');
+
+      spy.mockRestore();
+    });
   });
 
   describe('page creation and updates', () => {


### PR DESCRIPTION
## Pull Request Template

### Description
`resolveUserKeysInHtml()` previously fetched user info for every `ri:user` reference with `Promise.all`. If a single `getUserByKey()` call ever rejected (e.g. unexpected server response, future code path that bypasses the existing `try/catch`), the whole helper would throw and the caller would lose every other resolved display name on the page.

This PR switches to `Promise.allSettled` and falls back to the raw userkey for any rejected entry — matching the fallback `getUserByKey()` already returns when its own `try/catch` triggers. Successful lookups in the same batch are unaffected.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

### Testing
- [x] Tests pass locally with my changes (`npx jest`: 351/351 passed)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

The new test (`tests/confluence-client.test.js`) spies on `getUserByKey` to force one userkey to reject and another to resolve, then asserts that the resolved key is still replaced with `@DisplayName` and the rejected key falls back to `@<userkey>`.

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (no user-visible behavior change)
- [x] My changes generate no new warnings (`npm run lint` clean)
- [x] Any dependent changes have been merged and published in downstream modules

### Additional Context
Today `getUserByKey()` wraps the axios call in `try/catch` and returns a fallback object on failure, so in practice rejection is rare. This change is defensive: it removes the implicit dependency on that internal `try/catch` and makes the helper resilient to future refactors that might surface an error.