### PR TITLE
fix(converter): emit `> **MARKER**` form to close admonition round-trip

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,7 +789,7 @@ A blockquote whose first line is `**INFO**`, `**WARNING**`, or `**NOTE**` become
 > Side note for the reader.
 ```
 
-The reverse direction emits the equivalent shorthand (`[!info]` / `[!warning]` / `[!note]` followed by the body), which markdown→storage then re-expands.
+The reverse direction emits the same `> **INFO**` / `> **WARNING**` / `> **NOTE**` blockquote form, so multi-paragraph bodies round-trip cleanly. The bare `[!info]` / `[!warning]` / `[!note]` shorthand is still accepted on input for backwards compatibility.
 
 A blockquote without one of these markers stays a **plain blockquote** (`<blockquote>…</blockquote>`) — `> …` is treated as a quotation, not an alert. Use the markers above when you want a callout.
 

--- a/lib/macro-converter.js
+++ b/lib/macro-converter.js
@@ -303,6 +303,12 @@ class MacroConverter {
     // boundary, so multi-paragraph callouts survive download → re-upload.
     // markdownToStorage still accepts the bare `[!marker]` form on input for
     // backwards compatibility with already-downloaded files.
+    //
+    // Wrap the output with leading + trailing `\n` to combine with the single
+    // `\n` that htmlToMarkdown emits around adjacent `<p>` tags. Without
+    // these, a following `<p>after</p>` lazy-continues into the blockquote
+    // body and lands inside the macro on re-upload (blockquote semantics —
+    // unlike code fences, blockquotes have no closing delimiter).
     for (const marker of CALLOUT_MARKERS) {
       const re = new RegExp(`<ac:structured-macro ac:name="${marker}"[^>]*>[\\s\\S]*?<ac:rich-text-body>([\\s\\S]*?)<\\/ac:rich-text-body>[\\s\\S]*?<\\/ac:structured-macro>`, 'g');
       markdown = markdown.replace(re, (_, content) => {
@@ -312,7 +318,8 @@ class MacroConverter {
           .map((line) => (line.length === 0 ? '>' : `> ${line}`))
           .join('\n');
         const header = `> **${marker.toUpperCase()}**`;
-        return body.length === 0 ? header : `${header}\n${quotedBody}`;
+        const inner = body.length === 0 ? header : `${header}\n${quotedBody}`;
+        return `\n${inner}\n`;
       });
     }
 

--- a/lib/macro-converter.js
+++ b/lib/macro-converter.js
@@ -294,20 +294,27 @@ class MacroConverter {
       return `\n\`\`\`\n${code}\n\`\`\`\n`;
     });
 
-    markdown = markdown.replace(/<ac:structured-macro ac:name="info"[^>]*>[\s\S]*?<ac:rich-text-body>([\s\S]*?)<\/ac:rich-text-body>[\s\S]*?<\/ac:structured-macro>/g, (_, content) => {
-      const cleanContent = htmlToMarkdown(content);
-      return `[!info]\n${cleanContent}`;
-    });
-
-    markdown = markdown.replace(/<ac:structured-macro ac:name="warning"[^>]*>[\s\S]*?<ac:rich-text-body>([\s\S]*?)<\/ac:rich-text-body>[\s\S]*?<\/ac:structured-macro>/g, (_, content) => {
-      const cleanContent = htmlToMarkdown(content);
-      return `[!warning]\n${cleanContent}`;
-    });
-
-    markdown = markdown.replace(/<ac:structured-macro ac:name="note"[^>]*>[\s\S]*?<ac:rich-text-body>([\s\S]*?)<\/ac:rich-text-body>[\s\S]*?<\/ac:structured-macro>/g, (_, content) => {
-      const cleanContent = htmlToMarkdown(content);
-      return `[!note]\n${cleanContent}`;
-    });
+    // Emit the README-recommended `> **MARKER**` blockquote form rather than
+    // the bare `[!marker]` shorthand. The bare form has no explicit body
+    // terminator, so a blank line inside a multi-paragraph body is
+    // indistinguishable from the body ending — round-tripping such a body
+    // through markdownToStorage drops every paragraph after the first.
+    // The `>` prefix gives the blockquote-based handler an unambiguous body
+    // boundary, so multi-paragraph callouts survive download → re-upload.
+    // markdownToStorage still accepts the bare `[!marker]` form on input for
+    // backwards compatibility with already-downloaded files.
+    for (const marker of CALLOUT_MARKERS) {
+      const re = new RegExp(`<ac:structured-macro ac:name="${marker}"[^>]*>[\\s\\S]*?<ac:rich-text-body>([\\s\\S]*?)<\\/ac:rich-text-body>[\\s\\S]*?<\\/ac:structured-macro>`, 'g');
+      markdown = markdown.replace(re, (_, content) => {
+        const body = htmlToMarkdown(content).trim();
+        const quotedBody = body
+          .split('\n')
+          .map((line) => (line.length === 0 ? '>' : `> ${line}`))
+          .join('\n');
+        const header = `> **${marker.toUpperCase()}**`;
+        return body.length === 0 ? header : `${header}\n${quotedBody}`;
+      });
+    }
 
     // anchor macro → **ANCHOR: id** marker (round-trip with markdownToStorage).
     // Must run before the generic <ac:structured-macro> catch-all below, which

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -940,9 +940,9 @@ describe('ConfluenceClient', () => {
     test('should convert Confluence macros to admonitions', () => {
       const storage = '<ac:structured-macro ac:name="info"><ac:rich-text-body><p>This is info</p></ac:rich-text-body></ac:structured-macro>';
       const result = client.storageToMarkdown(storage);
-      
-      expect(result).toContain('[!info]');
-      expect(result).toContain('This is info');
+
+      expect(result).toContain('> **INFO**');
+      expect(result).toContain('> This is info');
     });
 
     test('should convert Confluence links to markdown', () => {

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -510,6 +510,29 @@ describe('MacroConverter storageToMarkdown callout round-trip', () => {
     expect(storage2).toContain('single line body');
     expect(storage2).not.toContain('**WARNING**');
   });
+
+  test('adjacent paragraphs stay outside the macro on round-trip', () => {
+    // Without leading + trailing `\n` around the emitted blockquote, an
+    // adjacent following paragraph lazy-continues into the blockquote body
+    // and lands inside the macro on re-upload. Markdown blockquotes have no
+    // closing delimiter — only a blank line ends them — so the separator
+    // newlines are load-bearing.
+    const storage = '<p>before content</p><ac:structured-macro ac:name="info"><ac:rich-text-body><p>foo</p><p>bar</p></ac:rich-text-body></ac:structured-macro><p>after content</p>';
+    const downloaded = converter.storageToMarkdown(storage);
+    const restored = converter.markdownToStorage(downloaded);
+    expect(restored).toMatch(/<p>foo<\/p>[\s\S]*<p>bar<\/p>[\s\S]*<\/ac:rich-text-body>/);
+    expect(restored).toMatch(/<\/ac:structured-macro>\s*<p>after content<\/p>/);
+    expect(restored).toMatch(/<p>before content<\/p>\s*<ac:structured-macro/);
+  });
+
+  test('downloaded markdown has blank-line separation around the callout', () => {
+    const storage = '<p>before</p><ac:structured-macro ac:name="info"><ac:rich-text-body><p>body</p></ac:rich-text-body></ac:structured-macro><p>after</p>';
+    const result = converter.storageToMarkdown(storage);
+    // Blank line between surrounding prose and the callout — same convention
+    // as `code` and `mermaid` macros (see confluence-client.test.js).
+    expect(result).toMatch(/before\n\n> \*\*INFO\*\*/);
+    expect(result).toMatch(/> body\n\nafter/);
+  });
 });
 
 describe('MacroConverter storageToMarkdown anchor round-trip', () => {

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -447,6 +447,71 @@ describe('MacroConverter storageToMarkdown EXPAND round-trip', () => {
   });
 });
 
+describe('MacroConverter storageToMarkdown callout round-trip', () => {
+  // Storage → markdown emits the `> **MARKER**` blockquote form (matching
+  // README) rather than the bare `[!marker]` shorthand, because the bare form
+  // has no body terminator — a blank line inside a multi-paragraph body is
+  // indistinguishable from the body ending, so re-uploading the bare form
+  // silently drops every paragraph after the first. The blockquote form's
+  // `>` prefix gives the body an explicit boundary.
+  const converter = new MacroConverter({ isCloud: true });
+
+  test('info macro emits the > **INFO** blockquote form', () => {
+    const storage = '<ac:structured-macro ac:name="info"><ac:rich-text-body><p>heads up</p></ac:rich-text-body></ac:structured-macro>';
+    const result = converter.storageToMarkdown(storage);
+    expect(result).toContain('> **INFO**');
+    expect(result).toContain('> heads up');
+    expect(result).not.toMatch(/^\[!info\]/m);
+  });
+
+  test('warning macro emits the > **WARNING** blockquote form', () => {
+    const storage = '<ac:structured-macro ac:name="warning"><ac:rich-text-body><p>be careful</p></ac:rich-text-body></ac:structured-macro>';
+    const result = converter.storageToMarkdown(storage);
+    expect(result).toContain('> **WARNING**');
+    expect(result).toContain('> be careful');
+    expect(result).not.toMatch(/^\[!warning\]/m);
+  });
+
+  test('note macro emits the > **NOTE** blockquote form', () => {
+    const storage = '<ac:structured-macro ac:name="note"><ac:rich-text-body><p>side note</p></ac:rich-text-body></ac:structured-macro>';
+    const result = converter.storageToMarkdown(storage);
+    expect(result).toContain('> **NOTE**');
+    expect(result).toContain('> side note');
+    expect(result).not.toMatch(/^\[!note\]/m);
+  });
+
+  test('multi-paragraph body separates paragraphs with `>` (issue #135)', () => {
+    // Regression guard for the round-trip body-bounds bug: a blank line
+    // between paragraphs must round-trip as a `>` line, not a bare blank
+    // line, so re-upload preserves both paragraphs inside the macro.
+    const storage = '<ac:structured-macro ac:name="info"><ac:rich-text-body><p>foo</p><p>bar</p></ac:rich-text-body></ac:structured-macro>';
+    const result = converter.storageToMarkdown(storage);
+    expect(result).toContain('> **INFO**\n> foo\n>\n> bar');
+  });
+
+  test('full round-trip preserves multi-paragraph body inside the macro (issue #135)', () => {
+    const original = '> **INFO**\n> foo\n>\n> bar';
+    const storage1 = converter.markdownToStorage(original);
+    const downloaded = converter.storageToMarkdown(storage1);
+    const storage2 = converter.markdownToStorage(downloaded);
+    // Both paragraphs must remain inside the rich-text-body after re-upload.
+    // Previously, the second paragraph escaped the macro because the bare
+    // `[!info]` output form had ambiguous body bounds.
+    expect(storage2).toMatch(/<ac:rich-text-body>[\s\S]*<p>foo<\/p>[\s\S]*<p>bar<\/p>[\s\S]*<\/ac:rich-text-body>/);
+    expect(storage2).not.toMatch(/<\/ac:structured-macro>\s*<p>bar<\/p>/);
+  });
+
+  test('full round-trip preserves single-paragraph body', () => {
+    const original = '> **WARNING**\n> single line body';
+    const storage1 = converter.markdownToStorage(original);
+    const downloaded = converter.storageToMarkdown(storage1);
+    const storage2 = converter.markdownToStorage(downloaded);
+    expect(storage2).toContain('<ac:structured-macro ac:name="warning">');
+    expect(storage2).toContain('single line body');
+    expect(storage2).not.toContain('**WARNING**');
+  });
+});
+
 describe('MacroConverter storageToMarkdown anchor round-trip', () => {
   const converter = new MacroConverter({ isCloud: true });
 


### PR DESCRIPTION
## Description

Closes #135.

`storageToMarkdown` emitted the bare `[!info]` shorthand for callout macros, but the bare form has no explicit body terminator. A blank line inside a multi-paragraph body is therefore indistinguishable from the body ending, so re-uploading downloaded markdown silently dropped every paragraph after the first — content escaped the macro on round-trip.

### Reproduction (pre-fix)

Author writes the README-recommended form:

```markdown
> **INFO**
> foo
>
> bar
```

`markdownToStorage` correctly puts both paragraphs inside `<ac:rich-text-body>`.
`storageToMarkdown` then collapses to:

```markdown
[!info]
foo

bar
```

Re-uploading hits `lib/macro-converter.js`'s preprocessor `(?=\n\s*\n|...)` lookahead, which treats the blank line as the end of the body. `<p>bar</p>` lands outside the macro.

### Fix

Switch the storage→markdown output to the `> **MARKER**` blockquote form that README already documents as the canonical authored shape. The `>` prefix gives the body an explicit boundary, so `markdownToStorage` — which already handles this form correctly via the blockquote handler (PR #132) — preserves every paragraph on re-upload.

`markdownToStorage` still accepts the bare `[!marker]` form on input for backwards compatibility with already-downloaded files.

The three near-duplicate per-marker handlers (`info` / `warning` / `note`) collapse into a single `CALLOUT_MARKERS` loop, matching the pattern already used elsewhere in this file (PRs #132 and #134).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Tests pass locally with my changes (391 passing, was 385)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

6 new tests in a `storageToMarkdown callout round-trip` describe block:

- `info` / `warning` / `note` macros emit the `> **MARKER**` form (3 tests)
- Multi-paragraph body separates paragraphs with `>` lines (issue #135 direct repro)
- Full round-trip (`md → storage → md → storage`) preserves both paragraphs inside `<ac:rich-text-body>` and asserts no paragraph escapes the macro
- Single-paragraph round-trip preserves body without leaking marker text

The pre-existing `should convert Confluence macros to admonitions` test in `confluence-client.test.js` is updated to assert the new output form.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Note on relationship to #132 / #134

This is the third bug in the same callout code path:

- #132 fixed marker text leaking into the rendered macro body (input side)
- #134 fixed the `[!info]` preprocessor running on tokens it shouldn't (input side, code/heading contexts)
- #135 / this PR fixes the output side emitting a form whose body bounds are ambiguous on re-upload

The author of #135 explicitly noted they discovered the bug while verifying #134.