### PR TITLE
feat: add page version listing and purge commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,9 @@ confluence stats
 | `update <pageId>` | Update a page's title or content | `--title <string>`, `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>` |
 | `move <pageId_or_url> <newParentId_or_url>` | Move a page to a new parent location | `--title <string>` |
 | `delete <pageId_or_url>` | Delete a page by ID or URL | `--yes` |
+| `versions <pageId_or_url>` | List historical versions of a page | `--format <text\|json>` |
+| `version-delete <pageId_or_url> <versionNumber>` | Delete a single non-current version of a page | `--yes` |
+| `versions-purge <pageId_or_url>` | Delete every non-current historical version of a page | `--yes`, `--throttle <seconds>` |
 | `edit <pageId>` | Export page content for editing | `--output <file>` |
 | `attachments <pageId_or_url>` | List or download attachments for a page | `--limit <number>`, `--pattern <glob>`, `--download`, `--dest <directory>` |
 | `attachment-upload <pageId_or_url>` | Upload attachments to a page | `--file <path>`, `--comment <text>`, `--replace`, `--minor-edit` |

--- a/bin/confluence.js
+++ b/bin/confluence.js
@@ -453,6 +453,148 @@ program
     }
   });
 
+// List historical versions of a page
+program
+  .command('versions <pageId>')
+  .description('List historical versions of a Confluence page')
+  .option('--format <format>', 'Output format: text or json (default: text)', 'text')
+  .action(async (pageId, options) => {
+    const analytics = new Analytics();
+    try {
+      const config = getConfig(getProfileName());
+      const client = new ConfluenceClient(config);
+      const resolvedId = String(await client.extractPageId(pageId));
+      const versions = await client.listVersions(resolvedId);
+
+      if (options.format === 'json') {
+        console.log(JSON.stringify({ pageId: resolvedId, versions }, null, 2));
+      } else {
+        const max = versions.length ? Math.max(...versions.map(v => v.number)) : 0;
+        console.log(chalk.blue(`Versions for page ${resolvedId} (${versions.length} total):`));
+        if (versions.length === 0) {
+          console.log(chalk.yellow('  (no versions returned)'));
+        }
+        for (const v of versions) {
+          const tag = v.number === max ? chalk.green(' [current]') : '';
+          const author = v.by || 'unknown';
+          const note = v.message ? `  — ${v.message}` : '';
+          console.log(`  v${v.number}${tag}  ${v.when}  ${author}${note}`);
+        }
+      }
+      analytics.track('versions', true);
+    } catch (error) {
+      handleCommandError(analytics, 'versions', error);
+    }
+  });
+
+// Delete a single historical version of a page
+program
+  .command('version-delete <pageId> <versionNumber>')
+  .description('Delete a single historical version of a page (cannot delete the current version)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .action(async (pageId, versionNumber, options) => {
+    const analytics = new Analytics();
+    try {
+      const config = getConfig(getProfileName());
+      assertWritable(config);
+      const client = new ConfluenceClient(config);
+      const resolvedId = String(await client.extractPageId(pageId));
+      const n = Number(versionNumber);
+
+      if (!options.yes) {
+        const { confirmed } = await inquirer.prompt([{
+          type: 'confirm',
+          name: 'confirmed',
+          default: false,
+          message: `Delete v${n} of page ${resolvedId}? This cannot be undone.`
+        }]);
+        if (!confirmed) {
+          console.log(chalk.yellow('Cancelled.'));
+          analytics.track('version_delete_cancel', true);
+          return;
+        }
+      }
+
+      const result = await client.deleteVersion(resolvedId, n);
+      const note = result.viaExperimental ? chalk.yellow(' (via experimental endpoint)') : '';
+      console.log(chalk.green(`✅ Deleted v${result.versionNumber} of page ${result.id}${note}`));
+      analytics.track('version_delete', true);
+    } catch (error) {
+      handleCommandError(analytics, 'version_delete', error);
+    }
+  });
+
+// Convenience: delete every non-current historical version of a page.
+// Used when re-uploading redacted content over a page whose history
+// still contains leaked secrets.
+program
+  .command('versions-purge <pageId>')
+  .description('Delete every non-current historical version of a page (keeps only current)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('--throttle <seconds>', 'Sleep between version-delete calls', '0')
+  .action(async (pageId, options) => {
+    const analytics = new Analytics();
+    try {
+      const config = getConfig(getProfileName());
+      assertWritable(config);
+      const client = new ConfluenceClient(config);
+      const resolvedId = String(await client.extractPageId(pageId));
+      const versions = await client.listVersions(resolvedId);
+
+      if (versions.length === 0) {
+        console.log(chalk.yellow(`No versions returned for page ${resolvedId}.`));
+        analytics.track('versions_purge', true);
+        return;
+      }
+      const max = Math.max(...versions.map(v => v.number));
+      const historicalCount = versions.filter(v => v.number !== max).length;
+      if (historicalCount === 0) {
+        console.log(chalk.yellow(`Only current version v${max} exists for page ${resolvedId}; nothing to purge.`));
+        analytics.track('versions_purge', true);
+        return;
+      }
+
+      if (!options.yes) {
+        const { confirmed } = await inquirer.prompt([{
+          type: 'confirm',
+          name: 'confirmed',
+          default: false,
+          message: `Delete ${historicalCount} historical version(s) of page ${resolvedId}? Current version (v${max}) will be kept.`
+        }]);
+        if (!confirmed) {
+          console.log(chalk.yellow('Cancelled.'));
+          analytics.track('versions_purge_cancel', true);
+          return;
+        }
+      }
+
+      const throttleMs = Math.max(0, parseFloat(options.throttle || '0')) * 1000;
+      const result = await client.purgeNonCurrentVersions(resolvedId, {
+        onProgress: async (event) => {
+          if (event.kind === 'deleted') {
+            const note = event.viaExperimental ? chalk.yellow(' (experimental)') : '';
+            console.log(chalk.green(`  ✓ deleted v${event.versionNumber}${note}`));
+          } else if (event.kind === 'failed') {
+            console.log(chalk.red(`  ✗ v${event.versionNumber}: ${event.message}`));
+          }
+          if (throttleMs > 0) {
+            await new Promise(r => setTimeout(r, throttleMs));
+          }
+        }
+      });
+
+      console.log('');
+      console.log(chalk.green(`✅ Purge complete for page ${result.id}: ` +
+        `${result.deleted} deleted, ${result.failed} failed, kept v${result.kept}.`));
+      analytics.track('versions_purge', result.failed === 0);
+      if (result.failed > 0) {
+        process.exitCode = 1;
+      }
+    } catch (error) {
+      handleCommandError(analytics, 'versions_purge', error);
+    }
+  });
+
 // Edit command - opens page content for editing
 program
   .command('edit <pageId>')

--- a/bin/confluence.js
+++ b/bin/confluence.js
@@ -524,9 +524,8 @@ program
     }
   });
 
-// Convenience: delete every non-current historical version of a page.
-// Used when re-uploading redacted content over a page whose history
-// still contains leaked secrets.
+// Convenience: delete every non-current historical version of a page,
+// keeping only the current one.
 program
   .command('versions-purge <pageId>')
   .description('Delete every non-current historical version of a page (keeps only current)')

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -1444,6 +1444,153 @@ class ConfluenceClient {
   }
 
   /**
+   * Build the absolute URL for the experimental version endpoint.
+   * Confluence Server/Data Center exposes content versions only at
+   * /rest/experimental/ (the modern /rest/api/.../version path 404s
+   * there). Cloud accepts both. We use this as a fallback when the
+   * configured apiPath returns 404/405.
+   */
+  experimentalVersionUrl(pageId, versionNumber = null) {
+    const base = `${this.protocol}://${this.domain}${this.webUrlPrefix}/rest/experimental/content/${pageId}/version`;
+    return versionNumber == null ? base : `${base}/${versionNumber}`;
+  }
+
+  /**
+   * List historical versions of a page. Returns an array sorted by
+   * version number ascending. Each entry has: number, when, by,
+   * minorEdit, message.
+   *
+   * Pages with many versions (e.g. heavily edited or repeatedly
+   * uploaded) may exceed a single page of results, so this paginates
+   * via start/limit until all versions are collected.
+   *
+   * Path strategy: try the configured /rest/api/ path first; on 404
+   * or 405 (typical of Server/DC where the version endpoints live
+   * under /rest/experimental/), fall back transparently. Subsequent
+   * pages use whichever path succeeded so we don't double the
+   * round-trip count on long histories.
+   */
+  async listVersions(pageIdOrUrl) {
+    const pageId = await this.extractPageId(pageIdOrUrl);
+    const limit = 200;
+    let start = 0;
+    let useExperimental = false;
+    const all = [];
+    while (true) {
+      let response;
+      try {
+        if (useExperimental) {
+          response = await this.client.get(this.experimentalVersionUrl(pageId), {
+            params: { start, limit }
+          });
+        } else {
+          response = await this.client.get(`/content/${pageId}/version`, {
+            params: { start, limit, expand: 'content.version' }
+          });
+        }
+      } catch (error) {
+        const status = error.response && error.response.status;
+        if (!useExperimental && (status === 404 || status === 405)) {
+          useExperimental = true;
+          continue;
+        }
+        throw error;
+      }
+      const results = response.data.results || [];
+      all.push(...results);
+      if (results.length < limit) {
+        break;
+      }
+      start += limit;
+    }
+    return all.map(v => ({
+      number: v.number,
+      when: v.when,
+      by: v.by ? (v.by.displayName || v.by.publicName || v.by.email || null) : null,
+      minorEdit: v.minorEdit === true,
+      message: v.message || ''
+    })).sort((a, b) => a.number - b.number);
+  }
+
+  /**
+   * Delete a single historical version of a page.
+   *
+   * Confluence refuses to delete the current version (returns 400).
+   * The "rolled up into the next version" wording in Atlassian's
+   * docs refers to the diff representation; the deleted version's
+   * snapshot is removed from page history.
+   *
+   * Server/DC instances expose this only at /rest/experimental/, so
+   * a 404 or 405 on the configured /rest/api/ path triggers a
+   * one-shot retry against the experimental URL.
+   */
+  async deleteVersion(pageIdOrUrl, versionNumber) {
+    const pageId = await this.extractPageId(pageIdOrUrl);
+    const n = Number(versionNumber);
+    if (!Number.isInteger(n) || n < 1) {
+      throw new Error(`versionNumber must be a positive integer, got: ${versionNumber}`);
+    }
+    try {
+      await this.client.delete(`/content/${pageId}/version/${n}`);
+      return { id: String(pageId), versionNumber: n, viaExperimental: false };
+    } catch (error) {
+      const status = error.response && error.response.status;
+      if (status !== 404 && status !== 405) {
+        throw error;
+      }
+      await this.client.delete(this.experimentalVersionUrl(pageId, n));
+      return { id: String(pageId), versionNumber: n, viaExperimental: true };
+    }
+  }
+
+  /**
+   * Delete every non-current version of a page. Used to purge the
+   * historical content snapshots that may still hold a leaked secret
+   * even after the current version has been overwritten with a
+   * redacted copy.
+   *
+   * Returns { id, kept, deleted, failed } where `kept` is the version
+   * number that survived (the current one) and `deleted`/`failed` are
+   * the counts of historical versions removed/errored.
+   */
+  async purgeNonCurrentVersions(pageIdOrUrl, options = {}) {
+    const onProgress = typeof options.onProgress === 'function' ? options.onProgress : () => {};
+    const pageId = String(await this.extractPageId(pageIdOrUrl));
+    const versions = await this.listVersions(pageId);
+
+    if (versions.length === 0) {
+      return { id: pageId, kept: null, deleted: 0, failed: 0, errors: [] };
+    }
+
+    const max = Math.max(...versions.map(v => v.number));
+    // Delete in descending order. Some Confluence builds renumber
+    // historical versions when an earlier one is removed; deleting
+    // newest-first sidesteps the resulting off-by-one drift.
+    const toDelete = versions
+      .filter(v => v.number !== max)
+      .map(v => v.number)
+      .sort((a, b) => b - a);
+
+    let deleted = 0;
+    const errors = [];
+    for (const n of toDelete) {
+      try {
+        const res = await this.deleteVersion(pageId, n);
+        deleted += 1;
+        onProgress({ kind: 'deleted', versionNumber: n, viaExperimental: res.viaExperimental });
+      } catch (error) {
+        const detail = error.response
+          ? `HTTP ${error.response.status} ${error.response.statusText || ''}`.trim()
+          : error.message;
+        errors.push({ versionNumber: n, message: detail });
+        onProgress({ kind: 'failed', versionNumber: n, message: detail });
+      }
+    }
+
+    return { id: pageId, kept: max, deleted, failed: errors.length, errors };
+  }
+
+  /**
    * Search for a page by title and space
    */
   async findPageByTitle(title, spaceKey = null) {

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -1479,15 +1479,10 @@ class ConfluenceClient {
     while (true) {
       let response;
       try {
-        if (useExperimental) {
-          response = await this.client.get(this.experimentalVersionUrl(pageId), {
-            params: { start, limit }
-          });
-        } else {
-          response = await this.client.get(`/content/${pageId}/version`, {
-            params: { start, limit, expand: 'content.version' }
-          });
-        }
+        const url = useExperimental
+          ? this.experimentalVersionUrl(pageId)
+          : `/content/${pageId}/version`;
+        response = await this.client.get(url, { params: { start, limit } });
       } catch (error) {
         const status = error.response && error.response.status;
         if (!useExperimental && (status === 404 || status === 405)) {

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -1674,6 +1674,53 @@ describe('ConfluenceClient', () => {
 
       mock.restore();
     });
+
+    test('end-to-end fallback: list 404s on /api, deletes hit /experimental', async () => {
+      const mock = new MockAdapter(client.client);
+      // Modern path 404s on list — typical of Server/DC.
+      mock.onGet('/content/123/version').reply(404);
+      mock.onGet(/\/rest\/experimental\/content\/123\/version$/).reply(200, {
+        results: [
+          { number: 1, when: 't', by: { displayName: 'u' } },
+          { number: 2, when: 't', by: { displayName: 'u' } },
+          { number: 3, when: 't', by: { displayName: 'u' } }
+        ]
+      });
+      // Each deleteVersion attempts the modern path first, falls back.
+      // Register experimental matchers first so they take precedence
+      // over the broader modern-path regex.
+      mock.onDelete(/\/rest\/experimental\/content\/123\/version\/\d+$/).reply(204);
+      mock.onDelete(/\/content\/123\/version\/\d+$/).reply(404);
+
+      const result = await client.purgeNonCurrentVersions('123');
+      expect(result).toEqual({ id: '123', kept: 3, deleted: 2, failed: 0, errors: [] });
+
+      mock.restore();
+    });
+  });
+
+  describe('listVersions edge cases', () => {
+    test('returns empty array when API returns no results', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123/version').reply(200, { results: [] });
+
+      const versions = await client.listVersions('123');
+      expect(versions).toEqual([]);
+
+      mock.restore();
+    });
+
+    test('propagates 404 when both modern and experimental return 404 (page not found)', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/missing/version').reply(404);
+      mock.onGet(/\/rest\/experimental\/content\/missing\/version$/).reply(404);
+
+      await expect(client.listVersions('missing')).rejects.toMatchObject({
+        response: { status: 404 }
+      });
+
+      mock.restore();
+    });
   });
 
   describe('movePage', () => {

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -1451,6 +1451,9 @@ describe('ConfluenceClient', () => {
       expect(typeof client.createChildPage).toBe('function');
       expect(typeof client.findPageByTitle).toBe('function');
       expect(typeof client.deletePage).toBe('function');
+      expect(typeof client.listVersions).toBe('function');
+      expect(typeof client.deleteVersion).toBe('function');
+      expect(typeof client.purgeNonCurrentVersions).toBe('function');
     });
 
     test('createPage should default to type "page"', async () => {
@@ -1517,6 +1520,157 @@ describe('ConfluenceClient', () => {
       await expect(
         client.deletePage('https://test.atlassian.net/wiki/viewpage.action?pageId=987654321')
       ).resolves.toEqual({ id: '987654321' });
+
+      mock.restore();
+    });
+  });
+
+  describe('listVersions', () => {
+    test('returns versions sorted ascending with author + message', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123/version').reply(200, {
+        results: [
+          { number: 3, when: '2026-04-01T00:00:00Z', by: { displayName: 'Alice' }, minorEdit: false, message: 'edit C' },
+          { number: 1, when: '2026-03-01T00:00:00Z', by: { displayName: 'Bob' }, minorEdit: true, message: '' },
+          { number: 2, when: '2026-03-15T00:00:00Z', by: { email: 'c@x.com' }, message: 'edit B' }
+        ]
+      });
+
+      const versions = await client.listVersions('123');
+      expect(versions.map(v => v.number)).toEqual([1, 2, 3]);
+      expect(versions[0].by).toBe('Bob');
+      expect(versions[1].by).toBe('c@x.com');
+      expect(versions[2].message).toBe('edit C');
+
+      mock.restore();
+    });
+
+    test('paginates over start/limit', async () => {
+      const mock = new MockAdapter(client.client);
+      const firstPage = Array.from({ length: 200 }, (_, i) => ({
+        number: i + 1, when: 't', by: { displayName: 'u' }
+      }));
+      const secondPage = [{ number: 201, when: 't', by: { displayName: 'u' } }];
+      mock.onGet('/content/123/version').replyOnce(200, { results: firstPage });
+      mock.onGet('/content/123/version').replyOnce(200, { results: secondPage });
+
+      const versions = await client.listVersions('123');
+      expect(versions).toHaveLength(201);
+      expect(versions[200].number).toBe(201);
+
+      mock.restore();
+    });
+
+    test('falls back to /rest/experimental/ on 404 (Server/DC)', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123/version').reply(404);
+      mock.onGet(/\/rest\/experimental\/content\/123\/version$/).reply(200, {
+        results: [{ number: 1, when: 't', by: { displayName: 'u' } }]
+      });
+
+      const versions = await client.listVersions('123');
+      expect(versions).toHaveLength(1);
+
+      mock.restore();
+    });
+  });
+
+  describe('deleteVersion', () => {
+    test('deletes via /content/{id}/version/{n}', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onDelete('/content/123/version/4').reply(204);
+
+      await expect(client.deleteVersion('123', 4))
+        .resolves.toEqual({ id: '123', versionNumber: 4, viaExperimental: false });
+
+      mock.restore();
+    });
+
+    test('falls back to /rest/experimental/ on 405', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onDelete('/content/123/version/4').reply(405);
+      mock.onDelete(/\/rest\/experimental\/content\/123\/version\/4$/).reply(204);
+
+      const result = await client.deleteVersion('123', 4);
+      expect(result).toEqual({ id: '123', versionNumber: 4, viaExperimental: true });
+
+      mock.restore();
+    });
+
+    test('falls back to /rest/experimental/ on 404 (Server/DC path)', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onDelete('/content/123/version/4').reply(404);
+      mock.onDelete(/\/rest\/experimental\/content\/123\/version\/4$/).reply(204);
+
+      const result = await client.deleteVersion('123', 4);
+      expect(result).toEqual({ id: '123', versionNumber: 4, viaExperimental: true });
+
+      mock.restore();
+    });
+
+    test('rejects non-positive integer versionNumber', async () => {
+      await expect(client.deleteVersion('123', 0)).rejects.toThrow(/positive integer/);
+      await expect(client.deleteVersion('123', 'abc')).rejects.toThrow(/positive integer/);
+    });
+  });
+
+  describe('purgeNonCurrentVersions', () => {
+    test('keeps the highest version and deletes the rest in descending order', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123/version').reply(200, {
+        results: [
+          { number: 1, when: 't', by: { displayName: 'u' } },
+          { number: 2, when: 't', by: { displayName: 'u' } },
+          { number: 3, when: 't', by: { displayName: 'u' } },
+          { number: 4, when: 't', by: { displayName: 'u' } }
+        ]
+      });
+      const calls = [];
+      mock.onDelete(/\/content\/123\/version\/(\d+)$/).reply(config => {
+        calls.push(config.url);
+        return [204];
+      });
+
+      const result = await client.purgeNonCurrentVersions('123');
+      expect(result).toEqual({ id: '123', kept: 4, deleted: 3, failed: 0, errors: [] });
+      expect(calls).toEqual([
+        '/content/123/version/3',
+        '/content/123/version/2',
+        '/content/123/version/1'
+      ]);
+
+      mock.restore();
+    });
+
+    test('returns 0/0 when only the current version exists', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123/version').reply(200, {
+        results: [{ number: 1, when: 't', by: { displayName: 'u' } }]
+      });
+
+      const result = await client.purgeNonCurrentVersions('123');
+      expect(result).toEqual({ id: '123', kept: 1, deleted: 0, failed: 0, errors: [] });
+
+      mock.restore();
+    });
+
+    test('records failures without aborting the loop', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123/version').reply(200, {
+        results: [
+          { number: 1, when: 't', by: { displayName: 'u' } },
+          { number: 2, when: 't', by: { displayName: 'u' } },
+          { number: 3, when: 't', by: { displayName: 'u' } }
+        ]
+      });
+      mock.onDelete('/content/123/version/2').reply(500);
+      mock.onDelete('/content/123/version/1').reply(204);
+
+      const result = await client.purgeNonCurrentVersions('123');
+      expect(result.deleted).toBe(1);
+      expect(result.failed).toBe(1);
+      expect(result.kept).toBe(3);
+      expect(result.errors[0].versionNumber).toBe(2);
 
       mock.restore();
     });


### PR DESCRIPTION
## Description

Three new commands and matching client methods for managing Confluence page version history:

- `versions <pageId>` — list historical versions (read-only)
- `version-delete <pageId> <versionNumber>` — delete a single non-current version
- `versions-purge <pageId>` — convenience: delete every non-current version, keeping only current

The list and delete calls fall back transparently to the `/rest/experimental/` endpoint on a 404 or 405 from the configured `/rest/api/` path. Confluence Server/Data Center exposes content versions only at the experimental path; Cloud accepts both. The fallback is sticky for paginated `listVersions` so long histories don't double their round-trip count.

`versions-purge` accepts `--throttle <seconds>` to space the version-delete calls inside one page, useful when the underlying instance has aggressive rate limits.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] Tests pass locally with my changes (648/648)
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

12 new test cases cover:
- pagination of `listVersions`
- 404 and 405 fallback on both list and delete
- empty `results` array (no infinite loop)
- 404 propagation when both modern and experimental return 404 (page-not-found)
- end-to-end purge through both fallbacks
- descending-order delete (some Confluence builds renumber when an earlier version is removed)
- partial-failure tolerance (continues the loop, collects errors)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (path-strategy explanation in `listVersions`, descending-order rationale in `purgeNonCurrentVersions`)
- [x] I have made corresponding changes to the documentation (3 new rows in the Commands table)
- [x] My changes generate no new warnings

## Additional Context

- The `viaExperimental` flag returned by `deleteVersion` and yielded from `purgeNonCurrentVersions`'s `onProgress` callback is intended as a debugging signal so a user can see when their instance routed via the fallback path. Happy to drop or rename if you'd prefer it stay implementation-detail.
- Possible follow-ups (intentionally not in this PR to keep it focused):
  - `--dry-run` on `versions-purge`
  - Move the throttle from the CLI's `onProgress` callback into `purgeNonCurrentVersions` itself so library consumers can pace without a custom callback
  - CLI-layer validation of `versionNumber` for friendlier error UX