### PR TITLE
feat(converter): add EXPAND marker for collapsible expand macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,24 @@ A paragraph containing only `**ANCHOR: my-section**` becomes a Confluence anchor
 **ANCHOR: my-section**
 ```
 
+### `**EXPAND: title** … **EXPAND_END**` — collapsible expand macro
+
+Wrap a block of content between `**EXPAND: title**` and `**EXPAND_END**` markers (each on its own paragraph) to render it as a Confluence expand macro with a collapsible body:
+
+````markdown
+**EXPAND: Show generated code**
+
+```js
+const x = 1;
+```
+
+**EXPAND_END**
+````
+
+The body may contain any content that is converted earlier in the pipeline (code blocks, tables, callout blockquotes). The reverse direction emits the same `**EXPAND: title**` / `**EXPAND_END**` markers so the conversion round-trips.
+
+Inline markdown inside the title (`*em*`, backtick code, links, `~~strike~~`) is stripped at capture time — Confluence's storage normalizer treats macro titles as plain text and will silently truncate or reject HTML in a `<ac:parameter>`. Title-less expand macros created in the Confluence UI still convert to `<details>/<summary>` blocks.
+
 ### `[text](#id)` — same-page anchor link
 
 A standard markdown link whose href starts with `#` becomes an `ac:link` with `ac:anchor`, rendering as an in-page jump in Confluence:

--- a/lib/macro-converter.js
+++ b/lib/macro-converter.js
@@ -125,6 +125,20 @@ class MacroConverter {
       '<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">$1</ac:parameter></ac:structured-macro>'
     );
 
+    // **EXPAND: title** … **EXPAND_END** → Confluence expand macro. Runs
+    // after code/blockquote/table conversion so the body can contain those
+    // macros. Strips inline HTML from the title because Confluence's storage
+    // normalizer treats <ac:parameter> as text-only — it silently truncates
+    // at the first '<' and rejects <s> outright with HTTP 500. Entities
+    // (&amp;, &lt;) survive because the regex requires a literal '<'.
+    storage = storage.replace(
+      /<p><strong>EXPAND: (.*?)<\/strong><\/p>\s*([\s\S]*?)\s*<p><strong>EXPAND_END<\/strong><\/p>/g,
+      (_, title, body) => {
+        const cleanTitle = title.replace(/<[^>]+>/g, '').trim();
+        return `<ac:structured-macro ac:name="expand"><ac:parameter ac:name="title">${cleanTitle}</ac:parameter><ac:rich-text-body>${body.trim()}</ac:rich-text-body></ac:structured-macro>`;
+      }
+    );
+
     // Same-page anchor links (href="#id") → ac:link with ac:anchor. Must run
     // before the general link conversion below so the #id pattern is not
     // consumed by the generic <a href> replacement (and so it works under
@@ -235,6 +249,16 @@ class MacroConverter {
       return `\n\`\`\`mermaid\n${code.trim()}\n\`\`\`\n`;
     });
 
+    // Titled expand macros → **EXPAND: title** / **EXPAND_END** markers
+    // (round-trip with markdownToStorage). Must run before the generic
+    // <details> fallback below, which would otherwise drop the title.
+    markdown = markdown.replace(
+      /<ac:structured-macro ac:name="expand"[^>]*>[\s\S]*?<ac:parameter ac:name="title">([\s\S]*?)<\/ac:parameter>[\s\S]*?<ac:rich-text-body>([\s\S]*?)<\/ac:rich-text-body>[\s\S]*?<\/ac:structured-macro>/g,
+      '\n**EXPAND: $1**\n\n$2\n\n**EXPAND_END**\n'
+    );
+
+    // Title-less expand macros (e.g. created in the Confluence UI without a
+    // title) fall back to <details>/<summary> with a localized default label.
     markdown = markdown.replace(/<ac:structured-macro ac:name="expand"[^>]*>[\s\S]*?<ac:rich-text-body>([\s\S]*?)<\/ac:rich-text-body>[\s\S]*?<\/ac:structured-macro>/g, (_, content) => {
       return `\n<details>\n<summary>${labels.expandDetails}</summary>\n\n${content}\n\n</details>\n`;
     });

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -88,6 +88,69 @@ describe('MacroConverter markdownToStorage marker conventions', () => {
     });
   });
 
+  describe('EXPAND', () => {
+    test('**EXPAND: title** / **EXPAND_END** wraps content in an expand macro', () => {
+      const markdown = '**EXPAND: Show details**\n\nHidden content here.\n\n**EXPAND_END**';
+      const result = converter.markdownToStorage(markdown);
+      expect(result).toContain('<ac:structured-macro ac:name="expand">');
+      expect(result).toContain('<ac:parameter ac:name="title">Show details</ac:parameter>');
+      expect(result).toContain('<ac:rich-text-body>');
+      expect(result).toContain('Hidden content here.');
+      expect(result).not.toContain('**EXPAND');
+    });
+
+    test('inline italic in title is stripped (would otherwise be silently truncated by Confluence)', () => {
+      const result = converter.markdownToStorage('**EXPAND: foo *bar* baz**\n\nbody\n\n**EXPAND_END**');
+      expect(result).toContain('<ac:parameter ac:name="title">foo bar baz</ac:parameter>');
+      expect(result).not.toContain('<em>');
+    });
+
+    test('inline code span in title is stripped', () => {
+      const result = converter.markdownToStorage('**EXPAND: use `getUser()` here**\n\nbody\n\n**EXPAND_END**');
+      expect(result).toContain('<ac:parameter ac:name="title">use getUser() here</ac:parameter>');
+      expect(result).not.toContain('<code>');
+    });
+
+    test('inline link in title is stripped (URL is dropped — macro titles cannot hold links)', () => {
+      const result = converter.markdownToStorage('**EXPAND: see [docs](https://example.com)**\n\nbody\n\n**EXPAND_END**');
+      expect(result).toContain('<ac:parameter ac:name="title">see docs</ac:parameter>');
+      expect(result).not.toContain('<a ');
+      expect(result).not.toContain('data-card-appearance');
+    });
+
+    test('inline strikethrough in title is stripped (would otherwise cause Confluence to reject the page with HTTP 500)', () => {
+      const result = converter.markdownToStorage('**EXPAND: ~~old~~ new**\n\nbody\n\n**EXPAND_END**');
+      expect(result).toContain('<ac:parameter ac:name="title">old new</ac:parameter>');
+      expect(result).not.toContain('<s>');
+    });
+
+    test('XML entities in title are preserved (the fix only strips literal tags)', () => {
+      const result = converter.markdownToStorage('**EXPAND: A & B**\n\nbody\n\n**EXPAND_END**');
+      expect(result).toContain('<ac:parameter ac:name="title">A &amp; B</ac:parameter>');
+    });
+
+    test('multiple EXPAND blocks in one document each get their own macro', () => {
+      const markdown = [
+        '**EXPAND: First**',
+        '',
+        'one',
+        '',
+        '**EXPAND_END**',
+        '',
+        '**EXPAND: Second**',
+        '',
+        'two',
+        '',
+        '**EXPAND_END**'
+      ].join('\n');
+      const result = converter.markdownToStorage(markdown);
+      const matches = result.match(/<ac:structured-macro ac:name="expand">/g) || [];
+      expect(matches).toHaveLength(2);
+      expect(result).toContain('<ac:parameter ac:name="title">First</ac:parameter>');
+      expect(result).toContain('<ac:parameter ac:name="title">Second</ac:parameter>');
+    });
+  });
+
   describe('same-page anchor links', () => {
     test('[text](#id) becomes ac:link with ac:anchor', () => {
       const result = converter.markdownToStorage('[Jump](#my-section)');
@@ -151,6 +214,37 @@ describe('MacroConverter markdownToStorage marker conventions', () => {
     });
   });
 
+});
+
+describe('MacroConverter storageToMarkdown EXPAND round-trip', () => {
+  const converter = new MacroConverter({ isCloud: true });
+
+  test('titled expand macro converts back to **EXPAND: title** / **EXPAND_END** markers', () => {
+    const storage = '<ac:structured-macro ac:name="expand" ac:schema-version="1" ac:macro-id="abc-123"><ac:parameter ac:name="title">My title</ac:parameter><ac:rich-text-body><p>body content</p></ac:rich-text-body></ac:structured-macro>';
+    const result = converter.storageToMarkdown(storage);
+    expect(result).toContain('**EXPAND: My title**');
+    expect(result).toContain('body content');
+    expect(result).toContain('**EXPAND_END**');
+    expect(result).not.toContain('<details>');
+  });
+
+  test('title-less expand macro still falls back to <details>/<summary> (preserves existing UI-created behavior)', () => {
+    const storage = '<ac:structured-macro ac:name="expand" ac:schema-version="1"><ac:rich-text-body><p>untitled body</p></ac:rich-text-body></ac:structured-macro>';
+    const result = converter.storageToMarkdown(storage);
+    expect(result).toContain('<details>');
+    expect(result).toContain('<summary>');
+    expect(result).toContain('untitled body');
+    expect(result).not.toContain('**EXPAND:');
+  });
+
+  test('full round-trip: markdown → storage → markdown preserves title and body', () => {
+    const original = '**EXPAND: Show details**\n\nHidden content here.\n\n**EXPAND_END**';
+    const storage = converter.markdownToStorage(original);
+    const back = converter.storageToMarkdown(storage);
+    expect(back).toContain('**EXPAND: Show details**');
+    expect(back).toContain('Hidden content here.');
+    expect(back).toContain('**EXPAND_END**');
+  });
 });
 
 describe('MacroConverter storageToMarkdown anchor round-trip', () => {


### PR DESCRIPTION
## Summary

Adds a paragraph-level marker convention for the Confluence expand macro, mirroring the existing **TOC** and **ANCHOR** markers. Wrap content between `**EXPAND: title**` and `**EXPAND_END**` (each on its own paragraph) and it converts to a collapsible expand macro:

```markdown
**EXPAND: Show generated code**

\`\`\`js
const x = 1;
\`\`\`

**EXPAND_END**
```

The forward handler runs after code/blockquote/table conversion, so the captured body can already contain those macros. The reverse direction (`storageToMarkdown`) emits the same markers so the conversion round-trips — title-less expand macros (typically created in the Confluence UI without a title) still fall back to the existing `<details>/<summary>` output.

## Title sanitization — the non-obvious bit

Confluence's storage normalizer treats `<ac:parameter>` as text-only. I verified empirically against a Confluence Cloud instance:

| Title content                       | Confluence behavior                          |
|-------------------------------------|----------------------------------------------|
| `foo <em>bar</em> baz`              | silently truncated to `foo `                 |
| `foo <code>bar</code> baz`          | silently truncated to `foo `                 |
| `see <a href="..." ...>docs</a>`    | silently truncated to `see `                 |
| `<s>old</s> new`                    | **HTTP 500** — page creation rejected        |
| `A &amp; B`                         | works correctly (entities preserved)         |

So if a user writes a natural-feeling title like `**EXPAND: \`getUser()\` impl**`, markdown-it produces `<code>` inside the captured title, and Confluence then silently lops it off — the page would be created with title \"\" (just one word) without any warning. Strikethrough is even worse: a single `~~` makes `confluence create` fail with 500 at the API layer.

The forward handler strips inline HTML from the captured title with `title.replace(/<[^>]+>/g, '').trim()` before emitting `<ac:parameter>`. Entities (`&amp;`, `&lt;`) survive because the regex needs a literal `<`. Inline formatting in macro titles can't render anyway — silently dropping it matches the rendering reality and degrades gracefully.

## Test plan

- [x] `npx jest tests/macro-converter.test.js` — 35/35 pass
- [x] `npx jest` — full suite 361/361 pass
- [x] `npx eslint lib/macro-converter.js tests/macro-converter.test.js` — clean
- [x] Empirically verified against a live Confluence Cloud instance (silent truncation + 500-on-`<s>` findings above)

New tests cover: forward conversion, multiple EXPAND blocks per document (non-greedy regex correctness), title sanitization for `em`/`code`/`a`/`s`, entity preservation, titled round-trip, title-less fallback to `<details>`, and full markdown→storage→markdown round-trip.

## Notes

- README's \"Markdown Marker Conventions\" section gets a new entry alongside TOC and ANCHOR.
- The reverse handler is positioned before the existing generic `<details>` fallback so titled expand macros consume first.
- No behavior change for users whose Confluence pages contain title-less expand macros — they still convert to `<details>/<summary>` exactly as before.