### PR TITLE
feat(spaces): paginate getSpaces and add --all flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,14 @@ confluence export 123456789 --skip-attachments
 
 ### List Spaces
 ```bash
+# Default: up to 500 spaces (paginated automatically across requests)
 confluence spaces
+
+# Increase the cap when your tenant has more than 500 spaces
+confluence spaces --limit 2000
+
+# Fetch every space, regardless of how many pages it takes
+confluence spaces --all
 ```
 
 ### List Child Pages
@@ -691,7 +698,7 @@ confluence stats
 | `read <pageId_or_url>` | Read page content | `--format <html\|text\|storage\|markdown>` |
 | `info <pageId_or_url>` | Get page information | `--format <text\|json>` |
 | `search <query>` | Search for pages | `--limit <number>` |
-| `spaces` | List available spaces | `--limit <number>` |
+| `spaces` | List available spaces | `--limit <number>`, `--all` |
 | `find <title>` | Find a page by its title | `--space <spaceKey>` |
 | `children <pageId>` | List child pages of a page | `--recursive`, `--max-depth <number>`, `--format <list\|tree\|json>`, `--show-url`, `--show-id` |
 | `create <title> <spaceKey>` | Create a new page or folder | `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>`, `--type <page\|folder>` |

--- a/bin/confluence.js
+++ b/bin/confluence.js
@@ -154,15 +154,17 @@ program
 program
   .command('spaces')
   .description('List Confluence spaces')
-  .option('-l, --limit <limit>', 'Limit number of results', '500')
+  .option('-l, --limit <limit>', 'Maximum total spaces to return across paginated requests', '500')
+  .option('--all', 'Fetch every space, paginating through all results (overrides --limit)')
   .action(async (options) => {
     const analytics = new Analytics();
     try {
       const config = getConfig(getProfileName());
       const client = new ConfluenceClient(config);
-      const spaces = await client.getSpaces(parseInt(options.limit));
-      
-      console.log(chalk.blue('Available spaces:'));
+      const maxResults = options.all ? null : parseInt(options.limit);
+      const spaces = await client.getSpaces(maxResults);
+
+      console.log(chalk.blue(`Available spaces (${spaces.length}):`));
       spaces.forEach(space => {
         console.log(`${chalk.green(space.key)} - ${space.name}`);
       });

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -437,20 +437,58 @@ class ConfluenceClient {
   }
 
   /**
-   * Get spaces
+   * List a single page of spaces with pagination metadata
    */
-  async getSpaces(limit = 500) {
+  async listSpaces(options = {}) {
+    const limit = this.parsePositiveInt(options.limit, 500);
+    const start = this.parsePositiveInt(options.start, 0);
+
     const response = await this.client.get('/space', {
-      params: {
-        limit
-      }
+      params: { limit, start }
     });
 
-    return response.data.results.map(space => ({
-      key: space.key,
-      name: space.name,
-      type: space.type
-    }));
+    const results = Array.isArray(response.data?.results)
+      ? response.data.results.map(space => ({
+        key: space.key,
+        name: space.name,
+        type: space.type
+      }))
+      : [];
+
+    return {
+      results,
+      nextStart: this.parseNextStart(response.data?._links?.next)
+    };
+  }
+
+  /**
+   * Get spaces, paginating through results until maxResults is reached or
+   * the server stops returning a `_links.next`. Pass `null` to fetch every space.
+   */
+  async getSpaces(maxResults = 500, options = {}) {
+    const cap = maxResults === null || maxResults === undefined
+      ? null
+      : this.parsePositiveInt(maxResults, 500);
+    const pageSize = this.parsePositiveInt(options.pageSize, 500);
+    let start = this.parsePositiveInt(options.start, 0);
+    const spaces = [];
+
+    let hasNext = true;
+    while (hasNext) {
+      const page = await this.listSpaces({ limit: pageSize, start });
+      spaces.push(...page.results);
+
+      if (cap !== null && spaces.length >= cap) {
+        return spaces.slice(0, cap);
+      }
+
+      hasNext = page.nextStart !== null && page.nextStart !== undefined;
+      if (hasNext) {
+        start = page.nextStart;
+      }
+    }
+
+    return spaces;
   }
 
   /**

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -475,12 +475,12 @@ class ConfluenceClient {
 
     let hasNext = true;
     while (hasNext) {
-      const page = await this.listSpaces({ limit: pageSize, start });
+      if (cap !== null && spaces.length >= cap) break;
+      const requestLimit = cap === null
+        ? pageSize
+        : Math.min(pageSize, cap - spaces.length);
+      const page = await this.listSpaces({ limit: requestLimit, start });
       spaces.push(...page.results);
-
-      if (cap !== null && spaces.length >= cap) {
-        return spaces.slice(0, cap);
-      }
 
       hasNext = page.nextStart !== null && page.nextStart !== undefined;
       if (hasNext) {
@@ -488,7 +488,7 @@ class ConfluenceClient {
       }
     }
 
-    return spaces;
+    return cap !== null ? spaces.slice(0, cap) : spaces;
   }
 
   /**

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -1215,7 +1215,54 @@ describe('ConfluenceClient', () => {
 
       const spaces = await client.getSpaces(null);
       expect(calls.map(c => c.start)).toEqual([0, 500, 1000]);
+      expect(calls.map(c => c.limit)).toEqual([500, 500, 500]);
       expect(spaces.map(s => s.key)).toEqual(['A', 'B', 'C']);
+      mock.restore();
+    });
+
+    test('should send limit equal to maxResults when smaller than the page size', async () => {
+      const mock = new MockAdapter(client.client);
+      const calls = [];
+      mock.onGet('/space').reply(config => {
+        calls.push({ ...config.params });
+        return [200, {
+          results: [{ key: 'A', name: 'Alpha', type: 'global' }],
+          _links: {}
+        }];
+      });
+
+      await client.getSpaces(1);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].limit).toBe(1);
+      mock.restore();
+    });
+
+    test('should shrink the page request size to the remaining cap on each iteration', async () => {
+      const mock = new MockAdapter(client.client);
+      const calls = [];
+      mock.onGet('/space').reply(config => {
+        calls.push({ ...config.params });
+        if (config.params.start === 0) {
+          return [200, {
+            results: Array.from({ length: 500 }, (_, i) => ({
+              key: `K${i}`, name: `N${i}`, type: 'global'
+            })),
+            _links: { next: '/rest/api/space?next=true&limit=500&start=500' }
+          }];
+        }
+        return [200, {
+          results: Array.from({ length: 250 }, (_, i) => ({
+            key: `K${500 + i}`, name: `N${500 + i}`, type: 'global'
+          })),
+          _links: {}
+        }];
+      });
+
+      const spaces = await client.getSpaces(750);
+      expect(calls).toHaveLength(2);
+      expect(calls[0].limit).toBe(500);
+      expect(calls[1].limit).toBe(250);
+      expect(spaces).toHaveLength(750);
       mock.restore();
     });
 
@@ -1244,6 +1291,8 @@ describe('ConfluenceClient', () => {
 
       const spaces = await client.getSpaces(3);
       expect(calls).toHaveLength(2);
+      expect(calls[0].limit).toBe(3);
+      expect(calls[1].limit).toBe(1);
       expect(spaces.map(s => s.key)).toEqual(['A', 'B', 'C']);
       mock.restore();
     });

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -1171,25 +1171,105 @@ describe('ConfluenceClient', () => {
   });
 
   describe('getSpaces', () => {
-    test('should return spaces with default limit of 500', async () => {
+    test('should request a single page with default page size of 500 when no _links.next', async () => {
       const mock = new MockAdapter(client.client);
+      const calls = [];
       mock.onGet('/space').reply(config => {
-        expect(config.params.limit).toBe(500);
-        return [200, { results: [], _links: {} }];
+        calls.push({ ...config.params });
+        return [200, {
+          results: [{ key: 'A', name: 'Alpha', type: 'global' }],
+          _links: {}
+        }];
       });
 
-      await client.getSpaces();
+      const spaces = await client.getSpaces();
+      expect(calls).toHaveLength(1);
+      expect(calls[0].limit).toBe(500);
+      expect(calls[0].start).toBe(0);
+      expect(spaces).toEqual([{ key: 'A', name: 'Alpha', type: 'global' }]);
       mock.restore();
     });
 
-    test('should return spaces with limit parameter', async () => {
+    test('should follow _links.next and aggregate results across pages', async () => {
       const mock = new MockAdapter(client.client);
+      const calls = [];
       mock.onGet('/space').reply(config => {
-        expect(config.params.limit).toBe(1000);
-        return [200, { results: [], _links: {} }];
+        calls.push({ ...config.params });
+        if (config.params.start === 0) {
+          return [200, {
+            results: [{ key: 'A', name: 'Alpha', type: 'global' }],
+            _links: { next: '/rest/api/space?next=true&limit=500&start=500' }
+          }];
+        }
+        if (config.params.start === 500) {
+          return [200, {
+            results: [{ key: 'B', name: 'Beta', type: 'global' }],
+            _links: { next: '/rest/api/space?next=true&limit=500&start=1000' }
+          }];
+        }
+        return [200, {
+          results: [{ key: 'C', name: 'Gamma', type: 'global' }],
+          _links: {}
+        }];
       });
 
-      await client.getSpaces(1000);
+      const spaces = await client.getSpaces(null);
+      expect(calls.map(c => c.start)).toEqual([0, 500, 1000]);
+      expect(spaces.map(s => s.key)).toEqual(['A', 'B', 'C']);
+      mock.restore();
+    });
+
+    test('should stop paginating once maxResults cap is reached and slice excess', async () => {
+      const mock = new MockAdapter(client.client);
+      const calls = [];
+      mock.onGet('/space').reply(config => {
+        calls.push({ ...config.params });
+        if (config.params.start === 0) {
+          return [200, {
+            results: [
+              { key: 'A', name: 'Alpha', type: 'global' },
+              { key: 'B', name: 'Beta', type: 'global' }
+            ],
+            _links: { next: '/rest/api/space?next=true&limit=500&start=500' }
+          }];
+        }
+        return [200, {
+          results: [
+            { key: 'C', name: 'Gamma', type: 'global' },
+            { key: 'D', name: 'Delta', type: 'global' }
+          ],
+          _links: { next: '/rest/api/space?next=true&limit=500&start=1000' }
+        }];
+      });
+
+      const spaces = await client.getSpaces(3);
+      expect(calls).toHaveLength(2);
+      expect(spaces.map(s => s.key)).toEqual(['A', 'B', 'C']);
+      mock.restore();
+    });
+  });
+
+  describe('listSpaces', () => {
+    test('returns nextStart parsed from _links.next', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/space').reply(200, {
+        results: [{ key: 'A', name: 'Alpha', type: 'global' }],
+        _links: { next: '/rest/api/space?next=true&limit=500&start=500' }
+      });
+
+      const page = await client.listSpaces({ limit: 500, start: 0 });
+      expect(page.results).toEqual([{ key: 'A', name: 'Alpha', type: 'global' }]);
+      expect(page.nextStart).toBe(500);
+      mock.restore();
+    });
+
+    test('returns null nextStart when there is no next link', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/space').reply(200, { results: [], _links: {} });
+
+      const page = await client.listSpaces();
+      expect(page.results).toEqual([]);
+      expect(page.nextStart).toBeNull();
       mock.restore();
     });
   });


### PR DESCRIPTION
## Summary

- Closes #168 — `getSpaces` now follows `_links.next` and aggregates across requests, so callers actually get the number of spaces they ask for.
- Adds `--all` flag to `confluence spaces` for "give me every space, however many pages it takes".
- Redefines `--limit` as a total cap across paginated requests (previous behaviour silently truncated at the API's per-request cap of 500).

## Background

#166 made `--limit` configurable, but the Confluence API caps results per request (typically 500). Passing `--limit 1000` still only returned 500 because we never followed the `_links.next` cursor in the response — users couldn't see spaces beyond that, with no indication anything was missing.

The repo already had a clean pagination pattern for comments / attachments / content properties (`listX` + `getAllX` + `parseNextStart`); this PR applies the same shape to spaces.

## Changes

- `lib/confluence-client.js`
  - New `listSpaces({ limit, start })` returning `{ results, nextStart }` (single page).
  - Rewrote `getSpaces(maxResults = 500, options = {})` as a pagination loop. Pass `null` to fetch every space.
- `bin/confluence.js`
  - Added `--all` option.
  - Updated `--limit` description to reflect "total cap" semantics.
  - Output now shows the count: `Available spaces (N):`.
- `tests/confluence-client.test.js`
  - Replaced the two old single-request tests (which were validating the buggy behaviour).
  - Added: single-page, multi-page aggregation following `_links.next`, `maxResults` cap with slicing, plus standalone `listSpaces` tests.
- `README.md` — updated the command table and added `--all` / `--limit` examples.

## Backwards compatibility

`getSpaces()` with no args still returns up to 500 spaces by default, so callers see no behavioural change *unless* their tenant actually has >500 spaces — in which case they now get correct results instead of a silent truncation. Worth a CHANGELOG note on release.

## Test plan

- [x] `npx jest` — 633/633 passing
- [ ] Manual smoke test against a tenant with >500 spaces (`confluence spaces --all` should return more than 500)
- [ ] Manual smoke test that `confluence spaces` (no flags) still works on small tenants