### PR TITLE
fix: strip callout markers and narrow detection to paragraph start

### DIFF
--- a/lib/macro-converter.js
+++ b/lib/macro-converter.js
@@ -2,6 +2,7 @@ const MarkdownIt = require('markdown-it');
 const { htmlToMarkdown } = require('./html-to-markdown');
 
 const VALID_LINK_STYLES = ['smart', 'plain', 'wiki'];
+const CALLOUT_MARKERS = ['info', 'warning', 'note'];
 
 class MacroConverter {
   constructor({ isCloud = false, webUrlPrefix = '', buildUrl = null, linkStyle = null } = {}) {
@@ -89,27 +90,36 @@ class MacroConverter {
     );
 
     storage = storage.replace(/<blockquote>(.*?)<\/blockquote>/gs, (_, content) => {
-      if (content.includes('<strong>INFO</strong>')) {
-        const cleanContent = content.replace(/<p><strong>INFO<\/strong><\/p>\s*/, '');
-        return `<ac:structured-macro ac:name="info">
-          <ac:rich-text-body>${cleanContent}</ac:rich-text-body>
-        </ac:structured-macro>`;
-      } else if (content.includes('<strong>WARNING</strong>')) {
-        const cleanContent = content.replace(/<p><strong>WARNING<\/strong><\/p>\s*/, '');
-        return `<ac:structured-macro ac:name="warning">
-          <ac:rich-text-body>${cleanContent}</ac:rich-text-body>
-        </ac:structured-macro>`;
-      } else if (content.includes('<strong>NOTE</strong>')) {
-        const cleanContent = content.replace(/<p><strong>NOTE<\/strong><\/p>\s*/, '');
-        return `<ac:structured-macro ac:name="note">
-          <ac:rich-text-body>${cleanContent}</ac:rich-text-body>
-        </ac:structured-macro>`;
-      } else {
+      // Detect the marker only when it sits at the very start of the first
+      // paragraph, immediately followed by a `</p>` close (separated form) or
+      // a `\n` (same-line body form). This is the same anchor condition the
+      // strip step uses below, so detection and stripping stay in sync.
+      // Without this anchor, a quotation that merely *mentions* `**INFO**` —
+      // e.g. `> Use **INFO** at the start.` — would be silently wrapped in an
+      // info macro, surprising the author.
+      const marker = CALLOUT_MARKERS.find((m) =>
+        new RegExp(`<p><strong>${m.toUpperCase()}<\\/strong>(<\\/p>|\\s*\\n)`).test(content)
+      );
+      if (!marker) {
         // Plain blockquote — `> …` is a quotation, not an alert. Use the
         // `> **INFO**` / `> **WARNING**` / `> **NOTE**` markers above to
         // produce a Confluence info / warning / note macro instead.
         return `<blockquote>${content}</blockquote>`;
       }
+      // Strip the leading `<strong>MARKER</strong>`. markdown-it produces two
+      // shapes depending on whether a blank `>` line separates marker and body:
+      //   case A (separated):  `<p><strong>MARKER</strong></p>\n<p>body</p>`
+      //   case B (same-line):  `<p><strong>MARKER</strong>\nbody</p>`
+      // The original cleanup only handled case A, so case B leaked the marker
+      // into the rendered macro body. README's recommended `> **INFO**\n> body`
+      // form parses as case B — exactly the form that broke.
+      const cleanContent = content.replace(
+        new RegExp(`<p><strong>${marker.toUpperCase()}<\\/strong>(<\\/p>\\s*|\\s*\\n)`),
+        (_, tail) => tail.startsWith('</p>') ? '' : '<p>'
+      );
+      return `<ac:structured-macro ac:name="${marker}">
+          <ac:rich-text-body>${cleanContent}</ac:rich-text-body>
+        </ac:structured-macro>`;
     });
 
     storage = storage.replace(/<table>(.*?)<\/table>/gs, '<table>$1</table>');

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -151,6 +151,105 @@ describe('MacroConverter markdownToStorage marker conventions', () => {
     });
   });
 
+  describe('marker text is stripped from macro body', () => {
+    // README's recommended form: `> **INFO**\n> body` (no blank `>` line).
+    // markdown-it parses this as a single paragraph, which the original
+    // cleanup regex did not handle — leaking `<strong>INFO</strong>` into
+    // the rendered macro body. These tests guard the README-documented form.
+    test('INFO marker is stripped (single-paragraph form)', () => {
+      const result = converter.markdownToStorage('> **INFO**\n> body line');
+      expect(result).toContain('ac:name="info"');
+      expect(result).toContain('body line');
+      expect(result).not.toContain('<strong>INFO</strong>');
+    });
+
+    test('INFO marker is stripped (paragraph-separated form)', () => {
+      const result = converter.markdownToStorage('> **INFO**\n>\n> body line');
+      expect(result).toContain('ac:name="info"');
+      expect(result).toContain('body line');
+      expect(result).not.toContain('<strong>INFO</strong>');
+    });
+
+    test('WARNING marker is stripped (single-paragraph form)', () => {
+      const result = converter.markdownToStorage('> **WARNING**\n> body line');
+      expect(result).toContain('ac:name="warning"');
+      expect(result).toContain('body line');
+      expect(result).not.toContain('<strong>WARNING</strong>');
+    });
+
+    test('WARNING marker is stripped (paragraph-separated form)', () => {
+      const result = converter.markdownToStorage('> **WARNING**\n>\n> body line');
+      expect(result).toContain('ac:name="warning"');
+      expect(result).toContain('body line');
+      expect(result).not.toContain('<strong>WARNING</strong>');
+    });
+
+    test('NOTE marker is stripped (single-paragraph form)', () => {
+      const result = converter.markdownToStorage('> **NOTE**\n> body line');
+      expect(result).toContain('ac:name="note"');
+      expect(result).toContain('body line');
+      expect(result).not.toContain('<strong>NOTE</strong>');
+    });
+
+    test('NOTE marker is stripped (paragraph-separated form)', () => {
+      const result = converter.markdownToStorage('> **NOTE**\n>\n> body line');
+      expect(result).toContain('ac:name="note"');
+      expect(result).toContain('body line');
+      expect(result).not.toContain('<strong>NOTE</strong>');
+    });
+
+    // The pre-processor expands `[!info]\nbody` → `> **INFO**\n> body`
+    // (single-paragraph form), so the round-trip path hits the same bug as
+    // the README form. Guard that round-trip here.
+    test('[!info] round-trip strips the marker', () => {
+      const result = converter.markdownToStorage('[!info]\nbody line');
+      expect(result).toContain('ac:name="info"');
+      expect(result).toContain('body line');
+      expect(result).not.toContain('<strong>INFO</strong>');
+    });
+
+    test('[!warning] round-trip strips the marker', () => {
+      const result = converter.markdownToStorage('[!warning]\nbody line');
+      expect(result).toContain('ac:name="warning"');
+      expect(result).toContain('body line');
+      expect(result).not.toContain('<strong>WARNING</strong>');
+    });
+
+    test('[!note] round-trip strips the marker', () => {
+      const result = converter.markdownToStorage('[!note]\nbody line');
+      expect(result).toContain('ac:name="note"');
+      expect(result).toContain('body line');
+      expect(result).not.toContain('<strong>NOTE</strong>');
+    });
+
+    // Negative cases: a quotation that merely *mentions* `**INFO**` (or any
+    // marker keyword) as part of prose must stay a plain blockquote — the
+    // marker is only honored when it sits at the very start of the first
+    // paragraph, immediately followed by `</p>` or `\n`. Both detection and
+    // stripping use this same anchor, so prose `**INFO**` survives untouched.
+    test('mid-sentence **INFO** stays a plain blockquote (no false-positive macro)', () => {
+      const result = converter.markdownToStorage('> Use **INFO** at the start of a callout.');
+      expect(result).toContain('<blockquote>');
+      expect(result).not.toContain('ac:name="info"');
+      expect(result).toContain('<strong>INFO</strong>');
+    });
+
+    test('**INFO** followed by trailing same-line text stays a plain blockquote', () => {
+      const result = converter.markdownToStorage('> **INFO** is an acronym\n> for Information.');
+      expect(result).toContain('<blockquote>');
+      expect(result).not.toContain('ac:name="info"');
+      expect(result).toContain('<strong>INFO</strong>');
+      expect(result).toContain('is an acronym');
+    });
+
+    test('**INFO** as the second word stays a plain blockquote', () => {
+      const result = converter.markdownToStorage('> Some **INFO** text here\n> next line.');
+      expect(result).toContain('<blockquote>');
+      expect(result).not.toContain('ac:name="info"');
+      expect(result).toContain('<strong>INFO</strong>');
+    });
+  });
+
 });
 
 describe('MacroConverter storageToMarkdown anchor round-trip', () => {


### PR DESCRIPTION
### Description

Closes #131.

The INFO/WARNING/NOTE callout markers in `MacroConverter` had two related issues that prevented the README-documented behavior from being reached.

#### 1. Marker text leaked into the macro body

The cleanup step only matched `<p><strong>MARKER</strong></p>` (separated paragraphs):

```js
content.replace(/<p><strong>INFO<\/strong><\/p>\s*/, '')
```

markdown-it parses the README form `> **INFO**\n> body` as a single paragraph `<p><strong>INFO</strong>\nbody</p>`, which never matched. The `[!info]` preprocessor emits the same single-paragraph shape, so both documented input formats produced macros with the marker text remaining in the body.

#5 originally introduced `[!info]` as an admonition that "renders as a Confluence info macro." #127 documented `> **INFO**\n> body` as the user-facing form. This change restores both forms to that behavior.

#### 2. Detection was too broad

`content.includes('<strong>INFO</strong>')` triggered an info macro for any blockquote containing the keyword anywhere in prose:

```markdown
> Use **INFO** at the start of a callout.
```

This was wrapped in an info macro and the marker text remained inside (since the strip regex correctly didn't match prose). Detection now uses the same anchor as stripping — the marker must sit at the start of the first paragraph, followed by `</p>` or `\n`.

#### Refactor

Three near-duplicate if/else branches (INFO/WARNING/NOTE) collapsed into a single `CALLOUT_MARKERS` lookup. The constant uses the canonical lowercase form (`['info', 'warning', 'note']`) matching `ac:name="info"` and the `[!info]` markdown shorthand. Uppercase conversion happens only at the marker-text matching site.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Testing

- [x] Tests pass locally with my changes (363 passing, was 351)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

12 new tests cover:
- Marker stripping for INFO/WARNING/NOTE × (single-paragraph form, separated form) — 6 tests
- `[!info]` / `[!warning]` / `[!note]` round-trip stripping — 3 tests
- Negative cases verifying that prose-level marker mentions stay plain blockquotes — 3 tests