### PR TITLE
fix: scope `[!info]` admonition rewrite to block context

### DIFF
--- a/lib/macro-converter.js
+++ b/lib/macro-converter.js
@@ -3,6 +3,10 @@ const { htmlToMarkdown } = require('./html-to-markdown');
 
 const VALID_LINK_STYLES = ['smart', 'plain', 'wiki'];
 const CALLOUT_MARKERS = ['info', 'warning', 'note'];
+// U+E000 (Unicode Private Use Area) is used as the stash placeholder
+// delimiter. Declared as an explicit escape so the byte is visible in source
+// and survives editor / formatter / lint passes that strip invisible chars.
+const STASH_DELIM = '\uE000';
 
 class MacroConverter {
   constructor({ isCloud = false, webUrlPrefix = '', buildUrl = null, linkStyle = null } = {}) {
@@ -26,12 +30,11 @@ class MacroConverter {
     this.markdown.core.ruler.before('normalize', 'confluence_macros', (state) => {
       // Stash fenced code blocks and inline code so the admonition rewrite
       // below cannot transform `[!info]` tokens that the author intended as
-      // literal text inside code. The placeholder uses a Unicode private-use
-      // character that does not legitimately appear in markdown source.
+      // literal text inside code.
       const stash = [];
-      state.src = state.src.replace(/```[\s\S]*?```|`[^`\n]+`/g, (m) => {
+      state.src = state.src.replace(/```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]+`/g, (m) => {
         stash.push(m);
-        return `${stash.length - 1}`;
+        return `${STASH_DELIM}${stash.length - 1}${STASH_DELIM}`;
       });
 
       // Anchor `[!info]` to the start of a line (string start or after a
@@ -46,7 +49,11 @@ class MacroConverter {
         );
       }
 
-      state.src = state.src.replace(/(\d+)/g, (_, i) => stash[+i]);
+      // Fall back to the original match if the index is out of range so a
+      // literal U+E000<digits>U+E000 in user prose survives untouched instead
+      // of becoming the string "undefined".
+      const restoreRe = new RegExp(`${STASH_DELIM}(\\d+)${STASH_DELIM}`, 'g');
+      state.src = state.src.replace(restoreRe, (m, i) => stash[+i] ?? m);
     });
   }
 

--- a/lib/macro-converter.js
+++ b/lib/macro-converter.js
@@ -2,6 +2,7 @@ const MarkdownIt = require('markdown-it');
 const { htmlToMarkdown } = require('./html-to-markdown');
 
 const VALID_LINK_STYLES = ['smart', 'plain', 'wiki'];
+const CALLOUT_MARKERS = ['info', 'warning', 'note'];
 
 class MacroConverter {
   constructor({ isCloud = false, webUrlPrefix = '', buildUrl = null, linkStyle = null } = {}) {
@@ -23,23 +24,29 @@ class MacroConverter {
     this.markdown.enable(['table', 'strikethrough', 'linkify']);
 
     this.markdown.core.ruler.before('normalize', 'confluence_macros', (state) => {
-      const src = state.src;
-
-      state.src = src.replace(/\[!info\]\s*([\s\S]*?)(?=\n\s*\n|\n\s*\[!|$)/g, (_, content) => {
-        return `> **INFO**\n> ${content.trim().replace(/\n/g, '\n> ')}`;
+      // Stash fenced code blocks and inline code so the admonition rewrite
+      // below cannot transform `[!info]` tokens that the author intended as
+      // literal text inside code. The placeholder uses a Unicode private-use
+      // character that does not legitimately appear in markdown source.
+      const stash = [];
+      state.src = state.src.replace(/```[\s\S]*?```|`[^`\n]+`/g, (m) => {
+        stash.push(m);
+        return `${stash.length - 1}`;
       });
 
-      state.src = state.src.replace(/\[!warning\]\s*([\s\S]*?)(?=\n\s*\n|\n\s*\[!|$)/g, (_, content) => {
-        return `> **WARNING**\n> ${content.trim().replace(/\n/g, '\n> ')}`;
-      });
+      // Anchor `[!info]` to the start of a line (string start or after a
+      // newline) so prose mid-paragraph, headings on the same line, and
+      // `> [!info]` GitHub-style alerts are left alone. The latter would
+      // otherwise expand to a nested blockquote that the storage handler's
+      // lazy regex cannot balance, producing malformed XML.
+      for (const m of CALLOUT_MARKERS) {
+        const re = new RegExp(`(^|\\n)\\[!${m}\\]\\s*([\\s\\S]*?)(?=\\n\\s*\\n|\\n\\s*\\[!|$)`, 'g');
+        state.src = state.src.replace(re, (_, pre, content) =>
+          `${pre}> **${m.toUpperCase()}**\n> ${content.trim().replace(/\n/g, '\n> ')}`
+        );
+      }
 
-      state.src = state.src.replace(/\[!note\]\s*([\s\S]*?)(?=\n\s*\n|\n\s*\[!|$)/g, (_, content) => {
-        return `> **NOTE**\n> ${content.trim().replace(/\n/g, '\n> ')}`;
-      });
-
-      state.src = state.src.replace(/^(\s*)- \[([ x])\] (.+)$/gm, (_, indent, checked, text) => {
-        return `${indent}- [${checked}] ${text}`;
-      });
+      state.src = state.src.replace(/(\d+)/g, (_, i) => stash[+i]);
     });
   }
 

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -294,6 +294,25 @@ describe('MacroConverter markdownToStorage marker conventions', () => {
       expect(result).toContain('third');
       expect(result).not.toContain('undefined');
     });
+
+    test('[!info] inside a tilde-fenced code block is left intact', () => {
+      const result = converter.markdownToStorage('~~~\n[!info]\nbody\n~~~');
+      expect(result).toContain('ac:name="code"');
+      expect(result).toContain('[!info]');
+      expect(result).not.toContain('ac:name="info"');
+    });
+
+    test('[!warning] at line start becomes a warning macro', () => {
+      const result = converter.markdownToStorage('[!warning]\nheads up');
+      expect(result).toContain('ac:name="warning"');
+      expect(result).toContain('heads up');
+    });
+
+    test('[!note] at line start becomes a note macro', () => {
+      const result = converter.markdownToStorage('[!note]\nside note');
+      expect(result).toContain('ac:name="note"');
+      expect(result).toContain('side note');
+    });
   });
 
   describe('marker text is stripped from macro body', () => {

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -151,6 +151,88 @@ describe('MacroConverter markdownToStorage marker conventions', () => {
     });
   });
 
+  describe('admonition preprocessor respects markdown context', () => {
+    // The previous raw-text preprocessor would transform any `[!info]`
+    // anywhere in the source — including inside fenced code blocks, inline
+    // code, and heading text — and break the surrounding markdown. Inline
+    // code and fenced code are now stashed before rewriting, and the
+    // admonition pattern is anchored to a line start so it cannot match
+    // mid-paragraph or after a `>` blockquote prefix.
+    test('[!info] inside inline code is left intact', () => {
+      const result = converter.markdownToStorage('use the `[!info]` marker for callouts');
+      expect(result).toContain('<code>[!info]</code>');
+      expect(result).not.toContain('ac:name="info"');
+    });
+
+    test('[!info] inside a heading\'s inline code is left intact', () => {
+      const result = converter.markdownToStorage('## 5. `[!info]` round-trip marker');
+      expect(result).toContain('<h2>');
+      expect(result).toContain('<code>[!info]</code>');
+      expect(result).not.toContain('ac:name="info"');
+    });
+
+    test('[!info] inside a fenced code block is left intact', () => {
+      const result = converter.markdownToStorage('```\n[!info]\nbody\n```');
+      expect(result).toContain('ac:name="code"');
+      expect(result).toContain('[!info]');
+      expect(result).not.toContain('ac:name="info"');
+    });
+
+    test('[!info] mentioned in heading text stays a heading', () => {
+      const result = converter.markdownToStorage('## [!info] is a section title');
+      expect(result).toContain('<h2>');
+      expect(result).toContain('[!info]');
+      expect(result).not.toContain('ac:name="info"');
+    });
+
+    test('[!info] mid-paragraph stays inline text', () => {
+      const result = converter.markdownToStorage('This text mentions [!info] in passing.');
+      expect(result).toContain('<p>');
+      expect(result).toContain('[!info]');
+      expect(result).not.toContain('ac:name="info"');
+    });
+
+    test('GitHub-style `> [!info]` defers to plain blockquote', () => {
+      // Recognizing `> [!info]` here would emit nested blockquote tokens
+      // that the storage handler's lazy regex can't balance — producing
+      // malformed XML that Confluence rejects with 400. Until the storage
+      // handler supports balanced blockquote parsing, this form must fall
+      // through to a plain `<blockquote>` containing literal `[!info]`.
+      const result = converter.markdownToStorage('> [!info]\n> body');
+      expect(result).toContain('<blockquote>');
+      expect(result).toContain('[!info]');
+      expect(result).not.toContain('ac:name="info"');
+    });
+
+    // Guard against the placeholder/restore step accidentally swallowing
+    // user-authored numbers. The stash uses Unicode private-use delimiters
+    // so the restore regex only matches the placeholder shape, never bare
+    // digits in prose, headings, or list markers.
+    test('plain digits in prose are preserved', () => {
+      const result = converter.markdownToStorage('Version 5 released. 1.0 milestone in 2026.');
+      expect(result).toContain('Version 5 released');
+      expect(result).toContain('1.0 milestone');
+      expect(result).toContain('2026');
+      expect(result).not.toContain('undefined');
+    });
+
+    test('digits in a heading next to inline code are preserved', () => {
+      const result = converter.markdownToStorage('## 5. `[!info]` round-trip marker');
+      expect(result).toContain('<h2>5.');
+      expect(result).toContain('<code>[!info]</code>');
+      expect(result).not.toContain('undefined');
+    });
+
+    test('ordered list markers and inline code coexist', () => {
+      const result = converter.markdownToStorage('1. first\n2. `code` item\n3. third');
+      expect(result).toContain('<ol>');
+      expect(result).toContain('first');
+      expect(result).toContain('<code>code</code> item');
+      expect(result).toContain('third');
+      expect(result).not.toContain('undefined');
+    });
+  });
+
 });
 
 describe('MacroConverter storageToMarkdown anchor round-trip', () => {


### PR DESCRIPTION
### Description

Closes #133.

The previous preprocessor ran a raw-text regex with no anchor, so any `[!info]` token in the source was rewritten — including inside fenced code blocks, inline code, headings, and `>` blockquote prefixes. The heading `## \`[!info]\` round-trip` ended up split mid-tag, and `> [!info]` GitHub-style alerts produced malformed XML that Confluence rejected with 400.

Two narrow changes contain the rewrite to its intended scope:

- **Stash fenced code blocks and inline code** with a Unicode private-use placeholder before the rewrite, then restore. Literal `[!info]` text inside code is no longer transformed.
- **Anchor the admonition pattern to a line start** (`(^|\n)\[!info\]`). Mid-paragraph mentions and `> [!info]` (preceded by a space, not a newline) no longer match, so the standard blockquote rule handles `> [!info]` as a plain quote — preventing the nested-blockquote XML mismatch that produced 400.

Also collapses three near-duplicate regex blocks into a `CALLOUT_MARKERS` loop and drops a no-op `- [ ]` task-list regex in the same function that captured and re-emitted the input unchanged.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Testing

- [x] Tests pass locally with my changes (360 passing, was 351)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

9 new tests cover the previously broken contexts:

- `[!info]` inside inline code (paragraph and heading)
- `[!info]` inside a fenced code block
- `[!info]` mentioned in heading text (no backticks)
- `[!info]` mid-paragraph
- `> [!info]` GitHub-style alerts deferring to plain blockquote

Plus 3 regression guards for the placeholder/restore step, ensuring user-authored numbers (in prose, headings, ordered list markers) survive the stash/restore round-trip and are not accidentally swapped for stash entries:

- digits in plain prose
- digits in a heading next to inline code
- ordered list markers coexisting with inline code

### Note on merge order with #132

This PR introduces \`const CALLOUT_MARKERS = ['info', 'warning', 'note'];\` at the top of \`lib/macro-converter.js\` and uses it in the new admonition loop. #132 introduces the same constant for the storage-side blockquote handler. Whichever PR lands second will hit a one-line declaration conflict — resolution is to keep a single declaration. The two PRs are otherwise independent and can land in either order.