### PR TITLE
fix(walker): escape markdown special chars in ri:content-title

### DIFF
--- a/lib/storage-walker.js
+++ b/lib/storage-walker.js
@@ -313,12 +313,13 @@ class StorageWalker {
     if (!riPage) return '';
     const spaceKey = decodeEntities(riPage.attribs['ri:space-key'] || '');
     const title = decodeEntities(riPage.attribs['ri:content-title'] || '');
+    const escapedTitle = this.escapeMarkdownText(title);
     const label = this.labels.includePage || 'Include Page';
     if (spaceKey.startsWith('~')) {
       const spacePath = `display/${spaceKey}/${encodeURIComponent(title)}`;
-      return `\n> 📄 **${label}**: [${title}](${this.buildUrl(`${this.webUrlPrefix}/${spacePath}`)})\n`;
+      return `\n> 📄 **${label}**: [${escapedTitle}](${this.buildUrl(`${this.webUrlPrefix}/${spacePath}`)})\n`;
     }
-    return `\n> 📄 **${label}**: [${title}](${this.buildUrl(`${this.webUrlPrefix}/spaces/${spaceKey}/pages/[PAGE_ID_HERE]`)}) _(manual link correction required)_\n`;
+    return `\n> 📄 **${label}**: [${escapedTitle}](${this.buildUrl(`${this.webUrlPrefix}/spaces/${spaceKey}/pages/[PAGE_ID_HERE]`)}) _(manual link correction required)_\n`;
   }
 
   handleSharedBlock(node, type) {
@@ -330,7 +331,7 @@ class StorageWalker {
       if (acLink) {
         const riPage = this.findChildByName(acLink, 'ri:page');
         if (riPage) {
-          const pageTitle = decodeEntities(riPage.attribs['ri:content-title'] || '');
+          const pageTitle = this.escapeMarkdownText(decodeEntities(riPage.attribs['ri:content-title'] || ''));
           const includeLabel = this.labels.includeSharedBlock || 'Include Shared Block';
           const fromPageLabel = this.labels.fromPage || 'from page';
           return `\n> 📄 **${includeLabel}**: ${blockKey} (${fromPageLabel}: ${pageTitle} [link needs manual correction])\n`;
@@ -394,7 +395,7 @@ class StorageWalker {
     }
     const riPage = this.findChildByName(node, 'ri:page');
     if (riPage) {
-      const title = decodeEntities(riPage.attribs['ri:content-title'] || '');
+      const title = this.escapeMarkdownText(decodeEntities(riPage.attribs['ri:content-title'] || ''));
       return `[${title}]`;
     }
     return '';
@@ -452,6 +453,16 @@ class StorageWalker {
 
   getTextContent(node) {
     return decodeEntities(this._collectText(node));
+  }
+
+  // Escape markdown structural characters in text that will be interpolated
+  // into link syntax (`[text](url)`). Confluence page titles can legitimately
+  // contain `()` / `[]`, and a maliciously-crafted title could otherwise inject
+  // a sibling link or break downstream parsers. Backslash is escaped so that
+  // an existing `\` in a title isn't reinterpreted as a markdown escape.
+  escapeMarkdownText(s) {
+    if (!s) return '';
+    return s.replace(/([\\[\]()])/g, '\\$1');
   }
 
   _collectText(node) {

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -824,6 +824,51 @@ describe('MacroConverter storageToMarkdown ac:link without body', () => {
   });
 });
 
+describe('MacroConverter storageToMarkdown ri:content-title escaping', () => {
+  // Page titles routinely contain `()` (e.g. "Release notes (v2.0)") and
+  // could in theory contain `[]` or `\`. Interpolating raw into markdown link
+  // syntax breaks downstream parsers and — for adversarially-crafted titles —
+  // allows a sibling link to be injected. Escape the four structural chars
+  // plus backslash at every site that splices a title into `[…](…)`.
+  const converter = new MacroConverter({ isCloud: true });
+
+  test('ri:page title with parentheses is escaped in [title] form', () => {
+    const storage = '<ac:link><ri:page ri:content-title="Release notes (v2.0)" /></ac:link>';
+    expect(converter.storageToMarkdown(storage)).toContain('[Release notes \\(v2.0\\)]');
+  });
+
+  test('ri:page title with brackets is escaped in [title] form', () => {
+    const storage = '<ac:link><ri:page ri:content-title="Plan [Q4]" /></ac:link>';
+    expect(converter.storageToMarkdown(storage)).toContain('[Plan \\[Q4\\]]');
+  });
+
+  test('ri:page title with backslash is escaped in [title] form', () => {
+    const storage = '<ac:link><ri:page ri:content-title="path\\\\name" /></ac:link>';
+    expect(converter.storageToMarkdown(storage)).toContain('[path\\\\\\\\name]');
+  });
+
+  test('include-page macro escapes title in markdown link text but not in URL', () => {
+    const storage = '<ac:structured-macro ac:name="include"><ac:parameter ac:name=""><ac:link><ri:page ri:space-key="~user" ri:content-title="Notes (draft)" /></ac:link></ac:parameter></ac:structured-macro>';
+    const result = converter.storageToMarkdown(storage);
+    expect(result).toContain('[Notes \\(draft\\)]');
+    expect(result).toContain('Notes%20(draft)');
+  });
+
+  test('include-shared-block escapes pageTitle interpolated into prose', () => {
+    const storage = '<ac:structured-macro ac:name="include-shared-block"><ac:parameter ac:name="shared-block-key">B1</ac:parameter><ac:parameter ac:name="page"><ac:link><ri:page ri:content-title="Specs (v3)" /></ac:link></ac:parameter></ac:structured-macro>';
+    expect(converter.storageToMarkdown(storage)).toContain('Specs \\(v3\\)');
+  });
+
+  test('adversarial title cannot inject a sibling markdown link', () => {
+    const storage = '<ac:link><ri:page ri:content-title="evil) [pwn](http://attacker.com" /></ac:link>';
+    const result = converter.storageToMarkdown(storage);
+    expect(result).not.toMatch(/\]\(http:\/\/attacker\.com/);
+    expect(result).toContain('\\(');
+    expect(result).toContain('\\[');
+    expect(result).toContain('\\]');
+  });
+});
+
 describe('MacroConverter storageToMarkdown ac:image external URL', () => {
   // <ac:image> wraps either <ri:attachment> (uploaded asset) or <ri:url>
   // (external image). The walker originally only handled the attachment


### PR DESCRIPTION
## Summary

Closes #143.

`ri:content-title` is interpolated directly into markdown link syntax. If a title contains `(`, `)`, `[`, `]`, or `\`, the link breaks or — for an adversarially-crafted title like `evil) [pwn](http://attacker.com` — allows injection of an unintended sibling link. This is **pre-existing on main** (the regex pipeline didn't escape either), but it's a real correctness bug for any Confluence page whose title legitimately contains parentheses.

## Changes

- Added `escapeMarkdownText(s)` helper that escapes `\ [ ] ( )`.
- Applied at the three sites that splice `ri:content-title` into markdown:
  - `handleAcLink` — `[title]` form for `<ri:page>` without link body.
  - `handleInclude` — link text in include-page output. URL path still uses the **unescaped** title via `encodeURIComponent`, so URL encoding is unaffected.
  - `handleSharedBlock` — `pageTitle` interpolated into prose between surrounding parens.

Out of scope: `ri:filename` (handleViewFile / handleImage) and the generic `<a>` link path. Those are pre-existing concerns the issue did not include.

## Test plan

- [x] New tests cover parentheses, brackets, backslash, the include-page macro path (verifying URL encoding is preserved), include-shared-block prose, and the adversarial sibling-link injection case.
- [x] `npx jest` — 560/560 passing.
- [x] `npx eslint` — clean on changed files.