### PR TITLE
fix(walker): drop malformed marker text for empty/missing macro params (#140)

### DIFF
--- a/lib/storage-walker.js
+++ b/lib/storage-walker.js
@@ -281,19 +281,23 @@ class StorageWalker {
 
   handleAnchor(node) {
     const param = this.findParamByName(node, '');
-    const id = param ? this.getTextContent(param) : '';
+    const id = (param ? this.getTextContent(param) : '').trim();
+    if (!id) return '';
     return `\n**ANCHOR: ${id}**\n`;
   }
 
   handlePanel(node) {
     const titleParam = this.findParamByName(node, 'title');
-    const title = titleParam ? this.getTextContent(titleParam) : '';
+    const title = (titleParam ? this.getTextContent(titleParam) : '').trim();
     const body = this.getMacroBody(node);
     // Trim before quoting — walkNodes wraps every <p> with a leading and
     // trailing \n, so untrimmed body splits into ['', 'body', ''] and emits
     // extra `>` blank lines that bracket the real content.
     const cleanContent = this.walkNodes(body).trim();
+    if (!title && !cleanContent) return '';
     const quoted = cleanContent.split('\n').map((line) => (line ? `> ${line}` : '>')).join('\n');
+    if (!title) return `\n${quoted}\n`;
+    if (!cleanContent) return `\n> **${title}**\n`;
     return `\n> **${title}**\n>\n${quoted}\n`;
   }
 

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -930,6 +930,45 @@ describe('MacroConverter storageToMarkdown panel formatting', () => {
   });
 });
 
+describe('MacroConverter storageToMarkdown empty/missing macro parameters', () => {
+  const converter = new MacroConverter({ isCloud: true });
+
+  test('anchor with no ac:parameter is dropped entirely', () => {
+    const storage = '<ac:structured-macro ac:name="anchor"></ac:structured-macro>';
+    expect(converter.storageToMarkdown(storage)).toBe('');
+  });
+
+  test('anchor with empty ac:parameter is dropped entirely', () => {
+    const storage = '<ac:structured-macro ac:name="anchor"><ac:parameter ac:name=""></ac:parameter></ac:structured-macro>';
+    expect(converter.storageToMarkdown(storage)).toBe('');
+  });
+
+  test('anchor with whitespace-only id is dropped entirely', () => {
+    const storage = '<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">   </ac:parameter></ac:structured-macro>';
+    expect(converter.storageToMarkdown(storage)).toBe('');
+  });
+
+  test('panel without title parameter emits body-only blockquote (no empty bold line)', () => {
+    const storage = '<ac:structured-macro ac:name="panel"><ac:rich-text-body><p>body</p></ac:rich-text-body></ac:structured-macro>';
+    expect(converter.storageToMarkdown(storage)).toBe('> body');
+  });
+
+  test('panel with empty title parameter emits body-only blockquote', () => {
+    const storage = '<ac:structured-macro ac:name="panel"><ac:parameter ac:name="title"></ac:parameter><ac:rich-text-body><p>body</p></ac:rich-text-body></ac:structured-macro>';
+    expect(converter.storageToMarkdown(storage)).toBe('> body');
+  });
+
+  test('panel with title but no body emits header-only blockquote', () => {
+    const storage = '<ac:structured-macro ac:name="panel"><ac:parameter ac:name="title">T</ac:parameter></ac:structured-macro>';
+    expect(converter.storageToMarkdown(storage)).toBe('> **T**');
+  });
+
+  test('panel with neither title nor body is dropped entirely', () => {
+    const storage = '<ac:structured-macro ac:name="panel"></ac:structured-macro>';
+    expect(converter.storageToMarkdown(storage)).toBe('');
+  });
+});
+
 describe('MacroConverter storageToMarkdown fenced code preserves indentation', () => {
   const converter = new MacroConverter({ isCloud: true });
   const codeMacro = (lang, body) =>


### PR DESCRIPTION
## Summary

Closes #140.

The walker emitted visibly broken markdown when macros were missing the parameter the handler reads:

| Input | Before | After |
|---|---|---|
| `<ac:structured-macro ac:name="anchor"></ac:structured-macro>` | `**ANCHOR: **` | _(dropped)_ |
| anchor with empty/whitespace `<ac:parameter ac:name="">` | `**ANCHOR: **` | _(dropped)_ |
| panel without title param | `> ****\n>\n> body` | `> body` |
| panel with empty title param | `> ****\n>\n> body` | `> body` |
| panel with title but no body | `> ****\n>\n>` | `> **T**` |
| empty panel (no title, no body) | `> ****\n>\n>` | _(dropped)_ |

## Why

Real Confluence pages occasionally contain partially-authored macros (e.g. someone deleted a panel title in the editor). The pre-walker regex pipeline matched on `(.+)` and silently skipped these; the walker re-emitted the wrapper with an empty interpolation slot, producing literal `**ANCHOR: **` and `> ****` in the output.

## Round-trip safety

- **anchor**: `markdownToStorage` matches `^ANCHOR: (.+)$` ([html-to-storage.js:69](https://github.com/pchuri/confluence-cli/blob/main/lib/html-to-storage.js#L69)), so empty ids never round-tripped to storage anyway. Dropping is safe.
- **panel**: storage→markdown is one-way. No inverse rule converts a blockquote back to a panel macro, so changing the output format has no round-trip impact.

## Out of scope

The empty-code-block edge (`ac:name="code"` with no language and no body) is left as-is — it produces an empty fenced block, which is valid markdown. Issue #140 also flagged this as lower-priority cosmetic.

## Test plan

- [x] New cases in `tests/macro-converter.test.js`:
  - anchor with no/empty/whitespace id → dropped
  - panel without title → body-only blockquote
  - panel with title but no body → header-only blockquote
  - panel with neither → dropped
- [x] Existing round-trip tests still pass ([macro-converter.test.js:579](https://github.com/pchuri/confluence-cli/blob/main/tests/macro-converter.test.js#L579))
- [x] Existing panel formatting tests still pass ([macro-converter.test.js:919](https://github.com/pchuri/confluence-cli/blob/main/tests/macro-converter.test.js#L919))
- [x] Full suite: 567/567 passing
- [x] eslint clean