### PR TITLE
fix(walker): preserve attributes on <ul>/<ol>/<li> in markdown→storage

### DIFF
--- a/lib/html-to-storage.js
+++ b/lib/html-to-storage.js
@@ -344,10 +344,11 @@ function dispatchTag(node, ctx) {
     return `<img${renderAttrs(node.attribs)}>`;
   case 'ul':
   case 'ol':
-    return `<${node.name}>${walkChildren(node, ctx)}</${node.name}>`;
+    return `<${node.name}${renderAttrs(node.attribs)}>${walkChildren(node, ctx)}</${node.name}>`;
   case 'li': {
     const inner = walkChildren(node, ctx);
-    return shouldWrapInP(node) ? `<li><p>${inner}</p></li>` : `<li>${inner}</li>`;
+    const open = `<li${renderAttrs(node.attribs)}>`;
+    return shouldWrapInP(node) ? `${open}<p>${inner}</p></li>` : `${open}${inner}</li>`;
   }
   case 'pre':
     return convertCodeBlock(node, ctx);

--- a/tests/html-to-storage.test.js
+++ b/tests/html-to-storage.test.js
@@ -92,6 +92,26 @@ describe('htmlToStorage', () => {
       expect(htmlToStorage('<ol><li>one</li></ol>'))
         .toBe('<ol><li><p>one</p></li></ol>');
     });
+
+    test('<ul> attributes are preserved on output', () => {
+      expect(htmlToStorage('<ul class="task-list" style="color:red"><li>x</li></ul>'))
+        .toBe('<ul class="task-list" style="color:red"><li><p>x</p></li></ul>');
+    });
+
+    test('<ol> attributes including start are preserved', () => {
+      expect(htmlToStorage('<ol class="numbered" start="3"><li>x</li></ol>'))
+        .toBe('<ol class="numbered" start="3"><li><p>x</p></li></ol>');
+    });
+
+    test('<li> attributes are preserved on the opening tag', () => {
+      expect(htmlToStorage('<ul><li class="highlighted">x</li></ul>'))
+        .toBe('<ul><li class="highlighted"><p>x</p></li></ul>');
+    });
+
+    test('<li> attributes survive when wrap is suppressed (block child)', () => {
+      expect(htmlToStorage('<ul><li class="x">outer<ul><li>inner</li></ul></li></ul>'))
+        .toBe('<ul><li class="x">outer<ul><li><p>inner</p></li></ul></li></ul>');
+    });
   });
 
   describe('code blocks', () => {


### PR DESCRIPTION
### Description

Addresses follow-up 1 from the #153 review (`<ul>` / `<ol>` missing `renderAttrs`).

`<ul>`, `<ol>`, and `<li>` were the only block-level elements in `lib/html-to-storage.js` that dropped their attributes. The `<table>` family already threaded `renderAttrs(node.attribs)` through, so the same plumbing is added here. For raw-HTML input via `--input-format html`, this means `<ul class="task-list">` and `<ol start="3">` now reach the storage payload with attributes intact instead of as bare `<ul>` / `<ol>`.

The `<ul>` / `<ol>` and `<table>` cases are kept as separate `case` blocks (rather than collapsed into one) to preserve the per-domain whitelist intent the rest of `dispatchTag` follows.

For `<li>`, the opening tag is hoisted into an `open` variable so both wrap and unwrap branches share it (same pattern as `<th>` / `<td>`).

### Verification (Confluence Cloud)

| Attribute | Storage save | Notes |
|-----------|--------------|-------|
| `class` on `<ul>` / `<ol>` / `<li>` | preserved | |
| `style` on `<ul>` / `<ol>` / `<li>` | preserved (normalized) | |
| `start` on `<ol>` | preserved | |
| `id`, `data-*`, `target`, `rel`, `type`, `value`, `reversed` | stripped server-side | Safe to emit anyway |

Also verified that `class` position on `<li>` vs the inner `<p>` does not affect storage preservation or rendered HTML — the current walker output shape (`<li class="x"><p>content</p></li>`) is fully accepted.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Testing

- [x] Tests pass locally with my changes (633 passing, was 630)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

4 new regression tests in `tests/html-to-storage.test.js`:
- `<ul>` with `class` + `style`
- `<ol>` with `class` + `start`
- `<li>` with `class` on the wrap path
- `<li>` with attribute on the unwrap path (block child suppresses `<p>` wrap)

### Out of scope

Round-trip preservation. The storage walker strips list attributes on storage → markdown export, so `<ul class>` round-trip loses its class regardless. That side needs its own design call (markdown has no native attribute syntax).