### PR TITLE
fix(walker): preserve indentation inside fenced code blocks

### DIFF
--- a/lib/storage-walker.js
+++ b/lib/storage-walker.js
@@ -465,13 +465,24 @@ class StorageWalker {
   }
 
   cleanup(text) {
+    // Split on fenced code boundaries so cleanup rules (indent stripping,
+    // multi-space collapsing) don't mangle indentation-sensitive code.
+    // Walker only emits triple-backtick fences (see code/mermaid macros).
+    const segments = text.split(/(```[\s\S]*?```)/g);
+    const cleaned = segments
+      .map((seg, i) => (i % 2 === 1 ? seg : this._cleanupOutsideFence(seg)))
+      .join('');
+    return cleaned.trim();
+  }
+
+  _cleanupOutsideFence(text) {
     let out = text;
     out = out.replace(/[ \t]+$/gm, '');
     out = out.replace(/^[ \t]+(?!([`>]|[*+-] |\d+[.)] ))/gm, '');
     out = out.replace(/^(#{1,6}[^\n]+)\n(?!\n)/gm, '$1\n\n');
     out = out.replace(/\n\s*\n\s*\n+/g, '\n\n');
     out = out.replace(/[ \t]+/g, ' ');
-    return out.trim();
+    return out;
   }
 }
 

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -799,3 +799,44 @@ describe('MacroConverter storageToMarkdown panel formatting', () => {
     expect(converter.storageToMarkdown(storage)).toBe('> **T**\n>\n> foo\n>\n> bar');
   });
 });
+
+describe('MacroConverter storageToMarkdown fenced code preserves indentation', () => {
+  const converter = new MacroConverter({ isCloud: true });
+  const codeMacro = (lang, body) =>
+    `<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">${lang}</ac:parameter><ac:plain-text-body><![CDATA[${body}]]></ac:plain-text-body></ac:structured-macro>`;
+
+  test('leading 4-space indent in fenced code is preserved', () => {
+    const storage = codeMacro('python', 'def foo():\n    return 1');
+    expect(converter.storageToMarkdown(storage)).toBe('```python\ndef foo():\n    return 1\n```');
+  });
+
+  test('nested 8-space indent in fenced code is preserved', () => {
+    const storage = codeMacro('python', 'def foo():\n    if x:\n        return 1');
+    expect(converter.storageToMarkdown(storage)).toBe('```python\ndef foo():\n    if x:\n        return 1\n```');
+  });
+
+  test('tab indent in fenced code is preserved', () => {
+    const storage = codeMacro('go', 'func f() {\n\treturn 1\n}');
+    expect(converter.storageToMarkdown(storage)).toBe('```go\nfunc f() {\n\treturn 1\n}\n```');
+  });
+
+  test('inline multi-space inside fenced code is preserved', () => {
+    const storage = codeMacro('text', 'a    b    c');
+    expect(converter.storageToMarkdown(storage)).toBe('```text\na    b    c\n```');
+  });
+
+  test('mermaid macro indent is preserved', () => {
+    const storage = '<ac:structured-macro ac:name="mermaid-macro"><ac:plain-text-body><![CDATA[graph TD\n    A --> B\n    A --> C]]></ac:plain-text-body></ac:structured-macro>';
+    expect(converter.storageToMarkdown(storage)).toBe('```mermaid\ngraph TD\n    A --> B\n    A --> C\n```');
+  });
+
+  test('non-fence content still has leading whitespace stripped', () => {
+    const storage = '<p>    hello world</p>';
+    expect(converter.storageToMarkdown(storage)).toBe('hello world');
+  });
+
+  test('cleanup still applies between fenced blocks', () => {
+    const storage = `<p>    para</p>${codeMacro('py', 'x = 1')}<p>    para2</p>`;
+    expect(converter.storageToMarkdown(storage)).toBe('para\n\n```py\nx = 1\n```\n\npara2');
+  });
+});

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -839,4 +839,14 @@ describe('MacroConverter storageToMarkdown fenced code preserves indentation', (
     const storage = `<p>    para</p>${codeMacro('py', 'x = 1')}<p>    para2</p>`;
     expect(converter.storageToMarkdown(storage)).toBe('para\n\n```py\nx = 1\n```\n\npara2');
   });
+
+  test('# comment lines inside fenced code do not trigger header blank-line rule', () => {
+    const storage = codeMacro('python', '# comment\nx = 1');
+    expect(converter.storageToMarkdown(storage)).toBe('```python\n# comment\nx = 1\n```');
+  });
+
+  test('trailing whitespace inside fenced code is preserved', () => {
+    const storage = codeMacro('py', 'x = 1   \ny = 2   ');
+    expect(converter.storageToMarkdown(storage)).toBe('```py\nx = 1   \ny = 2   \n```');
+  });
 });

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -849,4 +849,9 @@ describe('MacroConverter storageToMarkdown fenced code preserves indentation', (
     const storage = codeMacro('py', 'x = 1   \ny = 2   ');
     expect(converter.storageToMarkdown(storage)).toBe('```py\nx = 1   \ny = 2   \n```');
   });
+
+  test('consecutive blank lines inside fenced code are preserved (no 3+ collapse)', () => {
+    const storage = codeMacro('text', 'a\n\n\n\nb');
+    expect(converter.storageToMarkdown(storage)).toBe('```text\na\n\n\n\nb\n```');
+  });
 });


### PR DESCRIPTION
Closes #139.

## Problem

`StorageWalker.cleanup()` applied indent-stripping and multi-space-collapsing regexes to the entire converter output. This corrupted indentation-sensitive content inside fenced code blocks:

| Input (CDATA body) | Old output | New output |
|---|---|---|
| `def foo():\n    return 1` | `def foo():\nreturn 1` | `def foo():\n    return 1` |
| `func f() {\n\treturn 1\n}` | tab dropped | tab preserved |
| `a    b    c` | `a b c` | `a    b    c` |
| `# comment\nx = 1` | extra blank line injected by header rule | preserved verbatim |
| Mermaid `graph TD\n    A --> B` | indent dropped | indent preserved |

Python/Go/Mermaid pages stopped round-tripping to runnable/renderable markdown.

## Fix

Split output on triple-backtick fence boundaries (`/(\`\`\`[\s\S]*?\`\`\`)/g`) and apply cleanup rules only to non-fenced segments. The walker only emits triple-backtick fences (`lib/storage-walker.js:263, :299`), so the split is unambiguous.

Cleanup rules now skipped inside fences:
- leading-whitespace strip (the rule called out in #139)
- inline multi-space collapse (same shape of bug, also fixed)
- header blank-line insertion (`#` lines in code no longer trigger it)
- trailing-whitespace strip
- 3+ blank-line collapse

## Behavior changes inside fenced code

- **Trailing whitespace is now preserved.** Previously `cleanup()` stripped trailing `[ \t]+` from every line including code. Inside fences this is now left untouched — code is the source of truth, not markdown convention.
- **Blank-line collapsing no longer applies.** A code block with three or more consecutive blank lines keeps them.

These follow from the same principle: don't reshape code semantics under the guise of markdown cleanup.

## Known limitation

If a code body itself contains a literal triple-backtick (e.g. a Confluence code macro that documents fenced-code syntax), the lazy split mis-pairs the inner backticks with the outer fence and applies cleanup to the misidentified "between" segment. This is a fundamental ambiguity of triple-backtick fences and would require stateful fence tracking to fully resolve. Not addressed here — extremely rare in practice and out of scope for this fix.

## Test plan

- [x] Existing 413 tests pass
- [x] 10 new tests in `tests/macro-converter.test.js` cover: 4-space leading indent, 8-space nested indent, tab indent, inline multi-space, mermaid macro, non-fence still strips, cleanup still applies between fences, `#` comment inside fence, trailing whitespace preservation, consecutive blank-line preservation
- [x] `npm run lint` clean
- [x] All CI checks green (Node 18/20/22 + security)

## Out of scope

The same bug exists in `lib/html-to-markdown.js:146` (the legacy regex pipeline still exposed via `confluence-client.js:1203`). Tracked separately in #146 per #139's scope ("Source: lib/storage-walker.js").

🤖 Generated with [Claude Code](https://claude.com/claude-code)