### PR TITLE
refactor(markdown-cleanup): extract shared fence-aware cleanup helper

### DIFF
--- a/lib/html-to-markdown.js
+++ b/lib/html-to-markdown.js
@@ -1,3 +1,5 @@
+const { fenceLength, cleanupWithFences } = require('./markdown-cleanup');
+
 const NAMED_ENTITIES = {
   aring: 'å', auml: 'ä', ouml: 'ö',
   eacute: 'é', egrave: 'è', ecirc: 'ê', euml: 'ë',
@@ -165,58 +167,7 @@ function htmlToMarkdown(html) {
 
   markdown = markdown.replace(/&([a-zA-Z]+);/g, (match, name) => NAMED_ENTITIES[name] || match);
 
-  // Split on fenced code boundaries so cleanup rules (indent stripping,
-  // multi-space collapsing) don't mangle indentation-sensitive code.
-  // Backreference matches dynamically-sized fences emitted above when the
-  // body itself contains backticks.
-  const segments = splitOnFences(markdown);
-  markdown = segments
-    .map((seg, i) => (i % 2 === 1 ? seg : cleanupOutsideFence(seg)))
-    .join('');
-  markdown = markdown.trim();
-
-  return markdown;
-}
-
-// CommonMark allows fenced code with N≥3 backticks where the body contains
-// no run of N+ backticks. Pick the smallest N satisfying both so a code
-// block whose payload itself contains ``` does not close its own fence.
-function fenceLength(body) {
-  let max = 0;
-  const runs = body.match(/`+/g);
-  if (runs) {
-    for (const r of runs) if (r.length > max) max = r.length;
-  }
-  return Math.max(3, max + 1);
-}
-
-function splitOnFences(text) {
-  // CommonMark: a fence opens on a line that starts with up to 3 spaces
-  // followed by 3+ backticks, and closes on a line of equal-length
-  // backticks followed only by whitespace. Anchoring to line boundaries
-  // (^ / $ with m flag) prevents prose backticks (e.g. <p>literal ``` x</p>)
-  // from being mis-paired with real fence boundaries.
-  const result = [];
-  const re = /^ {0,3}(`{3,})[^\n]*\n[\s\S]*?\n {0,3}\1[\t ]*$/gm;
-  let lastIdx = 0;
-  let m;
-  while ((m = re.exec(text)) !== null) {
-    result.push(text.slice(lastIdx, m.index));
-    result.push(m[0]);
-    lastIdx = m.index + m[0].length;
-  }
-  result.push(text.slice(lastIdx));
-  return result;
-}
-
-function cleanupOutsideFence(text) {
-  let out = text;
-  out = out.replace(/[ \t]+$/gm, '');
-  out = out.replace(/^[ \t]+(?!([`>]|[*+-] |\d+[.)] ))/gm, '');
-  out = out.replace(/^(#{1,6}[^\n]+)\n(?!\n)/gm, '$1\n\n');
-  out = out.replace(/\n\s*\n\s*\n+/g, '\n\n');
-  out = out.replace(/[ \t]+/g, ' ');
-  return out;
+  return cleanupWithFences(markdown);
 }
 
 module.exports = {

--- a/lib/markdown-cleanup.js
+++ b/lib/markdown-cleanup.js
@@ -1,0 +1,80 @@
+// Shared fence-aware markdown cleanup for storage-walker and html-to-markdown.
+// Both converters need the same set of operations:
+//   1. Size opening/closing fences against the entity-decoded code body so a
+//      payload containing literal backticks (or numeric entities that decode
+//      to backticks) does not close its own fence.
+//   2. Split the post-conversion text on fenced code boundaries using a
+//      CommonMark line-anchored matcher so prose `\`\`\`` cannot be mis-paired
+//      with a real fence opening.
+//   3. Apply a 5-step whitespace cleanup chain only outside fenced code.
+//
+// Keeping these helpers in one place prevents the converters from drifting
+// apart again — see issue #149 for the history.
+
+// CommonMark allows fenced code with N≥3 backticks where the body contains
+// no run of N+ backticks. Pick the smallest N satisfying both. Caller must
+// pass an entity-decoded body — numeric entity refs like `&#96;` are
+// backticks once decoded, so sizing before decode would leave the fence
+// breakable when the entities resolve.
+function fenceLength(decodedBody) {
+  let max = 0;
+  const runs = decodedBody.match(/`+/g);
+  if (runs) {
+    for (const r of runs) if (r.length > max) max = r.length;
+  }
+  return Math.max(3, max + 1);
+}
+
+// Split text on fenced code boundaries. Returns an alternating sequence of
+// segments where even indices are outside-fence text and odd indices are
+// full fenced blocks (delimiters included).
+//
+// CommonMark: a fence opens on a line of up to 3 spaces + 3+ backticks and
+// closes on a line of equal-length backticks followed only by whitespace.
+// Anchoring to line boundaries (^ / $ with the m flag) prevents prose
+// backticks (e.g. a paragraph documenting markdown syntax) from being
+// mis-paired with a real fence opening.
+function splitOnFences(text) {
+  const result = [];
+  const re = /^ {0,3}(`{3,})[^\n]*\n[\s\S]*?\n {0,3}\1[\t ]*$/gm;
+  let lastIdx = 0;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    result.push(text.slice(lastIdx, m.index));
+    result.push(m[0]);
+    lastIdx = m.index + m[0].length;
+  }
+  result.push(text.slice(lastIdx));
+  return result;
+}
+
+// Whitespace cleanup safe to apply to text that sits outside fenced code.
+// Strips trailing whitespace, strips leading whitespace except where it
+// signals a list/blockquote/inline-code marker, ensures a blank line after
+// headers, collapses 3+ blank lines, and squashes runs of inline whitespace.
+function cleanupOutsideFence(text) {
+  let out = text;
+  out = out.replace(/[ \t]+$/gm, '');
+  out = out.replace(/^[ \t]+(?!([`>]|[*+-] |\d+[.)] ))/gm, '');
+  out = out.replace(/^(#{1,6}[^\n]+)\n(?!\n)/gm, '$1\n\n');
+  out = out.replace(/\n\s*\n\s*\n+/g, '\n\n');
+  out = out.replace(/[ \t]+/g, ' ');
+  return out;
+}
+
+// Apply outside-fence cleanup while leaving fenced code untouched, then
+// trim leading and trailing whitespace from the joined result.
+function cleanupWithFences(text) {
+  const segments = splitOnFences(text);
+  return segments
+    .map((seg, i) => (i % 2 === 1 ? seg : cleanupOutsideFence(seg)))
+    .join('')
+    .trim();
+}
+
+module.exports = {
+  fenceLength,
+  splitOnFences,
+  cleanupOutsideFence,
+  cleanupWithFences,
+};

--- a/lib/storage-walker.js
+++ b/lib/storage-walker.js
@@ -1,5 +1,6 @@
 const { parseDocument } = require('htmlparser2');
 const { decodeHTML } = require('entities');
+const { fenceLength, cleanupWithFences } = require('./markdown-cleanup');
 
 const DEFAULT_MAX_DEPTH = 256;
 
@@ -260,7 +261,8 @@ class StorageWalker {
     const lang = langParam ? this.getTextContent(langParam) : '';
     const plainBody = this.findChildByName(node, 'ac:plain-text-body');
     const code = plainBody ? this.getRawText(plainBody) : '';
-    return `\n\`\`\`${lang}\n${code}\n\`\`\`\n`;
+    const fence = '`'.repeat(fenceLength(code));
+    return `\n${fence}${lang}\n${code}\n${fence}\n`;
   }
 
   handleCallout(node, marker) {
@@ -296,7 +298,8 @@ class StorageWalker {
   handleMermaid(node) {
     const plainBody = this.findChildByName(node, 'ac:plain-text-body');
     const code = plainBody ? this.getRawText(plainBody).trim() : '';
-    return `\n\`\`\`mermaid\n${code}\n\`\`\`\n`;
+    const fence = '`'.repeat(fenceLength(code));
+    return `\n${fence}mermaid\n${code}\n${fence}\n`;
   }
 
   handleInclude(node) {
@@ -465,24 +468,7 @@ class StorageWalker {
   }
 
   cleanup(text) {
-    // Split on fenced code boundaries so cleanup rules (indent stripping,
-    // multi-space collapsing) don't mangle indentation-sensitive code.
-    // Walker only emits triple-backtick fences (see code/mermaid macros).
-    const segments = text.split(/(```[\s\S]*?```)/g);
-    const cleaned = segments
-      .map((seg, i) => (i % 2 === 1 ? seg : this._cleanupOutsideFence(seg)))
-      .join('');
-    return cleaned.trim();
-  }
-
-  _cleanupOutsideFence(text) {
-    let out = text;
-    out = out.replace(/[ \t]+$/gm, '');
-    out = out.replace(/^[ \t]+(?!([`>]|[*+-] |\d+[.)] ))/gm, '');
-    out = out.replace(/^(#{1,6}[^\n]+)\n(?!\n)/gm, '$1\n\n');
-    out = out.replace(/\n\s*\n\s*\n+/g, '\n\n');
-    out = out.replace(/[ \t]+/g, ' ');
-    return out;
+    return cleanupWithFences(text);
   }
 }
 

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -855,3 +855,44 @@ describe('MacroConverter storageToMarkdown fenced code preserves indentation', (
     expect(converter.storageToMarkdown(storage)).toBe('```text\na\n\n\n\nb\n```');
   });
 });
+
+describe('MacroConverter storageToMarkdown dynamic fence sizing', () => {
+  const converter = new MacroConverter({ isCloud: true });
+  const codeMacro = (lang, body) =>
+    `<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">${lang}</ac:parameter><ac:plain-text-body><![CDATA[${body}]]></ac:plain-text-body></ac:structured-macro>`;
+
+  test('payload containing ``` uses a 4-backtick fence (CommonMark-safe)', () => {
+    const storage = codeMacro('md', 'before\n```\nafter');
+    expect(converter.storageToMarkdown(storage)).toBe('````md\nbefore\n```\nafter\n````');
+  });
+
+  test('payload containing a 4-backtick run uses a 5-backtick fence', () => {
+    const storage = codeMacro('md', 'x ```` y');
+    expect(converter.storageToMarkdown(storage)).toBe('`````md\nx ```` y\n`````');
+  });
+
+  test('payload with &#96; decimal entities for backticks sizes fence after decode', () => {
+    const storage = codeMacro('md', 'before\n&#96;&#96;&#96;\nafter');
+    expect(converter.storageToMarkdown(storage)).toBe('````md\nbefore\n```\nafter\n````');
+  });
+
+  test('payload with &#x60; hex entities for backticks sizes fence after decode', () => {
+    const storage = codeMacro('md', 'before\n&#x60;&#x60;&#x60;\nafter');
+    expect(converter.storageToMarkdown(storage)).toBe('````md\nbefore\n```\nafter\n````');
+  });
+
+  test('mermaid payload containing ``` uses a 4-backtick fence', () => {
+    const storage = '<ac:structured-macro ac:name="mermaid-macro"><ac:plain-text-body><![CDATA[graph TD\n    A["literal ```"] --> B]]></ac:plain-text-body></ac:structured-macro>';
+    expect(converter.storageToMarkdown(storage)).toBe('````mermaid\ngraph TD\n    A["literal ```"] --> B\n````');
+  });
+
+  test('prose with mid-line ``` before a code macro does not steal fence boundary', () => {
+    const storage = `<p>literal \`\`\` marker</p>${codeMacro('js', 'const x = 1;')}<p>tail</p>`;
+    expect(converter.storageToMarkdown(storage)).toBe('literal ``` marker\n\n```js\nconst x = 1;\n```\n\ntail');
+  });
+
+  test('prose with mid-line ``` before a code macro preserves the code body indent', () => {
+    const storage = `<p>before \`\`\` after</p>${codeMacro('py', 'def foo():\n    return 1')}`;
+    expect(converter.storageToMarkdown(storage)).toBe('before ``` after\n\n```py\ndef foo():\n    return 1\n```');
+  });
+});

--- a/tests/markdown-cleanup.test.js
+++ b/tests/markdown-cleanup.test.js
@@ -1,0 +1,168 @@
+const {
+  fenceLength,
+  splitOnFences,
+  cleanupOutsideFence,
+  cleanupWithFences,
+} = require('../lib/markdown-cleanup');
+
+describe('markdown-cleanup fenceLength', () => {
+  test('empty body returns the 3-backtick floor', () => {
+    expect(fenceLength('')).toBe(3);
+  });
+
+  test('body with no backticks returns the 3-backtick floor', () => {
+    expect(fenceLength('plain text\nno ticks here')).toBe(3);
+  });
+
+  test('body with single backtick still returns the 3-backtick floor', () => {
+    expect(fenceLength('inline `code` here')).toBe(3);
+  });
+
+  test('body with a 3-backtick run escalates to 4', () => {
+    expect(fenceLength('before\n```\nafter')).toBe(4);
+  });
+
+  test('body with a 4-backtick run escalates to 5', () => {
+    expect(fenceLength('x ```` y')).toBe(5);
+  });
+
+  test('longest run wins when multiple runs of different lengths exist', () => {
+    expect(fenceLength('a `` b ``` c `````` d')).toBe(7);
+  });
+});
+
+describe('markdown-cleanup splitOnFences', () => {
+  test('empty input returns a single empty segment', () => {
+    expect(splitOnFences('')).toEqual(['']);
+  });
+
+  test('input with no fences returns a single segment with the input', () => {
+    const text = 'just prose\nwith newlines';
+    expect(splitOnFences(text)).toEqual([text]);
+  });
+
+  test('alternating segments invariant: even indices are outside, odd are full fences', () => {
+    const text = 'before\n```js\nx = 1\n```\nafter';
+    const segments = splitOnFences(text);
+    expect(segments).toHaveLength(3);
+    expect(segments[0]).toBe('before\n');
+    expect(segments[1]).toBe('```js\nx = 1\n```');
+    expect(segments[2]).toBe('\nafter');
+  });
+
+  test('multiple fences each get their own odd-indexed segment', () => {
+    const text = 'a\n```\nb\n```\nc\n```py\nd\n```\ne';
+    const segments = splitOnFences(text);
+    expect(segments).toHaveLength(5);
+    expect(segments[1]).toBe('```\nb\n```');
+    expect(segments[3]).toBe('```py\nd\n```');
+  });
+
+  test('opening fence indented up to 3 spaces is recognized', () => {
+    const text = '   ```js\nx\n   ```\n';
+    const segments = splitOnFences(text);
+    expect(segments).toHaveLength(3);
+    expect(segments[1]).toBe('   ```js\nx\n   ```');
+  });
+
+  test('opening fence indented 4+ spaces is treated as prose (not a fence)', () => {
+    const text = '    ```js\nx\n    ```\n';
+    expect(splitOnFences(text)).toEqual([text]);
+  });
+
+  test('greedy quantifier backtracks: 4-tick open with 3-tick close pairs at the 3-tick boundary', () => {
+    // The greedy `(\`{3,})` first tries to capture 4 backticks, then backtracks
+    // to 3 when no 4-tick close exists. Neither converter ever emits a
+    // mismatched fence, so this lenient behavior is harmless in practice — the
+    // test pins it so future tightening is a deliberate decision, not a regression.
+    const text = '````md\nbody\n```\nstill body';
+    expect(splitOnFences(text)).toEqual(['', '````md\nbody\n```', '\nstill body']);
+  });
+
+  test('matched 4-tick fence captures 3-tick payload as inner content', () => {
+    const text = 'before\n````md\nfoo\n```\nbar\n````\nafter';
+    const segments = splitOnFences(text);
+    expect(segments).toHaveLength(3);
+    expect(segments[1]).toBe('````md\nfoo\n```\nbar\n````');
+  });
+
+  test('close line with trailing tabs/spaces is allowed', () => {
+    const text = '```js\nx\n```   \t\nafter';
+    const segments = splitOnFences(text);
+    expect(segments).toHaveLength(3);
+    expect(segments[1]).toBe('```js\nx\n```   \t');
+  });
+
+  test('prose containing mid-line ``` does not open a fence', () => {
+    const text = 'see ``` here\nand ``` there';
+    expect(splitOnFences(text)).toEqual([text]);
+  });
+});
+
+describe('markdown-cleanup cleanupOutsideFence', () => {
+  test('strips trailing whitespace per line', () => {
+    expect(cleanupOutsideFence('foo   \nbar\t\n')).toBe('foo\nbar\n');
+  });
+
+  test('strips leading whitespace on plain lines', () => {
+    expect(cleanupOutsideFence('   hello')).toBe('hello');
+  });
+
+  test('leaves a single leading space before list / blockquote / inline-code markers', () => {
+    // The negative lookahead protects the marker from being glued to start of
+    // line: greedy `[ \t]+` backtracks until the position immediately after
+    // the match is no longer at the marker, leaving exactly one space behind.
+    expect(cleanupOutsideFence('  - item')).toBe(' - item');
+    expect(cleanupOutsideFence('  > quote')).toBe(' > quote');
+    expect(cleanupOutsideFence('  `code`')).toBe(' `code`');
+    expect(cleanupOutsideFence('  1. ordered')).toBe(' 1. ordered');
+  });
+
+  test('does not strip a marker that already starts at column 0', () => {
+    expect(cleanupOutsideFence('- item')).toBe('- item');
+    expect(cleanupOutsideFence('> quote')).toBe('> quote');
+    expect(cleanupOutsideFence('`code`')).toBe('`code`');
+    expect(cleanupOutsideFence('1. ordered')).toBe('1. ordered');
+  });
+
+  test('inserts a blank line after a header that lacks one', () => {
+    expect(cleanupOutsideFence('# Title\nnext')).toBe('# Title\n\nnext');
+  });
+
+  test('does not double-space a header that already has a blank line after it', () => {
+    expect(cleanupOutsideFence('# Title\n\nnext')).toBe('# Title\n\nnext');
+  });
+
+  test('collapses 3+ blank lines to a single blank line', () => {
+    expect(cleanupOutsideFence('a\n\n\n\nb')).toBe('a\n\nb');
+  });
+
+  test('squashes runs of inline whitespace to a single space', () => {
+    expect(cleanupOutsideFence('a    b\tc')).toBe('a b c');
+  });
+});
+
+describe('markdown-cleanup cleanupWithFences', () => {
+  test('returns trimmed empty string for empty input', () => {
+    expect(cleanupWithFences('')).toBe('');
+  });
+
+  test('trims leading and trailing whitespace from the result', () => {
+    expect(cleanupWithFences('\n\n  hello\n\n')).toBe('hello');
+  });
+
+  test('applies cleanup outside fences but leaves fenced content untouched', () => {
+    const text = '   prose   line\n\n```js\n  const x = 1;  \n```\n   tail';
+    expect(cleanupWithFences(text)).toBe('prose line\n\n```js\n  const x = 1;  \n```\ntail');
+  });
+
+  test('preserves consecutive blank lines and trailing spaces inside a fence', () => {
+    const text = 'a\n\n```text\nx\n\n\n\ny   \n```\nb';
+    expect(cleanupWithFences(text)).toBe('a\n\n```text\nx\n\n\n\ny   \n```\nb');
+  });
+
+  test('applies cleanup between two adjacent fenced blocks', () => {
+    const text = '```js\na\n```\n\n\n\n   ```py\nb\n   ```';
+    expect(cleanupWithFences(text)).toBe('```js\na\n```\n\n   ```py\nb\n   ```');
+  });
+});


### PR DESCRIPTION
## Summary

- New `lib/markdown-cleanup.js` exposing `fenceLength`, `splitOnFences`, `cleanupOutsideFence`, `cleanupWithFences`. Both converters delegate, removing the drift hazard that already cost two release cycles (#146, #147).
- `StorageWalker.handleCode` / `handleMermaid` now size fences dynamically against the entity-decoded body, fixing three latent walker bugs that #147 fixed in `html-to-markdown` but had not been ported:
  - **A.** Code body containing literal ` ``` ` closed its own fence early.
  - **B.** Body containing `&#96;` / `&#x60;` numeric entities sized the fence before entity-decode, so the resolved backticks broke the same way as (A).
  - **C.** Prose with mid-line ` ``` ` before a code block mis-paired with the real fence opening, dragging the code body into the outside-fence segment and regressing #146 indent preservation.
- Walker `cleanup()` is one-line delegation; `_cleanupOutsideFence` is removed.

## Test plan

- [x] `npx jest` — 454 passing (existing 447 + 7 new walker regression tests under `MacroConverter storageToMarkdown dynamic fence sizing`)
- [x] `npx eslint lib/markdown-cleanup.js lib/storage-walker.js lib/html-to-markdown.js tests/macro-converter.test.js`
- [x] New tests cover all three bugs (A, B, C) plus the 4-tick / 5-tick fence escalation and mermaid backtick handling.

Closes #149