### PR TITLE
chore(ci): bump actions/checkout and actions/setup-node to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -35,7 +35,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: npm ci
     - name: Run npm audit (production only)
       run: npm audit --audit-level moderate --omit=dev
@@ -53,13 +53,13 @@ jobs:
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '18'
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
         node-version: [18.x, 20.x, 22.x]
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -35,7 +35,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - run: npm ci
     - name: Run npm audit (production only)
       run: npm audit --audit-level moderate --omit=dev
@@ -53,13 +53,13 @@ jobs:
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '18'
         registry-url: 'https://registry.npmjs.org'
@@ -116,7 +116,7 @@ jobs:
           echo "url=${URL}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout homebrew-tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: pchuri/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary

Bumps all `actions/checkout` and `actions/setup-node` references in `.github/workflows/ci.yml` to `@v5` to clear the Node 20 deprecation warnings on every CI run.

## Context

The original plan (issue #175) was to bump `@v3 → @v4`. Verifying CI logs after that hop showed the warning still fires on `@v4`:

> `Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4`

`@v5` runs on Node 24 and clears the warning immediately, instead of waiting for GitHub's forced auto-migration of v4.

## Scope

| Line | Job | Before | After |
|---|---|---|---|
| 23 | `test` | `actions/checkout@v3` | `actions/checkout@v5` |
| 26 | `test` | `actions/setup-node@v3` | `actions/setup-node@v5` |
| 38 | `security` | `actions/checkout@v3` | `actions/checkout@v5` |
| 56 | `publish` | `actions/checkout@v3` | `actions/checkout@v5` |
| 62 | `publish` | `actions/setup-node@v3` | `actions/setup-node@v5` |
| 119 | `update-homebrew` | `actions/checkout@v4` | `actions/checkout@v5` |

Line 119 was already at `@v4`; bumped along with the rest for consistency.

## Test plan

- [ ] CI test matrix passes on Node 18.x / 20.x / 22.x (v5 of setup-node still installs older Node versions for the project; only the action's own runtime is Node 24)
- [ ] `security` job (npm audit) passes
- [ ] No more `Node.js 20 actions are deprecated` warning annotations on this run
- [ ] `publish` / `update-homebrew` paths are unchanged in behavior (no release-triggering changes)

Closes #175