### PR TITLE
fix(html-to-markdown): stop language token at whitespace in fence info

### DIFF
--- a/lib/html-to-markdown.js
+++ b/lib/html-to-markdown.js
@@ -40,7 +40,10 @@ function htmlToMarkdown(html) {
   markdown = markdown.replace(
     /<pre[^>]*>\s*<code([^>]*)>([\s\S]*?)<\/code>\s*<\/pre>/g,
     (_, codeAttrs, body) => {
-      const langMatch = codeAttrs.match(/class="language-([^"]+)"/);
+      // Stop the language token at whitespace so multi-class conventions
+      // like Prism / highlight.js (`class="language-js hljs"`) don't leak
+      // sibling class names into the fence info string.
+      const langMatch = codeAttrs.match(/class="language-([^"\s]+)/);
       const lang = langMatch ? langMatch[1] : '';
       const trimmed = body.replace(/^\n+|\n+$/g, '');
       // Size against entity-decoded content: the entity-decode pass runs

--- a/tests/html-to-markdown.test.js
+++ b/tests/html-to-markdown.test.js
@@ -298,5 +298,10 @@ describe('htmlToMarkdown', () => {
       const html = '<pre><code class="language-python prism">x = 1</code></pre>';
       expect(htmlToMarkdown(html)).toBe('```python\nx = 1\n```');
     });
+
+    test('hyphenated language identifier (e.g. objective-c) is preserved verbatim', () => {
+      const html = '<pre><code class="language-objective-c">int x;</code></pre>';
+      expect(htmlToMarkdown(html)).toBe('```objective-c\nint x;\n```');
+    });
   });
 });

--- a/tests/html-to-markdown.test.js
+++ b/tests/html-to-markdown.test.js
@@ -288,5 +288,15 @@ describe('htmlToMarkdown', () => {
       const html = '<p>before ``` after</p><pre><code class="language-py">def foo():\n    return 1</code></pre>';
       expect(htmlToMarkdown(html)).toBe('before ``` after\n\n```py\ndef foo():\n    return 1\n```');
     });
+
+    test('multi-class language attribute (Prism / highlight.js) extracts only the language token', () => {
+      const html = '<pre><code class="language-js hljs">x = 1</code></pre>';
+      expect(htmlToMarkdown(html)).toBe('```js\nx = 1\n```');
+    });
+
+    test('multi-class with sibling class after language- emits a clean info string', () => {
+      const html = '<pre><code class="language-python prism">x = 1</code></pre>';
+      expect(htmlToMarkdown(html)).toBe('```python\nx = 1\n```');
+    });
   });
 });


### PR DESCRIPTION
Closes #148.

## Problem

The language regex `/class="language-([^"]+)"/` greedily captured every character up to the closing quote. For `<code class="language-js hljs">` (the Prism / highlight.js convention), the capture became `js hljs`, and the emitted fence was:

```
```js hljs
x = 1
```
```

That info string is invalid in some CommonMark renderers (GitHub strips it; mdast-util-from-markdown treats the whole string as the language token, which fails syntax highlighting lookups).

## Repro

```js
const { htmlToMarkdown } = require('./lib/html-to-markdown');
htmlToMarkdown('<pre><code class="language-js hljs">x = 1</code></pre>');
// Before: "```js hljs\nx = 1\n```"
// After:  "```js\nx = 1\n```"
```

## Fix

One-character change: stop the capture at whitespace.

```js
- const langMatch = codeAttrs.match(/class="language-([^"]+)"/);
+ const langMatch = codeAttrs.match(/class="language-([^"\s]+)/);
```

`[^"\s]+` excludes both the closing `"` and any whitespace, so it captures only the language identifier and ignores sibling classes that follow.

## Out of scope (pre-existing limitations, verified by self-review)

| Pattern | Current behaviour | Why deferred |
|---|---|---|
| `class="hljs language-js"` (language as 2nd class) | bare fence (no language) | Real-world Prism / highlight.js output puts the language class first; fix would relax the anchor (e.g. `/class="[^"]*?\blanguage-([^"\s]+)/`) |
| `class='language-py'` (single-quoted attribute) | bare fence (no language) | Confluence storage and most HTML serialisers use double quotes; fix would add an alternation branch |

Both can be addressed separately if real-world content surfaces them. Walker uses `<ac:parameter ac:name="language">` (storage XML), not class attributes, so neither limitation applies there.

## Test plan

- [x] All 447 tests pass (444 existing + 3 new)
- [x] 3 new tests cover Prism/highlight.js multi-class (`language-js hljs`), 2-class variant (`language-python prism`), and hyphenated language identifier (`language-objective-c` — pin against future regex tweaks)
- [x] `npm run lint` clean
- [x] Existing single-class cases (`language-python`, `language-go`, `language-text`, etc.) still pass — `[^"\s]+` matches them identically since they contain no whitespace
- [x] Self-review verified `c++`, 3-class, attribute-order-variations, empty `language-` (graceful fallback) all behave correctly