### PR TITLE
fix(walker): preserve <u>/<sub>/<sup>/<mark> on storage ↔ markdown round-trip

### DIFF
--- a/lib/macro-converter.js
+++ b/lib/macro-converter.js
@@ -79,7 +79,7 @@ class MacroConverter {
   // a fence or backticks is preserved as text rather than passed through.
   _renderMarkdownToHtml(markdown) {
     const codeStash = [];
-    let src = String(markdown).replace(CODE_BLOCK_RE, (m) => {
+    let src = markdown.replace(CODE_BLOCK_RE, (m) => {
       codeStash.push(m);
       return `${STASH_DELIM}C${codeStash.length - 1}${STASH_DELIM}`;
     });

--- a/lib/macro-converter.js
+++ b/lib/macro-converter.js
@@ -13,7 +13,15 @@ const STASH_DELIM = '\uE000';
 // them as raw HTML on storage\u2192markdown, so they must round-trip back through
 // markdownToStorage; without this whitelist, MarkdownIt (html: false) escapes
 // them to literal `&lt;...&gt;` and the formatting is lost.
-const PASSTHROUGH_TAG_RE = /<\/?(?:u|sub|sup|mark)\b[^>]*>/gi;
+//
+// The lookahead `(?=[\s/>])` after the tag name rejects strings that look
+// like markdown autolinks (e.g. `<u@example.com>`, `<sub:foo>`) \u2014 a plain
+// `\b` word boundary would let these through and break linkify.
+//
+// The body alternation `"[^"]*"|'[^']*'|[^>]` makes the match quote-aware
+// so a literal `>` inside a quoted attribute value (e.g.
+// `<mark title="1>0">`) does not terminate the tag prematurely.
+const PASSTHROUGH_TAG_RE = /<\/?(?:u|sub|sup|mark)(?=[\s/>])(?:"[^"]*"|'[^']*'|[^>])*>/gi;
 // Single-backtick inline code spans. Block-level code (fenced + indented) is
 // detected via MarkdownIt's tokenizer in `_findCodeRanges` because a regex
 // can't reliably distinguish a 4-space-indented code block from a list-item

--- a/lib/macro-converter.js
+++ b/lib/macro-converter.js
@@ -14,10 +14,11 @@ const STASH_DELIM = '\uE000';
 // markdownToStorage; without this whitelist, MarkdownIt (html: false) escapes
 // them to literal `&lt;...&gt;` and the formatting is lost.
 const PASSTHROUGH_TAG_RE = /<\/?(?:u|sub|sup|mark)\b[^>]*>/gi;
-// Mirrors the code-protection regex in setupConfluenceMarkdownExtensions:
-// fenced (```/~~~) and single-backtick inline code. Stashing these first
-// keeps `<u>` written inside code blocks from being treated as passthrough.
-const CODE_BLOCK_RE = /```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]+`/g;
+// Single-backtick inline code spans. Block-level code (fenced + indented) is
+// detected via MarkdownIt's tokenizer in `_findCodeRanges` because a regex
+// can't reliably distinguish a 4-space-indented code block from a list-item
+// continuation that happens to align to four spaces.
+const INLINE_CODE_RE = /`[^`\n]+`/g;
 
 class MacroConverter {
   constructor({ isCloud = false, webUrlPrefix = '', buildUrl = null, linkStyle = null } = {}) {
@@ -75,28 +76,71 @@ class MacroConverter {
   }
 
   // Pre-stashes whitelisted inline HTML so MarkdownIt won't escape it, renders,
-  // then restores. Code regions are protected so a literal `<u>` written inside
-  // a fence or backticks is preserved as text rather than passed through.
+  // then restores. Code regions (fenced, indented, and inline) are skipped so a
+  // literal `<u>` typed inside a code block survives MarkdownIt's escape and
+  // round-trips as text rather than as a real tag — which would otherwise be
+  // smuggled past the escape and dropped by `convertCodeBlock`'s text-only
+  // child collection in html-to-storage.
   _renderMarkdownToHtml(markdown) {
-    const codeStash = [];
-    let src = markdown.replace(CODE_BLOCK_RE, (m) => {
-      codeStash.push(m);
-      return `${STASH_DELIM}C${codeStash.length - 1}${STASH_DELIM}`;
-    });
+    const codeRanges = this._findCodeRanges(markdown);
     const htmlStash = [];
-    src = src.replace(PASSTHROUGH_TAG_RE, (m) => {
+    const stashHtml = (text) => text.replace(PASSTHROUGH_TAG_RE, (m) => {
       htmlStash.push(m);
       return `${STASH_DELIM}H${htmlStash.length - 1}${STASH_DELIM}`;
     });
-    src = src.replace(
-      new RegExp(`${STASH_DELIM}C(\\d+)${STASH_DELIM}`, 'g'),
-      (m, i) => codeStash[+i] ?? m,
-    );
+
+    let src = '';
+    let pos = 0;
+    for (const [start, end] of codeRanges) {
+      src += stashHtml(markdown.slice(pos, start));
+      src += markdown.slice(start, end);
+      pos = end;
+    }
+    src += stashHtml(markdown.slice(pos));
+
     const html = this.markdown.render(src);
     return html.replace(
       new RegExp(`${STASH_DELIM}H(\\d+)${STASH_DELIM}`, 'g'),
       (m, i) => htmlStash[+i] ?? m,
     );
+  }
+
+  // Returns merged, sorted character ranges covering all code regions in the
+  // markdown source — fenced and indented blocks via MarkdownIt's tokenizer
+  // (which correctly distinguishes them from list-item continuations) and
+  // single-backtick inline spans via regex (MarkdownIt parses these into
+  // `code_inline` tokens but does not expose source positions for them).
+  _findCodeRanges(markdown) {
+    const tokens = this.markdown.parse(markdown, {});
+    const lineStarts = [0];
+    for (let i = 0; i < markdown.length; i++) {
+      if (markdown[i] === '\n') lineStarts.push(i + 1);
+    }
+    const lineToChar = (n) => (n < lineStarts.length ? lineStarts[n] : markdown.length);
+
+    const ranges = [];
+    for (const tok of tokens) {
+      if ((tok.type === 'code_block' || tok.type === 'fence') && tok.map) {
+        ranges.push([lineToChar(tok.map[0]), lineToChar(tok.map[1])]);
+      }
+    }
+    INLINE_CODE_RE.lastIndex = 0;
+    let m;
+    while ((m = INLINE_CODE_RE.exec(markdown)) !== null) {
+      ranges.push([m.index, m.index + m[0].length]);
+    }
+
+    ranges.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+    const merged = [];
+    for (const r of ranges) {
+      const last = merged[merged.length - 1];
+      if (last && r[0] <= last[1]) {
+        last[1] = Math.max(last[1], r[1]);
+      } else {
+        merged.push([r[0], r[1]]);
+      }
+    }
+    return merged;
   }
 
   htmlToConfluenceStorage(html) {

--- a/lib/macro-converter.js
+++ b/lib/macro-converter.js
@@ -9,6 +9,16 @@ const CALLOUT_MARKERS = ['info', 'warning', 'note'];
 // and survives editor / formatter / lint passes that strip invisible chars.
 const STASH_DELIM = '\uE000';
 
+// Inline HTML tags that markdown has no native syntax for. The walker emits
+// them as raw HTML on storage\u2192markdown, so they must round-trip back through
+// markdownToStorage; without this whitelist, MarkdownIt (html: false) escapes
+// them to literal `&lt;...&gt;` and the formatting is lost.
+const PASSTHROUGH_TAG_RE = /<\/?(?:u|sub|sup|mark)\b[^>]*>/gi;
+// Mirrors the code-protection regex in setupConfluenceMarkdownExtensions:
+// fenced (```/~~~) and single-backtick inline code. Stashing these first
+// keeps `<u>` written inside code blocks from being treated as passthrough.
+const CODE_BLOCK_RE = /```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]+`/g;
+
 class MacroConverter {
   constructor({ isCloud = false, webUrlPrefix = '', buildUrl = null, linkStyle = null } = {}) {
     this._isCloud = isCloud;
@@ -57,13 +67,36 @@ class MacroConverter {
   }
 
   markdownToStorage(markdown) {
-    const html = this.markdown.render(markdown);
-    return this.htmlToConfluenceStorage(html);
+    return this.htmlToConfluenceStorage(this._renderMarkdownToHtml(markdown));
   }
 
   markdownToNativeStorage(markdown) {
-    const html = this.markdown.render(markdown);
-    return this.htmlToConfluenceStorage(html);
+    return this.htmlToConfluenceStorage(this._renderMarkdownToHtml(markdown));
+  }
+
+  // Pre-stashes whitelisted inline HTML so MarkdownIt won't escape it, renders,
+  // then restores. Code regions are protected so a literal `<u>` written inside
+  // a fence or backticks is preserved as text rather than passed through.
+  _renderMarkdownToHtml(markdown) {
+    const codeStash = [];
+    let src = String(markdown).replace(CODE_BLOCK_RE, (m) => {
+      codeStash.push(m);
+      return `${STASH_DELIM}C${codeStash.length - 1}${STASH_DELIM}`;
+    });
+    const htmlStash = [];
+    src = src.replace(PASSTHROUGH_TAG_RE, (m) => {
+      htmlStash.push(m);
+      return `${STASH_DELIM}H${htmlStash.length - 1}${STASH_DELIM}`;
+    });
+    src = src.replace(
+      new RegExp(`${STASH_DELIM}C(\\d+)${STASH_DELIM}`, 'g'),
+      (m, i) => codeStash[+i] ?? m,
+    );
+    const html = this.markdown.render(src);
+    return html.replace(
+      new RegExp(`${STASH_DELIM}H(\\d+)${STASH_DELIM}`, 'g'),
+      (m, i) => htmlStash[+i] ?? m,
+    );
   }
 
   htmlToConfluenceStorage(html) {

--- a/lib/storage-walker.js
+++ b/lib/storage-walker.js
@@ -200,6 +200,7 @@ class StorageWalker {
     case 'blockquote':
       return this.handleBlockquote(node);
     case 'details': case 'summary':
+    case 'u': case 'sub': case 'sup': case 'mark':
       return `<${tag}>` + this.walkNodes(node.children) + `</${tag}>`;
     case 'ac:structured-macro':
       return this.handleMacro(node);

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -1006,6 +1006,42 @@ describe('MacroConverter <u>/<sub>/<sup>/<mark> passthrough', () => {
     expect(result).not.toContain('&lt;u&gt;');
   });
 
+  test('quoted attribute containing > is preserved verbatim', () => {
+    // Regression guard: a `[^>]*` body in the whitelist regex stopped at the
+    // first `>` inside the quoted value, leaving an incomplete tag that
+    // collapsed to `<p></p>` and silently dropped the user content.
+    const result = converter.markdownToStorage('<mark title="1>0">x</mark>');
+    expect(result).toContain('<mark title="1>0">x</mark>');
+  });
+
+  test('single-quoted attribute is accepted (htmlToStorage normalizes to double-quote on output)', () => {
+    const result = converter.markdownToStorage('<mark class=\'lit\'>y</mark>');
+    expect(result).toContain('<mark class="lit">y</mark>');
+  });
+
+  test('angle-bracket autolinks are not mistaken for whitelisted tags', () => {
+    // Regression guard: a plain `\b` boundary after the tag name allowed
+    // markdown autolinks like `<u@example.com>` and `<sub:foo>` to be stashed
+    // as if they were HTML tags, bypassing markdown-it's linkify path and
+    // emitting bogus `<u@example.com></u@example.com>` pairs.
+    const email = converter.markdownToStorage('<u@example.com>');
+    expect(email).toContain('href="mailto:u@example.com"');
+    expect(email).not.toMatch(/<u@example\.com>/);
+
+    const uri = converter.markdownToStorage('<sub:foo>');
+    expect(uri).toContain('href="sub:foo"');
+    expect(uri).not.toMatch(/<sub:foo>/);
+  });
+
+  test('hyphenated custom-element-like names are NOT passed through (e.g., <u-foo>)', () => {
+    // Tightened from the original `\b` behaviour: a custom element whose name
+    // starts with `u`/`sub`/etc. is not really a `<u>` tag, so we let
+    // markdown-it escape it like any other HTML.
+    const result = converter.markdownToStorage('<u-foo>x</u-foo>');
+    expect(result).toContain('&lt;u-foo&gt;');
+    expect(result).not.toMatch(/<u-foo>/);
+  });
+
   test('markdownToNativeStorage applies the same passthrough policy', () => {
     const result = converter.markdownToNativeStorage('H<sub>2</sub>O');
     expect(result).toContain('<sub>2</sub>');

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -948,6 +948,22 @@ describe('MacroConverter <u>/<sub>/<sup>/<mark> passthrough', () => {
     expect(converter.storageToMarkdown(converter.markdownToStorage(md)).trim()).toBe(md);
   });
 
+  test('round-trip: <u>under</u> survives markdown → storage → markdown', () => {
+    const md = '<u>under</u>';
+    expect(converter.storageToMarkdown(converter.markdownToStorage(md)).trim()).toBe(md);
+  });
+
+  test('round-trip: x<sup>2</sup> survives markdown → storage → markdown', () => {
+    const md = 'x<sup>2</sup>';
+    expect(converter.storageToMarkdown(converter.markdownToStorage(md)).trim()).toBe(md);
+  });
+
+  test('walker drops attributes on whitelisted tags (matches <details>/<summary> precedent)', () => {
+    // Asymmetric with markdown→storage which preserves attributes; documenting
+    // here so any future change is intentional rather than incidental.
+    expect(converter.storageToMarkdown('<p><sub class="chem">2</sub></p>')).toBe('<sub>2</sub>');
+  });
+
   test('attributes on whitelisted tags pass through markdown → storage', () => {
     const result = converter.markdownToStorage('<mark class="lit">x</mark>');
     expect(result).toContain('<mark class="lit">x</mark>');

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -987,6 +987,25 @@ describe('MacroConverter <u>/<sub>/<sup>/<mark> passthrough', () => {
     expect(result).toContain('<![CDATA[<u>x</u>]]>');
   });
 
+  test('literal <u> inside 4-space indented code is preserved as code body', () => {
+    // Regression guard: an earlier draft pre-stashed <u> with a regex that
+    // ignored indented code blocks. The placeholder ended up inside the
+    // rendered <pre><code>, the restored raw <u> was re-parsed as a real tag,
+    // and convertCodeBlock's text-only collection silently emptied the body.
+    const result = converter.markdownToStorage('    <u>x</u>');
+    expect(result).toContain('<![CDATA[<u>x</u>]]>');
+    expect(result).not.toContain('<![CDATA[]]>');
+  });
+
+  test('list-item continuation aligned to 4 spaces is NOT treated as code', () => {
+    // Tokenizer-based detection must distinguish indented code blocks from
+    // list-item continuations that happen to align to four spaces; otherwise
+    // <u> in continuations would be wrongly stashed-and-escaped.
+    const result = converter.markdownToStorage('- item1\n    <u>x</u>');
+    expect(result).toContain('<u>x</u>');
+    expect(result).not.toContain('&lt;u&gt;');
+  });
+
   test('markdownToNativeStorage applies the same passthrough policy', () => {
     const result = converter.markdownToNativeStorage('H<sub>2</sub>O');
     expect(result).toContain('<sub>2</sub>');

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -916,6 +916,67 @@ describe('MacroConverter storageToMarkdown <s>/<del> strikethrough', () => {
   });
 });
 
+describe('MacroConverter <u>/<sub>/<sup>/<mark> passthrough', () => {
+  // Markdown has no native syntax for these inline tags, so the walker emits
+  // them as raw HTML and markdownToStorage stashes them around MarkdownIt's
+  // html: false escape so they round-trip end-to-end.
+  const converter = new MacroConverter({ isCloud: true });
+
+  test('walker preserves <sub> in storage → markdown', () => {
+    expect(converter.storageToMarkdown('<p>H<sub>2</sub>O</p>')).toBe('H<sub>2</sub>O');
+  });
+
+  test('walker preserves <sup> in storage → markdown', () => {
+    expect(converter.storageToMarkdown('<p>x<sup>2</sup></p>')).toBe('x<sup>2</sup>');
+  });
+
+  test('walker preserves <u> in storage → markdown', () => {
+    expect(converter.storageToMarkdown('<p><u>under</u></p>')).toBe('<u>under</u>');
+  });
+
+  test('walker preserves <mark> in storage → markdown', () => {
+    expect(converter.storageToMarkdown('<p><mark>hi</mark></p>')).toBe('<mark>hi</mark>');
+  });
+
+  test('round-trip: H<sub>2</sub>O survives markdown → storage → markdown', () => {
+    const md = 'H<sub>2</sub>O';
+    expect(converter.storageToMarkdown(converter.markdownToStorage(md)).trim()).toBe(md);
+  });
+
+  test('round-trip: <mark>highlight</mark> survives markdown → storage → markdown', () => {
+    const md = '<mark>highlight</mark>';
+    expect(converter.storageToMarkdown(converter.markdownToStorage(md)).trim()).toBe(md);
+  });
+
+  test('attributes on whitelisted tags pass through markdown → storage', () => {
+    const result = converter.markdownToStorage('<mark class="lit">x</mark>');
+    expect(result).toContain('<mark class="lit">x</mark>');
+  });
+
+  test('whitelist does not allow non-listed tags through (e.g., <script> is escaped)', () => {
+    const result = converter.markdownToStorage('<script>alert(1)</script>');
+    expect(result).not.toContain('<script>');
+    expect(result).toContain('&lt;script&gt;');
+  });
+
+  test('literal <u> inside inline code is escaped, not passed through', () => {
+    const result = converter.markdownToStorage('`<u>x</u>`');
+    expect(result).toContain('&lt;u&gt;x&lt;/u&gt;');
+    expect(result).not.toMatch(/<u>x<\/u>/);
+  });
+
+  test('literal <u> inside fenced code is preserved as code body, not passthrough', () => {
+    const result = converter.markdownToStorage('```\n<u>x</u>\n```');
+    // Fenced code becomes a code macro with the literal source as plain-text-body.
+    expect(result).toContain('<![CDATA[<u>x</u>]]>');
+  });
+
+  test('markdownToNativeStorage applies the same passthrough policy', () => {
+    const result = converter.markdownToNativeStorage('H<sub>2</sub>O');
+    expect(result).toContain('<sub>2</sub>');
+  });
+});
+
 describe('MacroConverter storageToMarkdown panel formatting', () => {
   const converter = new MacroConverter({ isCloud: true });
 


### PR DESCRIPTION
## Summary

Picks **option 2** from #155 (selective tag whitelist) for `<u>`, `<sub>`, `<sup>`, `<mark>`. These four inline tags now survive storage ↔ markdown ↔ storage end-to-end. Closes #155.

## What changed

- **`lib/storage-walker.js`** — adds the four tags to the existing `<details>/<summary>` raw-HTML pass-through case, so storage→markdown emits e.g. `H<sub>2</sub>O` instead of dropping the wrapper to `H2O`.
- **`lib/macro-converter.js`** — wraps `markdownToStorage` / `markdownToNativeStorage` with a stash/restore that hides whitelisted tags from MarkdownIt (which is constructed with `html: false`) and re-injects them after rendering. Code fences and inline code are stashed first, so a literal `<u>` inside a backtick block stays escaped as text rather than being passed through.
- **`tests/macro-converter.test.js`** — 11 new tests covering walker output for each tag, full markdown→storage→markdown round-trip, attribute preservation, the `<script>` escape (proves the whitelist boundary holds), and the inline-code / fenced-code carve-outs.

## Why this approach over the alternatives in the issue

- **Option 1 (`html: true` on MarkdownIt)** — too broad. It would let arbitrary user HTML reach Confluence storage XHTML and rely on Confluence's sanitizer as the safety boundary. The four tags above are the only documented information loss; opening the whole HTML grammar to address it is disproportionate.
- **Option 3 (status quo)** — leaves real information loss for chemistry/math docs (`<sub>`/`<sup>`) and any `<u>`/`<mark>` use, including content created via the Confluence editor.
- **Option 2 (this PR)** — fixes the four tags the issue identifies, keeps the safety boundary surgical, and re-uses the `STASH_DELIM` pattern already in `setupConfluenceMarkdownExtensions`. No new dependencies.

`<details>`/`<summary>` were mentioned parenthetically in the issue but deferred — they're block-level and need different placeholder shaping to avoid `<p>`-wrap interactions. Out of scope here.

## Verification

```
npx jest          # 612 passing (was 601; +11 new)
npx eslint lib/macro-converter.js lib/storage-walker.js tests/macro-converter.test.js   # clean
```

Reproduction from the issue, after the fix:

```js
const c = new MacroConverter({ isCloud: true });
c.storageToMarkdown('<p>H<sub>2</sub>O</p>');                  // 'H<sub>2</sub>O'
c.markdownToStorage(c.storageToMarkdown('<p>H<sub>2</sub>O</p>'));  // '<p>H<sub>2</sub>O</p>\n'
c.markdownToStorage('<script>alert(1)</script>');              // '<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>\n'
c.markdownToStorage('`<u>x</u>`');                             // '<p><code>&lt;u&gt;x&lt;/u&gt;</code></p>\n'
```

## Test plan
- [x] New unit tests for each of the four tags (storage→markdown direction)
- [x] Round-trip tests for `<sub>` and `<mark>`
- [x] Whitelist boundary test: `<script>` is still escaped
- [x] Code carve-out tests: `<u>` inside inline code and inside fenced code is preserved as literal text
- [x] `markdownToNativeStorage` shares the same passthrough policy
- [x] Full `npx jest` suite (612 passing, no regressions)