### PR TITLE
feat(client): add limit configurable in getSpaces and spaces command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A powerful command-line interface for Atlassian Confluence that allows you to re
 - 📖 **Read pages** - Get page content in text or HTML format
 - 🔍 **Search** - Find pages using Confluence's powerful search
 - ℹ️ **Page info** - Get detailed information about pages
-- 🏠 **List spaces** - View all available Confluence spaces
+- 🏠 **List spaces** - View available Confluence spaces
 - ✏️ **Create pages** - Create new pages with support for Markdown, HTML, or Storage format
 - 📝 **Update pages** - Update existing page content and titles
 - 🗑️ **Delete pages** - Delete (or move to trash) pages by ID or URL
@@ -691,7 +691,7 @@ confluence stats
 | `read <pageId_or_url>` | Read page content | `--format <html\|text\|storage\|markdown>` |
 | `info <pageId_or_url>` | Get page information | `--format <text\|json>` |
 | `search <query>` | Search for pages | `--limit <number>` |
-| `spaces` | List all available spaces | |
+| `spaces` | List available spaces | `--limit <number>` |
 | `find <title>` | Find a page by its title | `--space <spaceKey>` |
 | `children <pageId>` | List child pages of a page | `--recursive`, `--max-depth <number>`, `--format <list\|tree\|json>`, `--show-url`, `--show-id` |
 | `create <title> <spaceKey>` | Create a new page | `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>`|
@@ -739,7 +739,7 @@ confluence info 123456789
 # Search with limit
 confluence search "API documentation" --limit 3
 
-# List all spaces
+# List spaces
 confluence spaces
 
 # Move a page to a new parent

--- a/bin/confluence.js
+++ b/bin/confluence.js
@@ -139,13 +139,14 @@ program
 // List spaces command
 program
   .command('spaces')
-  .description('List all Confluence spaces')
-  .action(async () => {
+  .description('List Confluence spaces')
+  .option('-l, --limit <limit>', 'Limit number of results', '500')
+  .action(async (options) => {
     const analytics = new Analytics();
     try {
       const config = getConfig(getProfileName());
       const client = new ConfluenceClient(config);
-      const spaces = await client.getSpaces();
+      const spaces = await client.getSpaces(parseInt(options.limit));
       
       console.log(chalk.blue('Available spaces:'));
       spaces.forEach(space => {

--- a/examples/demo-page-management.sh
+++ b/examples/demo-page-management.sh
@@ -30,7 +30,7 @@ echo "5. Searching for pages..."
 echo "confluence search \"CLI\""
 
 echo ""
-echo "6. Listing all spaces..."
+echo "6. Listing spaces..."
 echo "confluence spaces"
 
 echo ""

--- a/examples/demo.sh
+++ b/examples/demo.sh
@@ -13,7 +13,7 @@ if ! command -v confluence &> /dev/null; then
 fi
 
 echo ""
-echo "📋 Listing all spaces..."
+echo "📋 Listing spaces..."
 confluence spaces
 
 echo ""

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -437,12 +437,12 @@ class ConfluenceClient {
   }
 
   /**
-   * Get all spaces
+   * Get spaces
    */
-  async getSpaces() {
+  async getSpaces(limit = 500) {
     const response = await this.client.get('/space', {
       params: {
-        limit: 500
+        limit
       }
     });
 

--- a/plugins/confluence/skills/confluence/SKILL.md
+++ b/plugins/confluence/skills/confluence/SKILL.md
@@ -221,7 +221,7 @@ confluence search --cql 'siteSearch ~ "deployment pipeline" and space = "MYSPACE
 
 ### `spaces`
 
-List all accessible Confluence spaces (key and name).
+List accessible Confluence spaces (key and name).
 
 ```sh
 confluence spaces

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -1170,6 +1170,30 @@ describe('ConfluenceClient', () => {
     });
   });
 
+  describe('getSpaces', () => {
+    test('should return spaces with default limit of 500', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/space').reply(config => {
+        expect(config.params.limit).toBe(500);
+        return [200, { results: [], _links: {} }];
+      });
+
+      await client.getSpaces();
+      mock.restore();
+    });
+
+    test('should return spaces with limit parameter', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/space').reply(config => {
+        expect(config.params.limit).toBe(1000);
+        return [200, { results: [], _links: {} }];
+      });
+
+      await client.getSpaces(1000);
+      mock.restore();
+    });
+  });
+
   describe('escapeCql', () => {
     test('escapes backslash and double quote', () => {
       expect(client.escapeCql('a"b')).toBe('a\\"b');


### PR DESCRIPTION
### Description
Previously the spaces API call had a hardcoded limit of 500. 
This change allows callers to request more than 500 spaces by passing an explicit limit to getSpaces(), 
and exposes it as a --limit option on the `confluence spaces` CLI command.

- getSpaces(limit = 500): limit is now a parameter (default 500)
- `confluence spaces --limit <n>`: new CLI option, defaults to 500
- Add tests verifying the limit param is forwarded to the API request

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

### Testing
- [x] Tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x]  I have made corresponding changes to the documentation

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

closes #166 