### PR TITLE
fix(walker): preserve <s>/<del> strikethrough on storage → markdown

### DIFF
--- a/lib/storage-walker.js
+++ b/lib/storage-walker.js
@@ -128,8 +128,6 @@ class StorageWalker {
       return '*' + this.walkNodes(node.children) + '*';
     case 's': case 'del':
       return '~~' + this.walkNodes(node.children) + '~~';
-    case 'u': case 'sub': case 'sup': case 'mark':
-      return `<${tag}>` + this.walkNodes(node.children) + `</${tag}>`;
     case 'code':
       return '`' + this.walkNodes(node.children) + '`';
     case 'br':

--- a/lib/storage-walker.js
+++ b/lib/storage-walker.js
@@ -126,6 +126,10 @@ class StorageWalker {
       return '**' + this.walkNodes(node.children) + '**';
     case 'em': case 'i':
       return '*' + this.walkNodes(node.children) + '*';
+    case 's': case 'del':
+      return '~~' + this.walkNodes(node.children) + '~~';
+    case 'u': case 'sub': case 'sup': case 'mark':
+      return `<${tag}>` + this.walkNodes(node.children) + `</${tag}>`;
     case 'code':
       return '`' + this.walkNodes(node.children) + '`';
     case 'br':

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -833,28 +833,6 @@ describe('MacroConverter storageToMarkdown <s>/<del> strikethrough', () => {
   });
 });
 
-describe('MacroConverter storageToMarkdown raw-HTML inline tags', () => {
-  // Markdown has no native syntax for <u>/<sub>/<sup>/<mark>. Pass them
-  // through as raw HTML so common technical-doc usage (chemistry, math,
-  // highlights) survives storage → markdown export.
-  const converter = new MacroConverter({ isCloud: true });
-
-  test('<u> passes through as raw HTML', () => {
-    const storage = '<p><u>under</u>line</p>';
-    expect(converter.storageToMarkdown(storage)).toBe('<u>under</u>line');
-  });
-
-  test('<sub> and <sup> pass through as raw HTML', () => {
-    const storage = '<p>H<sub>2</sub>O and E=mc<sup>2</sup></p>';
-    expect(converter.storageToMarkdown(storage)).toBe('H<sub>2</sub>O and E=mc<sup>2</sup>');
-  });
-
-  test('<mark> passes through as raw HTML', () => {
-    const storage = '<p>see <mark>this</mark></p>';
-    expect(converter.storageToMarkdown(storage)).toBe('see <mark>this</mark>');
-  });
-});
-
 describe('MacroConverter storageToMarkdown panel formatting', () => {
   const converter = new MacroConverter({ isCloud: true });
 

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -811,6 +811,50 @@ describe('MacroConverter storageToMarkdown ac:image external URL', () => {
   });
 });
 
+describe('MacroConverter storageToMarkdown <s>/<del> strikethrough', () => {
+  // markdownToStorage enables markdown-it's strikethrough plugin, but the
+  // walker had no <s>/<del> handler — both fell through to the default
+  // branch and the wrapper was dropped, losing strikethrough on round-trip.
+  const converter = new MacroConverter({ isCloud: true });
+
+  test('<s> renders as ~~text~~', () => {
+    const storage = '<p><s>old</s> new</p>';
+    expect(converter.storageToMarkdown(storage)).toBe('~~old~~ new');
+  });
+
+  test('<del> renders as ~~text~~ (HTML5 alias)', () => {
+    const storage = '<p><del>removed</del> kept</p>';
+    expect(converter.storageToMarkdown(storage)).toBe('~~removed~~ kept');
+  });
+
+  test('round-trip: ~~old~~ new survives markdown → storage → markdown', () => {
+    const storage = converter.markdownToStorage('~~old~~ new');
+    expect(converter.storageToMarkdown(storage)).toBe('~~old~~ new');
+  });
+});
+
+describe('MacroConverter storageToMarkdown raw-HTML inline tags', () => {
+  // Markdown has no native syntax for <u>/<sub>/<sup>/<mark>. Pass them
+  // through as raw HTML so common technical-doc usage (chemistry, math,
+  // highlights) survives storage → markdown export.
+  const converter = new MacroConverter({ isCloud: true });
+
+  test('<u> passes through as raw HTML', () => {
+    const storage = '<p><u>under</u>line</p>';
+    expect(converter.storageToMarkdown(storage)).toBe('<u>under</u>line');
+  });
+
+  test('<sub> and <sup> pass through as raw HTML', () => {
+    const storage = '<p>H<sub>2</sub>O and E=mc<sup>2</sup></p>';
+    expect(converter.storageToMarkdown(storage)).toBe('H<sub>2</sub>O and E=mc<sup>2</sup>');
+  });
+
+  test('<mark> passes through as raw HTML', () => {
+    const storage = '<p>see <mark>this</mark></p>';
+    expect(converter.storageToMarkdown(storage)).toBe('see <mark>this</mark>');
+  });
+});
+
 describe('MacroConverter storageToMarkdown panel formatting', () => {
   const converter = new MacroConverter({ isCloud: true });
 


### PR DESCRIPTION
## Summary
Add walker handlers for `<s>` / `<del>` so strikethrough survives storage → markdown round-trip. `markdownToStorage` already enables markdown-it's strikethrough plugin, so the regression was inbound-only.

Closes #141

## Scope note (revised)
An earlier revision of this PR also added raw-HTML pass-through for `<u>` / `<sub>` / `<sup>` / `<mark>` (per the policy suggestion in the issue body). Self-review confirmed that breaks `markdown → storage` re-import: `MarkdownIt` is constructed with default `html: false`, so those tags get escaped to literal `&lt;...&gt;` on the next upload — defeating the "preserve information" intent.

That decision is deferred to **#155**. This PR is now scoped to the actual bug only.

## Test plan
- [x] New unit tests for `<s>`, `<del>`, and `~~old~~ new` round-trip
- [x] Full `npx jest` suite (489 passing, no regressions)
- [x] `<s>` inside `<ac:parameter>` still safely stripped — existing expand-title test at tests/macro-converter.test.js:121 covers the HTTP 500 case