### PR TITLE
fix(walker): handle external <ri:url> images in handleImage

### DIFF
--- a/lib/storage-walker.js
+++ b/lib/storage-walker.js
@@ -354,9 +354,17 @@ class StorageWalker {
 
   handleImage(node) {
     const riAttachment = this.findChildByName(node, 'ri:attachment');
-    if (!riAttachment) return '';
-    const filename = decodeEntities(riAttachment.attribs['ri:filename'] || '');
-    return `![${filename}](${this.attachmentsDir}/${filename})`;
+    if (riAttachment) {
+      const filename = decodeEntities(riAttachment.attribs['ri:filename'] || '');
+      return `![${filename}](${this.attachmentsDir}/${filename})`;
+    }
+    const riUrl = this.findChildByName(node, 'ri:url');
+    if (riUrl) {
+      const url = decodeEntities(riUrl.attribs['ri:value'] || '');
+      if (!url) return '';
+      return `![](${url})`;
+    }
+    return '';
   }
 
   handleAcLink(node) {

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -786,6 +786,31 @@ describe('MacroConverter storageToMarkdown ac:link without body', () => {
   });
 });
 
+describe('MacroConverter storageToMarkdown ac:image external URL', () => {
+  // <ac:image> wraps either <ri:attachment> (uploaded asset) or <ri:url>
+  // (external image). The walker originally only handled the attachment
+  // branch; external images were silently dropped from the export.
+  const converter = new MacroConverter({ isCloud: true });
+
+  test('<ri:url> image renders with empty alt and the external URL', () => {
+    const storage = '<ac:image><ri:url ri:value="https://example.com/diagram.png" /></ac:image>';
+    expect(converter.storageToMarkdown(storage)).toBe('![](https://example.com/diagram.png)');
+  });
+
+  test('<ri:url> image decodes entities in the URL value', () => {
+    const storage = '<ac:image><ri:url ri:value="https://example.com/path?q=caf&eacute;" /></ac:image>';
+    expect(converter.storageToMarkdown(storage)).toBe('![](https://example.com/path?q=café)');
+  });
+
+  test('<ac:image> with neither ri:attachment nor ri:url emits nothing', () => {
+    const storage = '<p>Before</p><ac:image></ac:image><p>After</p>';
+    const result = converter.storageToMarkdown(storage);
+    expect(result).not.toContain('![]');
+    expect(result).toContain('Before');
+    expect(result).toContain('After');
+  });
+});
+
 describe('MacroConverter storageToMarkdown panel formatting', () => {
   const converter = new MacroConverter({ isCloud: true });
 


### PR DESCRIPTION
Closes #142.

## Problem

`StorageWalker.handleImage()` only matched `<ri:attachment>` children. Confluence storage also wraps external image URLs in `<ri:url>`:

```xml
<ac:image><ri:url ri:value="https://example.com/diagram.png" /></ac:image>
```

The handler returned `''` for these, dropping the image from exported markdown entirely.

This is **pre-existing on main** — the regex pipeline only matched `ri:attachment` either — but the walker rewrite is the natural moment to add the missing branch.

## Fix

Add an explicit `<ri:url>` branch that emits `![](url)` after named-entity decoding the `ri:value` attribute, mirroring every other attribute read site in the walker. Empty URLs fall through to `''` so we never emit a visibly-empty `![](\)` marker.

```js
const riUrl = this.findChildByName(node, 'ri:url');
if (riUrl) {
  const url = decodeEntities(riUrl.attribs['ri:value'] || '');
  if (!url) return '';
  return `![](${url})`;
}
return '';
```

## Test plan

- [x] All 486 existing tests pass
- [x] 3 new tests in `tests/macro-converter.test.js` cover:
  - external `<ri:url>` image renders as `![](url)`
  - entity-encoded URL value (`caf&eacute;` → `café`) is decoded
  - `<ac:image>` with no children emits no marker
- [x] `npm run lint` clean