### PR TITLE
refactor(converter): replace regex-based markdown→storage with htmlparser2 walker

### DIFF
--- a/lib/html-to-storage.js
+++ b/lib/html-to-storage.js
@@ -1,0 +1,394 @@
+// HTML → Confluence storage walker. Parses with htmlparser2 using
+// `decodeEntities: false` so attribute and text entities round-trip
+// byte-identical. Dispatches by tag; unhandled tags pass through with
+// attributes preserved.
+
+const { parseDocument } = require('htmlparser2');
+
+const VALID_LINK_STYLES = ['smart', 'plain', 'wiki'];
+// Hard cap on input HTML nesting to keep the recursive walker off the JS
+// stack ceiling for pathological / malicious input.
+const DEFAULT_MAX_DEPTH = 256;
+
+class HtmlDepthExceededError extends Error {
+  constructor(maxDepth) {
+    super(`HTML nesting exceeds limit of ${maxDepth} levels`);
+    this.name = 'HtmlDepthExceededError';
+    this.maxDepth = maxDepth;
+  }
+}
+// Only `hr` is normalized to self-closing. `br` / `img` flow through in
+// whatever shape the source had (markdown-it emits them without a slash).
+const VOID_TAGS = new Set(['hr']);
+const CALLOUT_MARKERS = ['info', 'warning', 'note'];
+
+// Phrasing-content tags that trigger the `<li>` / `<th>` / `<td>` `<p>`-wrap
+// quirk: if an item contains only inline children and no text-node newline,
+// the walker wraps its content in `<p>`. markdown-it never emits the latter
+// half of this set, but raw HTML input does, so they need the same treatment.
+const INLINE_TAGS = new Set([
+  'a', 'strong', 'em', 'code', 'br', 'img', 'span',
+  'mark', 'sub', 'sup', 'ins', 'del', 'b', 'i', 'u', 'small', 's',
+  'abbr', 'kbd', 'q', 'var', 'cite', 'time', 'dfn', 'samp',
+]);
+
+function shouldWrapInP(node) {
+  if (!node.children) return true;
+  for (const child of node.children) {
+    if (child.type === 'text' && child.data.includes('\n')) return false;
+    if (child.type === 'tag' && !INLINE_TAGS.has(child.name)) return false;
+  }
+  return true;
+}
+
+function isWhitespaceOnly(node) {
+  return node.type === 'text' && /^\s*$/.test(node.data);
+}
+
+// Filter out whitespace-only text nodes so structural shape checks (single
+// `<strong>` inside a paragraph, etc.) tolerate parser variations that emit
+// trailing/leading whitespace text siblings.
+function meaningfulChildren(node) {
+  return (node.children || []).filter((c) => !isWhitespaceOnly(c));
+}
+
+// Detects `<p><strong>TOC</strong></p>` and `<p><strong>ANCHOR: id</strong></p>`
+// macro markers. The strict "p > one strong > one text" shape is intentional —
+// any embellishment must fall through to a plain paragraph.
+function detectParagraphMarker(node) {
+  if (node.name !== 'p') return null;
+  const kids = meaningfulChildren(node);
+  if (kids.length !== 1) return null;
+  const strong = kids[0];
+  if (strong.type !== 'tag' || strong.name !== 'strong') return null;
+  const strongKids = meaningfulChildren(strong);
+  if (strongKids.length !== 1) return null;
+  const text = strongKids[0];
+  if (text.type !== 'text') return null;
+  if (text.data === 'TOC') return { kind: 'toc' };
+  const anchor = text.data.match(/^ANCHOR: (.+)$/);
+  if (anchor) return { kind: 'anchor', id: anchor[1] };
+  return null;
+}
+
+// EXPAND open `<p><strong>EXPAND: …</strong></p>`. The title may contain
+// nested inline HTML (em, code, a, s, …) which gets stripped later — so we
+// only require that the strong's first text child starts with `EXPAND: `,
+// not that it's the only child.
+function isExpandOpen(node) {
+  if (node.type !== 'tag' || node.name !== 'p') return false;
+  const kids = meaningfulChildren(node);
+  if (kids.length !== 1) return false;
+  const strong = kids[0];
+  if (strong.type !== 'tag' || strong.name !== 'strong') return false;
+  if (!strong.children || strong.children.length === 0) return false;
+  const first = strong.children[0];
+  return first.type === 'text' && first.data.startsWith('EXPAND: ');
+}
+
+function isExpandClose(node) {
+  if (node.type !== 'tag' || node.name !== 'p') return false;
+  const kids = meaningfulChildren(node);
+  if (kids.length !== 1) return false;
+  const strong = kids[0];
+  if (strong.type !== 'tag' || strong.name !== 'strong') return false;
+  const strongKids = meaningfulChildren(strong);
+  if (strongKids.length !== 1) return false;
+  const text = strongKids[0];
+  return text.type === 'text' && text.data === 'EXPAND_END';
+}
+
+// Replacement order matters for doubly-escaped input: the default order
+// replaces the ampersand entity first, which over-decodes (the escaped
+// form of an `<`-entity collapses all the way to `<`). `preserveDouble`
+// reverses the order so the same input round-trips as `&lt;` instead.
+// Both orderings are intentional — call sites pick via the option.
+function decodeEntities(text, { preserveDouble = false } = {}) {
+  if (preserveDouble) {
+    // Apostrophe (`&#39;`) intentionally omitted from this branch: the
+    // previous code-fence decoder didn't list it either, only the anchor
+    // body decoder did. The asymmetry is preserved for byte parity.
+    return text
+      .replace(/&quot;/g, '"')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&amp;/g, '&');
+  }
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, '\'');
+}
+
+// Anchor links (`href="#id"`) short-circuit linkStyle; external href
+// branches on it.
+function convertLink(node, ctx) {
+  const attribs = node.attribs || {};
+  const href = attribs.href || '';
+  const inner = walkChildren(node, ctx);
+
+  if (href.startsWith('#')) {
+    const anchor = href.slice(1);
+    const text = decodeEntities(inner);
+    return `<ac:link ac:anchor="${anchor}"><ac:plain-text-link-body><![CDATA[${text}]]></ac:plain-text-link-body></ac:link>`;
+  }
+
+  switch (ctx.linkStyle) {
+  case 'smart': {
+    // Spread order forces policy: any pre-existing `data-card-appearance`
+    // on the source `<a>` is overwritten — smart links must be inline.
+    const merged = { ...attribs, 'data-card-appearance': 'inline' };
+    return `<a${renderAttrs(merged)}>${inner}</a>`;
+  }
+  case 'wiki':
+    return `<ac:link><ri:url ri:value="${href}" /><ac:plain-text-link-body><![CDATA[${inner}]]></ac:plain-text-link-body></ac:link>`;
+  case 'plain':
+  default:
+    return `<a${renderAttrs(attribs)}>${inner}</a>`;
+  }
+}
+
+// `> **INFO|WARNING|NOTE**` blockquotes become callout macros; others pass
+// through. Detection runs structurally on the DOM so false-positives for
+// mid-paragraph `**INFO**` are ruled out — the strong must be the first
+// meaningful child of the first paragraph.
+//
+// Two markdown-it shapes:
+//   separated: `<blockquote><p><strong>INFO</strong></p><p>body</p></blockquote>`
+//   same-line: `<blockquote><p><strong>INFO</strong>\nbody</p></blockquote>`
+function detectBlockquoteCallout(node) {
+  const kids = meaningfulChildren(node);
+  if (kids.length === 0) return null;
+  const firstP = kids[0];
+  if (firstP.type !== 'tag' || firstP.name !== 'p') return null;
+  const pKids = firstP.children || [];
+  const firstIdx = pKids.findIndex((c) => !isWhitespaceOnly(c));
+  if (firstIdx < 0) return null;
+  const strong = pKids[firstIdx];
+  if (strong.type !== 'tag' || strong.name !== 'strong') return null;
+  const strongKids = meaningfulChildren(strong);
+  if (strongKids.length !== 1 || strongKids[0].type !== 'text') return null;
+  const marker = CALLOUT_MARKERS.find((m) => strongKids[0].data === m.toUpperCase());
+  if (!marker) return null;
+  const tail = pKids.slice(firstIdx + 1);
+  const tailHasContent = tail.some((c) => !isWhitespaceOnly(c));
+  if (tailHasContent) {
+    // Check tail[0] (not the first meaningful child): the body of
+    // `> **INFO**\n> body` must literally start with a newline. A leading
+    // whitespace-only text node without a newline (`<strong>INFO</strong>
+    // body`) is prose continuation, not callout — it must be rejected here
+    // even though `meaningfulChildren` would otherwise look past it.
+    if (tail[0].type !== 'text' || !/^\s*\n/.test(tail[0].data)) return null;
+  }
+  return { marker, sameLine: tailHasContent, markerP: firstP, tail };
+}
+
+function convertBlockquote(node, ctx) {
+  const detected = detectBlockquoteCallout(node);
+  if (!detected) {
+    return `<blockquote>${walkChildren(node, ctx)}</blockquote>`;
+  }
+  const { marker, sameLine, markerP, tail } = detected;
+  const blockquoteKids = node.children || [];
+  let body;
+  if (sameLine) {
+    // Same-line form: the strong's siblings inside the marker paragraph form
+    // the body of the first `<p>`. Strip the leading newline that markdown-it
+    // emits between strong and body text.
+    const firstPBody = tail.map((c) => walkNode(c, ctx)).join('').replace(/^\s*\n/, '');
+    const rest = blockquoteKids
+      .filter((c) => c !== markerP)
+      .map((c) => walkNode(c, ctx))
+      .join('');
+    body = `<p>${firstPBody}</p>${rest}`;
+  } else {
+    // Separated form: drop the marker paragraph entirely and walk the rest.
+    // Leading whitespace from the now-removed paragraph's neighbor text node
+    // is trimmed.
+    body = blockquoteKids
+      .filter((c) => c !== markerP)
+      .map((c) => walkNode(c, ctx))
+      .join('')
+      .replace(/^\s+/, '');
+  }
+  return `<ac:structured-macro ac:name="${marker}">
+          <ac:rich-text-body>${body}</ac:rich-text-body>
+        </ac:structured-macro>`;
+}
+
+// Strict `<pre><code>` adjacency only — `<pre>` with whitespace siblings or
+// any other shape falls through as plain `<pre>`. The body needs manual
+// entity decode because the parser keeps entities raw and CDATA is opaque
+// downstream.
+function convertCodeBlock(node, ctx) {
+  const children = node.children || [];
+  const isCodeBlock = children.length === 1 &&
+    children[0].type === 'tag' &&
+    children[0].name === 'code';
+  if (!isCodeBlock) {
+    return `<pre>${walkChildren(node, ctx)}</pre>`;
+  }
+  const codeNode = children[0];
+  const classAttr = codeNode.attribs.class || '';
+  const langMatch = classAttr.match(/language-(\w+)/);
+  const language = langMatch ? langMatch[1] : 'text';
+  let body = '';
+  for (const c of codeNode.children || []) {
+    if (c.type === 'text') body += c.data;
+  }
+  body = decodeEntities(body.replace(/\n$/, ''), { preserveDouble: true })
+    .replace(/]]>/g, ']]]]><![CDATA[>');
+  return `<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">${language}</ac:parameter><ac:plain-text-body><![CDATA[${body}]]></ac:plain-text-body></ac:structured-macro>`;
+}
+
+// Re-escape literal `"` inside attribute values. htmlparser2 with
+// `decodeEntities: false` keeps source-escaped entities intact, but a
+// single-quoted source attribute (`<a title='he said "hi"'>`) lands a
+// literal `"` here that would close the emitted double-quoted slot and
+// corrupt the XML. `&` is left as-is so already-escaped sources
+// (`&amp;`, `&quot;`, …) round-trip cleanly.
+//
+// Trust boundary: input is assumed to be valid HTML. A valid HTML
+// attribute value cannot contain raw `<` or `>` (they must be entities),
+// so they're not escaped here. Malformed input that smuggles raw
+// angle brackets through would produce malformed XML.
+function escapeAttrValue(v) {
+  return String(v).replace(/"/g, '&quot;');
+}
+
+function renderAttrs(attribs) {
+  if (!attribs) return '';
+  return Object.keys(attribs)
+    .map((k) => ` ${k}="${escapeAttrValue(attribs[k])}"`)
+    .join('');
+}
+
+function walkChildren(node, ctx) {
+  if (!node.children) return '';
+  const children = node.children;
+  const out = [];
+  let i = 0;
+  while (i < children.length) {
+    const child = children[i];
+    // Sibling-level EXPAND span — collapse open/close pair into one macro
+    // with everything between as the body. Pairs the first EXPAND_END
+    // after this open: a nested EXPAND open/close pair inside the body
+    // would have its close consumed by the outer open, leaving the
+    // second close as an orphan paragraph. Same non-greedy behavior as
+    // the previous regex pipeline.
+    if (isExpandOpen(child)) {
+      const endIdx = children.findIndex((c, j) => j > i && isExpandClose(c));
+      if (endIdx !== -1) {
+        const titleStrong = child.children[0];
+        const titleHtml = walkChildren(titleStrong, ctx).replace(/^EXPAND: /, '');
+        // Confluence's `<ac:parameter>` normalizer is text-only (rejects `<s>`
+        // with HTTP 500, silently truncates at the first '<'). Strip literal
+        // tags; entities survive because the rule requires a literal '<'.
+        const cleanTitle = titleHtml.replace(/<[^>]+>/g, '').trim();
+        const bodyHtml = children
+          .slice(i + 1, endIdx)
+          .map((c) => walkNode(c, ctx))
+          .join('')
+          .trim();
+        out.push(`<ac:structured-macro ac:name="expand"><ac:parameter ac:name="title">${cleanTitle}</ac:parameter><ac:rich-text-body>${bodyHtml}</ac:rich-text-body></ac:structured-macro>`);
+        i = endIdx + 1;
+        continue;
+      }
+    }
+    out.push(walkNode(child, ctx));
+    i++;
+  }
+  return out.join('');
+}
+
+function walkNode(node, ctx) {
+  if (node.type === 'text') return node.data;
+  if (node.type !== 'tag') return '';
+  if (++ctx.depth > ctx.maxDepth) {
+    ctx.depth--;
+    throw new HtmlDepthExceededError(ctx.maxDepth);
+  }
+  try {
+    return dispatchTag(node, ctx);
+  } finally {
+    ctx.depth--;
+  }
+}
+
+function dispatchTag(node, ctx) {
+  switch (node.name) {
+  case 'p': {
+    const marker = detectParagraphMarker(node);
+    if (marker && marker.kind === 'toc') return '<ac:structured-macro ac:name="toc" />';
+    if (marker && marker.kind === 'anchor') {
+      return `<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">${marker.id}</ac:parameter></ac:structured-macro>`;
+    }
+    return `<p${renderAttrs(node.attribs)}>${walkChildren(node, ctx)}</p>`;
+  }
+  case 'h1':
+  case 'h2':
+  case 'h3':
+  case 'h4':
+  case 'h5':
+  case 'h6':
+  case 'strong':
+  case 'em':
+    return `<${node.name}${renderAttrs(node.attribs)}>${walkChildren(node, ctx)}</${node.name}>`;
+  case 'hr':
+    return '<hr />';
+  case 'br':
+    return '<br>';
+  case 'img':
+    return `<img${renderAttrs(node.attribs)}>`;
+  case 'ul':
+  case 'ol':
+    return `<${node.name}>${walkChildren(node, ctx)}</${node.name}>`;
+  case 'li': {
+    const inner = walkChildren(node, ctx);
+    return shouldWrapInP(node) ? `<li><p>${inner}</p></li>` : `<li>${inner}</li>`;
+  }
+  case 'pre':
+    return convertCodeBlock(node, ctx);
+  case 'code':
+    // Inline only — `<code>` inside `<pre>` is consumed by convertCodeBlock.
+    return `<code${renderAttrs(node.attribs)}>${walkChildren(node, ctx)}</code>`;
+  case 'a':
+    return convertLink(node, ctx);
+  case 'blockquote':
+    return convertBlockquote(node, ctx);
+  case 'table':
+  case 'thead':
+  case 'tbody':
+  case 'tfoot':
+  case 'tr':
+    return `<${node.name}${renderAttrs(node.attribs)}>${walkChildren(node, ctx)}</${node.name}>`;
+  case 'th':
+  case 'td': {
+    const inner = walkChildren(node, ctx);
+    const open = `<${node.name}${renderAttrs(node.attribs)}>`;
+    return shouldWrapInP(node) ? `${open}<p>${inner}</p></${node.name}>` : `${open}${inner}</${node.name}>`;
+  }
+  default:
+    if (VOID_TAGS.has(node.name)) {
+      return `<${node.name}${renderAttrs(node.attribs)} />`;
+    }
+    return `<${node.name}${renderAttrs(node.attribs)}>${walkChildren(node, ctx)}</${node.name}>`;
+  }
+}
+
+function htmlToStorage(html, options = {}) {
+  const isCloud = !!options.isCloud;
+  const linkStyle = VALID_LINK_STYLES.includes(options.linkStyle)
+    ? options.linkStyle
+    : (isCloud ? 'smart' : 'wiki');
+  const ctx = {
+    linkStyle,
+    depth: 0,
+    maxDepth: typeof options.maxDepth === 'number' ? options.maxDepth : DEFAULT_MAX_DEPTH,
+  };
+  return walkChildren(parseDocument(html, { decodeEntities: false }), ctx);
+}
+
+module.exports = { htmlToStorage, HtmlDepthExceededError };

--- a/lib/macro-converter.js
+++ b/lib/macro-converter.js
@@ -1,5 +1,6 @@
 const MarkdownIt = require('markdown-it');
 const { StorageWalker } = require('./storage-walker');
+const { htmlToStorage } = require('./html-to-storage');
 
 const VALID_LINK_STYLES = ['smart', 'plain', 'wiki'];
 const CALLOUT_MARKERS = ['info', 'warning', 'note'];
@@ -39,9 +40,7 @@ class MacroConverter {
 
       // Anchor `[!info]` to the start of a line (string start or after a
       // newline) so prose mid-paragraph, headings on the same line, and
-      // `> [!info]` GitHub-style alerts are left alone. The latter would
-      // otherwise expand to a nested blockquote that the storage handler's
-      // lazy regex cannot balance, producing malformed XML.
+      // `> [!info]` GitHub-style alerts are left alone.
       for (const m of CALLOUT_MARKERS) {
         const re = new RegExp(`(^|\\n)\\[!${m}\\]\\s*([\\s\\S]*?)(?=\\n\\s*\\n|\\n\\s*\\[!|$)`, 'g');
         state.src = state.src.replace(re, (_, pre, content) =>
@@ -68,129 +67,7 @@ class MacroConverter {
   }
 
   htmlToConfluenceStorage(html) {
-    let storage = html;
-
-    storage = storage.replace(/<h([1-6])>(.*?)<\/h[1-6]>/g, '<h$1>$2</h$1>');
-
-    storage = storage.replace(/<p>(.*?)<\/p>/g, '<p>$1</p>');
-
-    storage = storage.replace(/<strong>(.*?)<\/strong>/g, '<strong>$1</strong>');
-
-    storage = storage.replace(/<em>(.*?)<\/em>/g, '<em>$1</em>');
-
-    storage = storage.replace(/<ul>(.*?)<\/ul>/gs, '<ul>$1</ul>');
-    storage = storage.replace(/<li>(.*?)<\/li>/g, '<li><p>$1</p></li>');
-
-    storage = storage.replace(/<ol>(.*?)<\/ol>/gs, '<ol>$1</ol>');
-
-    storage = storage.replace(/<pre><code(?:\s+class="language-(\w+)")?>(.*?)<\/code><\/pre>/gs, (_, lang, code) => {
-      const language = lang || 'text';
-      const decodedCode = code.replace(/\n$/, '')
-        .replace(/&quot;/g, '"')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .replace(/&amp;/g, '&');
-      const safeCode = decodedCode.replace(/]]>/g, ']]]]><![CDATA[>');
-      return `<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">${language}</ac:parameter><ac:plain-text-body><![CDATA[${safeCode}]]></ac:plain-text-body></ac:structured-macro>`;
-    });
-
-    storage = storage.replace(/<code>(.*?)<\/code>/g, '<code>$1</code>');
-
-    // **TOC** paragraph → Confluence Table of Contents macro (uses macro defaults)
-    storage = storage.replace(
-      /<p><strong>TOC<\/strong><\/p>/g,
-      '<ac:structured-macro ac:name="toc" />'
-    );
-
-    storage = storage.replace(/<blockquote>(.*?)<\/blockquote>/gs, (_, content) => {
-      // Detect the marker only when it sits at the very start of the first
-      // paragraph, immediately followed by a `</p>` close (separated form) or
-      // a `\n` (same-line body form). This is the same anchor condition the
-      // strip step uses below, so detection and stripping stay in sync.
-      // Without this anchor, a quotation that merely *mentions* `**INFO**` —
-      // e.g. `> Use **INFO** at the start.` — would be silently wrapped in an
-      // info macro, surprising the author.
-      const marker = CALLOUT_MARKERS.find((m) =>
-        new RegExp(`<p><strong>${m.toUpperCase()}<\\/strong>(<\\/p>|\\s*\\n)`).test(content)
-      );
-      if (!marker) {
-        // Plain blockquote — `> …` is a quotation, not an alert. Use the
-        // `> **INFO**` / `> **WARNING**` / `> **NOTE**` markers above to
-        // produce a Confluence info / warning / note macro instead.
-        return `<blockquote>${content}</blockquote>`;
-      }
-      // Strip the leading `<strong>MARKER</strong>`. markdown-it produces two
-      // shapes depending on whether a blank `>` line separates marker and body:
-      //   case A (separated):  `<p><strong>MARKER</strong></p>\n<p>body</p>`
-      //   case B (same-line):  `<p><strong>MARKER</strong>\nbody</p>`
-      // The original cleanup only handled case A, so case B leaked the marker
-      // into the rendered macro body. README's recommended `> **INFO**\n> body`
-      // form parses as case B — exactly the form that broke.
-      const cleanContent = content.replace(
-        new RegExp(`<p><strong>${marker.toUpperCase()}<\\/strong>(<\\/p>\\s*|\\s*\\n)`),
-        (_, tail) => tail.startsWith('</p>') ? '' : '<p>'
-      );
-      return `<ac:structured-macro ac:name="${marker}">
-          <ac:rich-text-body>${cleanContent}</ac:rich-text-body>
-        </ac:structured-macro>`;
-    });
-
-    storage = storage.replace(/<table>(.*?)<\/table>/gs, '<table>$1</table>');
-    storage = storage.replace(/<thead>(.*?)<\/thead>/gs, '<thead>$1</thead>');
-    storage = storage.replace(/<tbody>(.*?)<\/tbody>/gs, '<tbody>$1</tbody>');
-    storage = storage.replace(/<tr>(.*?)<\/tr>/gs, '<tr>$1</tr>');
-    storage = storage.replace(/<th>(.*?)<\/th>/g, '<th><p>$1</p></th>');
-    storage = storage.replace(/<td>(.*?)<\/td>/g, '<td><p>$1</p></td>');
-
-    // **ANCHOR: id** paragraph → Confluence anchor macro
-    storage = storage.replace(
-      /<p><strong>ANCHOR: (.*?)<\/strong><\/p>/g,
-      '<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">$1</ac:parameter></ac:structured-macro>'
-    );
-
-    // **EXPAND: title** … **EXPAND_END** → Confluence expand macro. Runs
-    // after code/blockquote/table conversion so the body can contain those
-    // macros. Strips inline HTML from the title because Confluence's storage
-    // normalizer treats <ac:parameter> as text-only — it silently truncates
-    // at the first '<' and rejects <s> outright with HTTP 500. Entities
-    // (&amp;, &lt;) survive because the regex requires a literal '<'.
-    storage = storage.replace(
-      /<p><strong>EXPAND: (.*?)<\/strong><\/p>\s*([\s\S]*?)\s*<p><strong>EXPAND_END<\/strong><\/p>/g,
-      (_, title, body) => {
-        const cleanTitle = title.replace(/<[^>]+>/g, '').trim();
-        return `<ac:structured-macro ac:name="expand"><ac:parameter ac:name="title">${cleanTitle}</ac:parameter><ac:rich-text-body>${body.trim()}</ac:rich-text-body></ac:structured-macro>`;
-      }
-    );
-
-    // Same-page anchor links (href="#id") → ac:link with ac:anchor. Must run
-    // before the general link conversion below so the #id pattern is not
-    // consumed by the generic <a href> replacement (and so it works under
-    // all linkStyle modes, including "plain" which leaves <a> tags as-is).
-    storage = storage.replace(/<a href="#(.*?)">(.*?)<\/a>/gs, (_, anchor, body) => {
-      const text = body
-        .replace(/&amp;/g, '&')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .replace(/&quot;/g, '"')
-        .replace(/&#39;/g, '\'');
-      return `<ac:link ac:anchor="${anchor}"><ac:plain-text-link-body><![CDATA[${text}]]></ac:plain-text-link-body></ac:link>`;
-    });
-
-    // Convert links based on linkStyle:
-    //   "smart" — Cloud smart links (<a data-card-appearance="inline">)
-    //   "plain" — simple <a href>; workaround for "Cannot handle: DefaultLink"
-    //             errors on custom-domain Cloud instances
-    //   "wiki"  — Server/DC ac:link + ri:url storage format
-    if (this.linkStyle === 'smart') {
-      storage = storage.replace(/<a href="(.*?)">(.*?)<\/a>/g, '<a href="$1" data-card-appearance="inline">$2</a>');
-    } else if (this.linkStyle === 'wiki') {
-      storage = storage.replace(/<a href="(.*?)">(.*?)<\/a>/g, '<ac:link><ri:url ri:value="$1" /><ac:plain-text-link-body><![CDATA[$2]]></ac:plain-text-link-body></ac:link>');
-    }
-    // "plain" — leave <a href> tags as-is
-
-    storage = storage.replace(/<hr\s*\/?>/g, '<hr />');
-
-    return storage;
+    return htmlToStorage(html, { isCloud: this._isCloud, linkStyle: this.linkStyle });
   }
 
   detectLanguageLabels(text) {

--- a/tests/html-to-storage.test.js
+++ b/tests/html-to-storage.test.js
@@ -1,0 +1,376 @@
+const { htmlToStorage, HtmlDepthExceededError } = require('../lib/html-to-storage');
+
+describe('htmlToStorage', () => {
+  describe('text node entities', () => {
+    test('plain text passes through', () => {
+      expect(htmlToStorage('<p>hello</p>')).toBe('<p>hello</p>');
+    });
+
+    test('ampersand entity is preserved verbatim (parser keeps entities raw)', () => {
+      expect(htmlToStorage('<p>a &amp; b</p>')).toBe('<p>a &amp; b</p>');
+    });
+
+    test('angle bracket entities are preserved verbatim', () => {
+      expect(htmlToStorage('<p>1 &lt; 2 &gt; 0</p>')).toBe('<p>1 &lt; 2 &gt; 0</p>');
+    });
+
+    test('literal `"` in text is left literal (matches V1 markdown-it output)', () => {
+      expect(htmlToStorage('<p>he said "hi"</p>')).toBe('<p>he said "hi"</p>');
+    });
+  });
+
+  describe('handled element types', () => {
+    test('headings h1-h6 round-trip', () => {
+      for (let i = 1; i <= 6; i++) {
+        expect(htmlToStorage(`<h${i}>title</h${i}>`)).toBe(`<h${i}>title</h${i}>`);
+      }
+    });
+
+    test('strong / em nest correctly', () => {
+      expect(htmlToStorage('<p>plain <strong>bold <em>inner</em></strong> end</p>'))
+        .toBe('<p>plain <strong>bold <em>inner</em></strong> end</p>');
+    });
+
+    test('hr is normalized to self-closing form (matches V1\'s explicit normalize)', () => {
+      expect(htmlToStorage('<hr>')).toBe('<hr />');
+    });
+
+    test('br stays in markdown-it form `<br>` (V1 does not transform it)', () => {
+      expect(htmlToStorage('<br>')).toBe('<br>');
+    });
+
+    test('img stays in markdown-it form `<img …>` with attributes preserved', () => {
+      expect(htmlToStorage('<img src="x" alt="y">')).toBe('<img src="x" alt="y">');
+    });
+
+    test('attributes on h1-h6 / p / strong / em / inline code are preserved (raw HTML input)', () => {
+      // markdown-it never emits these with attributes, but raw HTML input
+      // through `htmlToConfluenceStorage` does. Walker must preserve them.
+      expect(htmlToStorage('<h1 id="top">Title</h1>'))
+        .toBe('<h1 id="top">Title</h1>');
+      expect(htmlToStorage('<p class="lead">intro</p>'))
+        .toBe('<p class="lead">intro</p>');
+      expect(htmlToStorage('<p>see <strong class="hl">bold</strong> word</p>'))
+        .toBe('<p>see <strong class="hl">bold</strong> word</p>');
+      expect(htmlToStorage('<p>use <code data-x="y">npm</code></p>'))
+        .toBe('<p>use <code data-x="y">npm</code></p>');
+    });
+  });
+
+  describe('list elements', () => {
+    test('tight `<li>` content is wrapped in `<p>` to match V1 regex', () => {
+      expect(htmlToStorage('<ul><li>one</li><li>two</li></ul>'))
+        .toBe('<ul><li><p>one</p></li><li><p>two</p></li></ul>');
+    });
+
+    test('inline children do not prevent the `<p>` wrap', () => {
+      expect(htmlToStorage('<ul><li>text <strong>bold</strong> end</li></ul>'))
+        .toBe('<ul><li><p>text <strong>bold</strong> end</p></li></ul>');
+    });
+
+    test('phrasing-content children (kbd, abbr, etc.) do not prevent the `<p>` wrap', () => {
+      // Raw-HTML input case: V1's single-line regex would wrap any inline
+      // content. The walker treats common phrasing-content elements the
+      // same way for byte parity with V1 on `--input-format html`.
+      expect(htmlToStorage('<ul><li>press <kbd>Ctrl</kbd> to copy</li></ul>'))
+        .toBe('<ul><li><p>press <kbd>Ctrl</kbd> to copy</p></li></ul>');
+    });
+
+    test('block-level child (nested list) suppresses the wrap', () => {
+      const html = '<ul><li>outer<ul><li>inner</li></ul></li></ul>';
+      expect(htmlToStorage(html))
+        .toBe('<ul><li>outer<ul><li><p>inner</p></li></ul></li></ul>');
+    });
+
+    test('newline in a text-node child suppresses the wrap', () => {
+      const html = '<ul>\n<li>line one\nline two</li>\n</ul>';
+      expect(htmlToStorage(html))
+        .toBe('<ul>\n<li>line one\nline two</li>\n</ul>');
+    });
+
+    test('ordered list behaves the same as unordered', () => {
+      expect(htmlToStorage('<ol><li>one</li></ol>'))
+        .toBe('<ol><li><p>one</p></li></ol>');
+    });
+  });
+
+  describe('code blocks', () => {
+    test('fenced code with language → ac:structured-macro with CDATA', () => {
+      const html = '<pre><code class="language-javascript">function() { return 1; }\n</code></pre>';
+      expect(htmlToStorage(html)).toBe(
+        '<ac:structured-macro ac:name="code">' +
+        '<ac:parameter ac:name="language">javascript</ac:parameter>' +
+        '<ac:plain-text-body><![CDATA[function() { return 1; }]]></ac:plain-text-body>' +
+        '</ac:structured-macro>'
+      );
+    });
+
+    test('fenced code without a language defaults to text', () => {
+      const html = '<pre><code>plain code</code></pre>';
+      expect(htmlToStorage(html)).toContain('<ac:parameter ac:name="language">text</ac:parameter>');
+    });
+
+    test('html entities in code body are emitted decoded inside CDATA', () => {
+      const html = '<pre><code class="language-html">&lt;blockquote&gt;</code></pre>';
+      expect(htmlToStorage(html)).toContain('<![CDATA[<blockquote>]]>');
+    });
+
+    test(']]> in code body is escaped via CDATA section split', () => {
+      const html = '<pre><code>foo]]&gt;bar</code></pre>';
+      expect(htmlToStorage(html)).toContain('foo]]]]><![CDATA[>bar');
+    });
+
+    test('code body preserves double-encoding (`&amp;lt;` round-trips as `&lt;`)', () => {
+      // preserveDouble:true ordering: amp runs last, so the literal entity
+      // payload survives. Without it, the body would over-decode to `<`.
+      const html = '<pre><code>&amp;lt;tag&amp;gt;</code></pre>';
+      expect(htmlToStorage(html)).toContain('<![CDATA[&lt;tag&gt;]]>');
+    });
+
+    test('code body decodes single-encoded entities normally', () => {
+      // Verifies preserveDouble:true still decodes single-encoded entities
+      // (the four it knows about). `&quot;` → `"`, `&amp;` → `&`.
+      const html = '<pre><code>a &amp; b &quot;c&quot;</code></pre>';
+      expect(htmlToStorage(html)).toContain('<![CDATA[a & b "c"]]>');
+    });
+
+    test('inline `<code>` is identity (not transformed to a macro)', () => {
+      expect(htmlToStorage('<p>see <code>x &lt; y</code></p>'))
+        .toBe('<p>see <code>x &lt; y</code></p>');
+    });
+
+    test('`<pre>` without a single `<code>` child is left as plain pre', () => {
+      expect(htmlToStorage('<pre>raw block</pre>')).toBe('<pre>raw block</pre>');
+    });
+
+    test('`<pre>` with whitespace siblings around `<code>` is not transformed', () => {
+      // V1's regex requires `<pre><code...>` adjacency; whitespace defeats it.
+      const html = '<pre>\n<code>hi</code>\n</pre>';
+      expect(htmlToStorage(html)).toBe('<pre>\n<code>hi</code>\n</pre>');
+    });
+  });
+
+  describe('passthrough fallback for unhandled tags', () => {
+    test('attributes on unhandled tags are preserved', () => {
+      const out = htmlToStorage('<aside data-x="y"><span>note</span></aside>');
+      expect(out).toBe('<aside data-x="y"><span>note</span></aside>');
+    });
+
+    test('attribute values with `&quot;` entities are preserved verbatim', () => {
+      const out = htmlToStorage('<details title="he said &quot;hi&quot;">x</details>');
+      expect(out).toBe('<details title="he said &quot;hi&quot;">x</details>');
+    });
+  });
+
+  describe('blockquote and callout markers', () => {
+    test('plain blockquote stays a blockquote', () => {
+      expect(htmlToStorage('<blockquote><p>quote</p></blockquote>'))
+        .toBe('<blockquote><p>quote</p></blockquote>');
+    });
+
+    test('INFO marker (paragraph-separated form) becomes info macro', () => {
+      const html = '<blockquote>\n<p><strong>INFO</strong></p>\n<p>body</p>\n</blockquote>';
+      const out = htmlToStorage(html);
+      expect(out).toContain('<ac:structured-macro ac:name="info">');
+      expect(out).toContain('<p>body</p>');
+      expect(out).not.toContain('<strong>INFO</strong>');
+    });
+
+    test('INFO marker (same-line form) becomes info macro and strips marker text', () => {
+      const html = '<blockquote>\n<p><strong>INFO</strong>\nbody</p>\n</blockquote>';
+      const out = htmlToStorage(html);
+      expect(out).toContain('<ac:structured-macro ac:name="info">');
+      expect(out).toContain('<p>body</p>');
+      expect(out).not.toContain('<strong>INFO</strong>');
+    });
+
+    test('WARNING and NOTE markers map to their respective macros', () => {
+      expect(htmlToStorage('<blockquote><p><strong>WARNING</strong>\nx</p></blockquote>'))
+        .toContain('<ac:structured-macro ac:name="warning">');
+      expect(htmlToStorage('<blockquote><p><strong>NOTE</strong>\nx</p></blockquote>'))
+        .toContain('<ac:structured-macro ac:name="note">');
+    });
+
+    test('mid-paragraph **INFO** does NOT trigger marker conversion (false-positive guard)', () => {
+      const html = '<blockquote><p>see <strong>INFO</strong> at the start.</p></blockquote>';
+      const out = htmlToStorage(html);
+      expect(out).not.toContain('ac:structured-macro');
+      expect(out).toContain('<blockquote>');
+    });
+
+    test('nested INFO inside outer blockquote keeps outer balanced', () => {
+      const html = '<blockquote>\n<blockquote>\n<p><strong>INFO</strong>\ninner</p>\n</blockquote>\n</blockquote>';
+      const out = htmlToStorage(html);
+      expect(out).toMatch(/<blockquote>[\s\S]*<ac:structured-macro ac:name="info">[\s\S]*<\/ac:structured-macro>[\s\S]*<\/blockquote>/);
+      expect(out).not.toMatch(/<\/ac:structured-macro>\s*<\/blockquote>\s*<\/blockquote>/);
+    });
+  });
+
+  describe('paragraph marker patterns', () => {
+    test('`<p><strong>TOC</strong></p>` becomes the toc macro', () => {
+      expect(htmlToStorage('<p><strong>TOC</strong></p>'))
+        .toBe('<ac:structured-macro ac:name="toc" />');
+    });
+
+    test('`<p><strong>ANCHOR: id</strong></p>` becomes the anchor macro', () => {
+      expect(htmlToStorage('<p><strong>ANCHOR: my-section</strong></p>'))
+        .toBe('<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">my-section</ac:parameter></ac:structured-macro>');
+    });
+
+    test('paragraph marker detection requires the strict shape (extra text falls through)', () => {
+      // Embellished — extra text outside the strong → plain paragraph
+      expect(htmlToStorage('<p>see <strong>TOC</strong></p>'))
+        .toBe('<p>see <strong>TOC</strong></p>');
+    });
+
+    test('EXPAND open + close paragraphs collapse into the expand macro', () => {
+      const html = '<p><strong>EXPAND: Show</strong></p>\n<p>body</p>\n<p><strong>EXPAND_END</strong></p>';
+      const out = htmlToStorage(html);
+      expect(out).toContain('<ac:structured-macro ac:name="expand">');
+      expect(out).toContain('<ac:parameter ac:name="title">Show</ac:parameter>');
+      expect(out).toContain('<p>body</p>');
+      expect(out).not.toContain('<strong>EXPAND');
+    });
+
+    test('EXPAND title with inline HTML is stripped (matches V1 cleanTitle rule)', () => {
+      const html = '<p><strong>EXPAND: a <em>b</em> c</strong></p>\n<p>body</p>\n<p><strong>EXPAND_END</strong></p>';
+      const out = htmlToStorage(html);
+      expect(out).toContain('<ac:parameter ac:name="title">a b c</ac:parameter>');
+      expect(out).not.toContain('<em>');
+    });
+
+    test('EXPAND without a matching close is left as plain paragraphs', () => {
+      const html = '<p><strong>EXPAND: orphan</strong></p>\n<p>body</p>';
+      const out = htmlToStorage(html);
+      expect(out).not.toContain('ac:structured-macro');
+      expect(out).toContain('<p><strong>EXPAND: orphan</strong></p>');
+    });
+
+    test('EXPAND_END detection tolerates trailing whitespace text nodes inside <p>', () => {
+      // Defensive: if a parser variation emits `<p><strong>EXPAND_END</strong>\n</p>`
+      // (with a trailing whitespace text node inside the paragraph), the close
+      // is still detected and the macro still collapses.
+      const html = '<p><strong>EXPAND: t</strong>\n</p>\n<p>body</p>\n<p><strong>EXPAND_END</strong>\n</p>';
+      const out = htmlToStorage(html);
+      expect(out).toContain('<ac:structured-macro ac:name="expand">');
+      expect(out).toContain('<ac:parameter ac:name="title">t</ac:parameter>');
+    });
+
+    test('TOC marker detection tolerates trailing whitespace text nodes', () => {
+      const html = '<p><strong>TOC</strong>\n</p>';
+      expect(htmlToStorage(html)).toBe('<ac:structured-macro ac:name="toc" />');
+    });
+  });
+
+  describe('tables', () => {
+    test('table / thead / tbody / tr emit verbatim with children walked', () => {
+      const html = '<table><thead><tr><th>h</th></tr></thead><tbody><tr><td>c</td></tr></tbody></table>';
+      // th and td additionally wrap their inline content in <p> per V1 quirk
+      expect(htmlToStorage(html)).toBe(
+        '<table><thead><tr><th><p>h</p></th></tr></thead><tbody><tr><td><p>c</p></td></tr></tbody></table>'
+      );
+    });
+
+    test('th / td with inline children get the `<p>` wrap', () => {
+      const html = '<table><tbody><tr><td>plain <strong>bold</strong></td></tr></tbody></table>';
+      expect(htmlToStorage(html)).toBe(
+        '<table><tbody><tr><td><p>plain <strong>bold</strong></p></td></tr></tbody></table>'
+      );
+    });
+
+    test('th / td whose content spans multiple lines do NOT get the wrap', () => {
+      const html = '<table><tbody><tr><td>line one\nline two</td></tr></tbody></table>';
+      expect(htmlToStorage(html)).toBe(
+        '<table><tbody><tr><td>line one\nline two</td></tr></tbody></table>'
+      );
+    });
+  });
+
+  describe('links', () => {
+    test('plain mode is identity (preserves all attributes)', () => {
+      const html = '<a href="https://example.com" title="t">link</a>';
+      expect(htmlToStorage(html, { linkStyle: 'plain' })).toBe(html);
+    });
+
+    test('smart mode adds data-card-appearance and keeps other attributes', () => {
+      const html = '<a href="https://example.com" title="tooltip">link</a>';
+      expect(htmlToStorage(html, { linkStyle: 'smart' })).toBe(
+        '<a href="https://example.com" title="tooltip" data-card-appearance="inline">link</a>'
+      );
+    });
+
+    test('wiki mode rewrites to ac:link + ri:url with CDATA body', () => {
+      expect(htmlToStorage('<a href="https://example.com">link</a>', { linkStyle: 'wiki' }))
+        .toBe('<ac:link><ri:url ri:value="https://example.com" /><ac:plain-text-link-body><![CDATA[link]]></ac:plain-text-link-body></ac:link>');
+    });
+
+    test('default linkStyle is `wiki` for server (isCloud:false) and `smart` for cloud', () => {
+      const a = '<a href="x">y</a>';
+      expect(htmlToStorage(a, { isCloud: false })).toContain('<ac:link>');
+      expect(htmlToStorage(a, { isCloud: true })).toContain('data-card-appearance="inline"');
+    });
+
+    test('anchor link (`#id`) becomes ac:link with ac:anchor regardless of linkStyle', () => {
+      const html = '<a href="#section">jump</a>';
+      const expected = '<ac:link ac:anchor="section"><ac:plain-text-link-body><![CDATA[jump]]></ac:plain-text-link-body></ac:link>';
+      expect(htmlToStorage(html, { linkStyle: 'smart' })).toBe(expected);
+      expect(htmlToStorage(html, { linkStyle: 'wiki' })).toBe(expected);
+      expect(htmlToStorage(html, { linkStyle: 'plain' })).toBe(expected);
+    });
+
+    test('anchor link body decodes the entity set V1 decodes', () => {
+      const html = '<a href="#x">a &amp; b &lt;c&gt;</a>';
+      expect(htmlToStorage(html, { linkStyle: 'wiki' }))
+        .toContain('<![CDATA[a & b <c>]]>');
+    });
+  });
+
+  describe('whitespace and structure', () => {
+    test('newlines between elements are preserved', () => {
+      const html = '<h1>A</h1>\n<h2>B</h2>\n';
+      expect(htmlToStorage(html)).toBe(html);
+    });
+
+    test('multiple top-level paragraphs are walked in order', () => {
+      const html = '<p>one</p>\n<p>two</p>\n<p>three</p>\n';
+      expect(htmlToStorage(html)).toBe(html);
+    });
+  });
+
+  describe('attribute value escaping', () => {
+    test('literal `"` from a single-quoted source attribute is escaped to &quot;', () => {
+      // htmlparser2 accepts single-quoted attribute values containing literal
+      // double quotes. Without escape on emit, the resulting double-quoted
+      // attribute slot would be closed mid-value and corrupt the XML.
+      const out = htmlToStorage('<details title=\'he said "hi"\'>x</details>');
+      expect(out).toBe('<details title="he said &quot;hi&quot;">x</details>');
+    });
+
+    test('literal `"` in a smart-link href is escaped on emit', () => {
+      // The smart-link branch spreads attribs into a new object; the same
+      // escape must apply there. Single-quoted href is the realistic vector
+      // (ampersand-rich URLs in single-quoted attributes).
+      const html = '<a href=\'q?a="b"\'>l</a>';
+      expect(htmlToStorage(html, { linkStyle: 'smart' }))
+        .toBe('<a href="q?a=&quot;b&quot;" data-card-appearance="inline">l</a>');
+    });
+  });
+
+  describe('max-depth guard', () => {
+    test('throws HtmlDepthExceededError on pathologically deep nesting rather than crashing the process', () => {
+      // Build a 1000-deep chain of <div> wrappers — well past the default cap
+      // of 256. A native stack overflow would abort any caller mid-convert; a
+      // typed error lets the caller skip the input and continue. Mirrors the
+      // storage-walker test in tests/macro-converter.test.js.
+      const html = '<div>'.repeat(1000) + 'x' + '</div>'.repeat(1000);
+      expect(() => htmlToStorage(html)).toThrow(HtmlDepthExceededError);
+    });
+
+    test('within-limit nesting (50 levels) walks without error', () => {
+      // 50 levels comfortably exceeds realistic markdown-it output depth but
+      // stays well under the 256 cap, so it must succeed.
+      const html = '<div>'.repeat(50) + 'x' + '</div>'.repeat(50);
+      expect(() => htmlToStorage(html)).not.toThrow();
+    });
+  });
+});

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -214,6 +214,49 @@ describe('MacroConverter markdownToStorage marker conventions', () => {
     });
   });
 
+  describe('nested blockquote balanced parsing', () => {
+    test('nested blockquote with INFO marker on inner level keeps outer balanced', () => {
+      const result = converter.markdownToStorage('> > **INFO**\n> > body');
+      // outer blockquote wraps the inner info macro; nothing dangles outside
+      expect(result).toMatch(/<blockquote>[\s\S]*<ac:structured-macro ac:name="info">[\s\S]*<\/ac:structured-macro>[\s\S]*<\/blockquote>/);
+      expect(result).not.toMatch(/<\/ac:structured-macro>\s*<\/blockquote>\s*<\/blockquote>/);
+    });
+
+    test('plain nested blockquote without any marker preserves both levels', () => {
+      const result = converter.markdownToStorage('> > nested quote');
+      expect(result).toMatch(/<blockquote>\s*<blockquote>[\s\S]*<\/blockquote>\s*<\/blockquote>/);
+      expect(result).not.toContain('ac:structured-macro');
+    });
+
+    test('INFO marker on outer with plain nested blockquote inside body', () => {
+      const result = converter.markdownToStorage('> **INFO**\n>\n> > nested inside info');
+      // info macro contains the inner plain blockquote — no stray outer </blockquote> outside the macro
+      expect(result).toMatch(/<ac:structured-macro ac:name="info">[\s\S]*<blockquote>[\s\S]*<\/blockquote>[\s\S]*<\/ac:structured-macro>/);
+      const macroEnd = result.indexOf('</ac:structured-macro>');
+      expect(result.slice(macroEnd)).not.toContain('</blockquote>');
+    });
+
+    test('three-level nesting with INFO marker at deepest level keeps both outer levels balanced', () => {
+      const result = converter.markdownToStorage('> > > **INFO**\n> > > body');
+      // two outer blockquotes wrap the innermost info macro
+      expect(result).toMatch(
+        /<blockquote>[\s\S]*<blockquote>[\s\S]*<ac:structured-macro ac:name="info">[\s\S]*<\/ac:structured-macro>[\s\S]*<\/blockquote>[\s\S]*<\/blockquote>/
+      );
+      // depth tracking past two: no inner close should leak past the outer pair
+      expect(result).not.toMatch(/<\/ac:structured-macro>\s*<\/blockquote>\s*<\/blockquote>\s*<\/blockquote>/);
+    });
+
+    test('two sibling top-level blockquotes with different markers each become their own macro', () => {
+      const result = converter.markdownToStorage('> **INFO**\n> info body\n\n> **WARNING**\n> warning body');
+      // both macros are emitted as siblings; the walker advances past the first match cleanly
+      expect(result).toMatch(
+        /<ac:structured-macro ac:name="info">[\s\S]*<\/ac:structured-macro>[\s\S]*<ac:structured-macro ac:name="warning">[\s\S]*<\/ac:structured-macro>/
+      );
+      // neither sibling leaks a plain <blockquote> wrapper
+      expect(result).not.toContain('<blockquote>');
+    });
+  });
+
   describe('admonition preprocessor respects markdown context', () => {
     // The previous raw-text preprocessor would transform any `[!info]`
     // anywhere in the source — including inside fenced code blocks, inline
@@ -256,11 +299,6 @@ describe('MacroConverter markdownToStorage marker conventions', () => {
     });
 
     test('GitHub-style `> [!info]` defers to plain blockquote', () => {
-      // Recognizing `> [!info]` here would emit nested blockquote tokens
-      // that the storage handler's lazy regex can't balance — producing
-      // malformed XML that Confluence rejects with 400. Until the storage
-      // handler supports balanced blockquote parsing, this form must fall
-      // through to a plain `<blockquote>` containing literal `[!info]`.
       const result = converter.markdownToStorage('> [!info]\n> body');
       expect(result).toContain('<blockquote>');
       expect(result).toContain('[!info]');
@@ -894,5 +932,49 @@ describe('MacroConverter storageToMarkdown dynamic fence sizing', () => {
   test('prose with mid-line ``` before a code macro preserves the code body indent', () => {
     const storage = `<p>before \`\`\` after</p>${codeMacro('py', 'def foo():\n    return 1')}`;
     expect(converter.storageToMarkdown(storage)).toBe('before ``` after\n\n```py\ndef foo():\n    return 1\n```');
+  });
+});
+
+describe('MacroConverter integration smoke tests', () => {
+  const converter = new MacroConverter({ isCloud: true });
+
+  test('code fence with literal HTML adjacent to an INFO marker does not corrupt either', () => {
+    // Regression for the CDATA-confused-by-blockquote-literal class: a code
+    // block whose body contains `<blockquote>` literal text used to derail
+    // the regex blockquote walker for any real blockquote that followed.
+    const result = converter.markdownToStorage(
+      '```html\n<blockquote>code</blockquote>\n```\n\n> **INFO**\n> after code'
+    );
+    expect(result).toContain('<![CDATA[<blockquote>code</blockquote>]]>');
+    expect(result).toContain('<ac:structured-macro ac:name="info">');
+    expect(result).toContain('after code');
+  });
+
+  test('htmlToConfluenceStorage transforms raw HTML directly (public CLI/API path)', () => {
+    // `confluence convert --input-format html` and `--format html` go through
+    // this method without first rendering markdown-it, so it must convert
+    // structural HTML on its own.
+    const html = '<blockquote>\n<p><strong>WARNING</strong></p>\n<p>raw html input</p>\n</blockquote>';
+    const result = converter.htmlToConfluenceStorage(html);
+    expect(result).toContain('<ac:structured-macro ac:name="warning">');
+    expect(result).toContain('raw html input');
+    expect(result).not.toContain('<strong>WARNING</strong>');
+  });
+
+  test('task list checkboxes survive as literal text — push-side write is not implemented', () => {
+    // Locks the current limitation. If/when a future change adds proper
+    // ac:task-list emission, this test will fail and signal the change.
+    const result = converter.markdownToStorage('- [ ] open\n- [x] done');
+    expect(result).toContain('<li><p>[ ] open</p></li>');
+    expect(result).toContain('<li><p>[x] done</p></li>');
+    expect(result).not.toContain('ac:task-list');
+  });
+
+  test('table cells receive `<p>` wrap for single-line content', () => {
+    // V1's `<td>(.*?)</td>` non-greedy regex wrapped single-line cells in
+    // `<p>`; the walker reproduces that for byte parity.
+    const result = converter.markdownToStorage('| h |\n|---|\n| c |');
+    expect(result).toContain('<th><p>h</p></th>');
+    expect(result).toContain('<td><p>c</p></td>');
   });
 });


### PR DESCRIPTION
## Background

Companion PR to #137 in the opposite direction. This work was paused as the refactor is fairly large in scope and I wanted to align on the architectural direction. After #137 landed and confirmed the choice (htmlparser2 + DOM walker), this PR resumes that effort, applying the same approach to the reverse path.

## Description

The mirror of #137 in the opposite direction. Replaces the 173-line
regex pipeline in `htmlToConfluenceStorage` (and through it,
`markdownToStorage` / `markdownToNativeStorage`) with an htmlparser2
DOM walker.

The previous regex pipeline had the same structural fragility #137
documented for `storageToMarkdown`:

- Nested `<blockquote>(.*?)</blockquote>` could not track depth across
  nested macros, so `> > **INFO**` lost its outer closing tag.
- CDATA literals containing `<blockquote>` confused the blockquote
  regex from inside code blocks.
- The `[!info]` admonition rewrite had to anchor itself defensively
  because it ran on raw markdown text (#134).
- Marker detection was tightly coupled to markdown-it's exact
  paragraph serialization shape.

Recent fix commits in this area (#132, #134, #136) were all workarounds
for that structural fragility.

## Type of Change

- [x] Code refactoring
- [x] Performance improvement (single parse pass replaces 10+ regex
      passes over the same string)

## What changed

| File | Change |
|------|--------|
| `lib/html-to-storage.js` (new) | DOM walker with handlers for headings, paragraphs, inline formatting, lists (with `<p>`-wrap quirk on tight items), code blocks (CDATA + language + `]]>` split) and inline code, links (smart/plain/wiki + anchor `#id` branch), tables, blockquote with INFO/WARNING/NOTE marker detection, TOC/ANCHOR/EXPAND paragraph markers, and void tags. Parser uses `decodeEntities: false` so text and attribute entities round-trip byte-identical. Recursion is capped at 256 levels via a typed `HtmlDepthExceededError`. |
| `lib/macro-converter.js` | `htmlToConfluenceStorage` shrinks 173 → 2 lines, delegating to `htmlToStorage`. `markdownToStorage` and `markdownToNativeStorage` route through it, so all three methods share the walker backend. |
| `tests/html-to-storage.test.js` (new) | 55 unit tests covering each handler in isolation, including depth-guard guarantees (1000-deep throws, 50-deep succeeds). |
| `tests/macro-converter.test.js` | +5 nested-blockquote regression tests (the original `> > **INFO**` unbalance bug plus three-level nesting and sibling blockquotes), +4 integration smoke tests (CDATA-adjacent-marker, public `htmlToConfluenceStorage` path, task-list literal-text behavior, table-cell `<p>` wrap). |

## Testing

- 548/548 tests pass locally; lint clean.
- Existing macro-converter tests act as the public-API regression net,
  mirroring #137's testing approach.
- New walker unit tests cover handler-level behavior independently of
  markdown-it's serialization shape, including the depth guard.

```
Test Suites: 13 passed, 13 total
Tests:       548 passed, 548 total
```

### Local validation during development

Beyond the committed test suite, walker development used a 19-case
golden fixture A/B diff harness (16 markdown + 3 HTML, covering all
handler categories — headings, blockquote markers and nesting,
admonitions, CDATA-with-HTML, TOC / ANCHOR / EXPAND, tables, link
styles ×3, task lists, deeply nested lists, mixed content, inline
edges) and reached byte parity 0/19 between the V1 entry point and a
direct walker call.

The fixture infrastructure was removed from this PR following #137's
"existing tests act as regression net" approach; the four new
integration smoke tests in `tests/macro-converter.test.js` cover the
corners not transitively covered by existing tests.

## What is intentionally not changed

The markdown-it preprocessor that rewrites the `[!info]` shorthand into
the canonical `> **INFO**` blockquote form (added in #134) stays in
place. It operates on markdown source where line-break information is
needed to support both the `[!info]\nbody` newline form and the
single-line `[!info] body` form. Migrating it to the tree level would
lose the single-line form's body delimiter and silently break
backwards compatibility.

## Behavioral Notes

For raw-HTML input via `--input-format html`, the walker's `<p>`-wrap
behavior on `<li>` / `<th>` / `<td>` differs from the previous regex
pipeline in a few edge cases. The walker decides via inline-tag
membership + newline absence rather than the previous "single-line
regex match" rule:

- **Improvement (most cases)**: A single-line `<li><p>existing</p></li>`
  (loose-list canonical form, common in Confluence storage round-trips)
  no longer gets double-wrapped to `<li><p><p>existing</p></p></li>`.
  The previous regex captured the existing `<p>` and re-wrapped it; the
  walker recognizes `<p>` as a block child and skips wrap.
- **Silent divergence (rare)**: An `<li>` containing only HTML5 phrasing
  elements *not* covered by the walker's `INLINE_TAGS` set (e.g.
  `<meter>`, `<output>`) won't get the `<p>` wrap the regex would have
  applied. markdown-it doesn't emit these so the markdown→storage path
  is unaffected; only hand-authored raw HTML triggers it.

HTML comments (`<!-- ... -->`) in raw HTML input are dropped during
conversion rather than preserved in the output payload. This diverges
from the previous regex pipeline (which left them untouched), but
Confluence's storage layer strips HTML comments server-side regardless,
so the rendered page is unchanged.

Extra `<a>` attributes (`title`, `class`, etc.) on raw-HTML input are
dropped in `wiki` linkStyle output (only `href` is preserved via
`<ri:url ri:value>`). The previous regex pipeline matched only the
exact `<a href="...">` shape and passed any decorated `<a>` through
unchanged. Affects only Server/DC users explicitly choosing `wiki` —
Cloud's storage format does not render the wiki form at all (shown as
"unsupported macro" in the editor), so Cloud defaults to `smart`.

The dominant markdown-it path is byte-identical to the previous regex
pipeline. The CLI `--input-format html` and `--format html` paths
continue to work, now backed by the same walker. The `[!info]`
shorthand path is unchanged from the user's perspective.

## Checklist

- [x] My code follows the style guidelines of this project (lint clean)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


