### PR TITLE
fix(deps): bump axios to ~1.15.2 to address security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.15.0",
+        "axios": "~1.15.2",
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
         "entities": "^4.5.0",
@@ -1504,9 +1504,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "pchuri",
   "license": "MIT",
   "dependencies": {
-    "axios": "^1.15.0",
+    "axios": "~1.15.2",
     "chalk": "^4.1.2",
     "commander": "^11.1.0",
     "entities": "^4.5.0",


### PR DESCRIPTION
## Summary

- Pin `axios` to the `1.15.x` patch range (`~1.15.2`) to resolve 13 high-severity advisories covering the `1.0.0 – 1.15.1` range.
- Unblocks the `security` CI job (`npm audit --audit-level moderate --omit=dev`) which was failing on every push to `main` and PRs.
- `~1.15.2` keeps us on a known-good 1.15.x patch line (avoiding the very recent 1.16.0 minor whose behavioral changes haven't yet had time to surface).

## Affected advisories

axios `1.0.0 – 1.15.1` — fixed in `1.15.2`:

- GHSA-w9j2-pvgh-6h63 — Authentication Bypass via Prototype Pollution in `validateStatus`
- GHSA-pmwg-cvhr-8vh7 — Incomplete fix for CVE-2025-62718 (NO_PROXY 127.0.0.0/8 bypass)
- GHSA-3w6x-2g7m-8v23 — Invisible JSON Response Tampering via Prototype Pollution in `parseReviver`
- GHSA-q8qp-cvcw-x6jj — Prototype pollution read-side gadgets in HTTP adapter
- GHSA-xhjh-pmcv-23jw — Null Byte Injection via Reverse-Encoding in `AxiosURLSearchParams`
- GHSA-445q-vr5w-6q77 — CRLF Injection in `multipart/form-data` via unsanitized `blob.type`
- GHSA-m7pr-hjqh-92cm — `no_proxy` bypass via IP alias allows SSRF
- GHSA-62hf-57xw-28j9 — Unbounded recursion in `toFormData` (DoS)
- GHSA-5c9x-8gcm-mpgx — HTTP adapter streamed uploads bypass `maxBodyLength` when `maxRedirects: 0`
- GHSA-vf2m-468p-8v99 — HTTP adapter streamed responses bypass `maxContentLength`
- GHSA-pf86-5x62-jrwf — Prototype Pollution Gadgets (Response Tampering, Data Exfiltration, Request Hijacking)
- GHSA-6chq-wfr3-2hj9 — Header Injection via Prototype Pollution
- GHSA-xx6v-rp6x-q39c — XSRF Token Cross-Origin Leakage via Prototype Pollution in `withXSRFToken`

## Local verification

| Check | Result |
|---|---|
| `npm ls axios` | `axios@1.15.2` (prod + dev sub-dep deduped) |
| `npm audit --audit-level moderate --omit=dev` | exit 0, `found 0 vulnerabilities` |
| `npm test` | 15 suites / 652 tests pass |
| `npm run lint` | clean |

## Test plan

- [x] `npm audit --audit-level moderate --omit=dev` exits 0 locally
- [x] All existing tests pass
- [x] Lint passes
- [ ] CI green on Node 18.x / 20.x / 22.x
- [ ] Manual smoke test against a real Confluence instance:
  - [ ] Authenticated GET (`confluence get <pageId>`)
  - [ ] Tiny-link redirect resolution (`confluence get https://<domain>/wiki/x/<code>`) — exercises `extractPageId`'s `maxRedirects: 0` + custom `validateStatus` path, which is touched by GHSA-w9j2-pvgh-6h63 and GHSA-5c9x-8gcm-mpgx
  - [ ] Attachment upload (`confluence attach upload ...`) — exercises FormData / `maxBodyLength: Infinity` path, touched by GHSA-445q-vr5w-6q77 and GHSA-vf2m-468p-8v99

Closes #173