### PR TITLE
fix(convert): route html → markdown through htmlToMarkdown

### DIFF
--- a/bin/confluence.js
+++ b/bin/confluence.js
@@ -2200,7 +2200,7 @@ program
         const { convert: htmlToText } = require('html-to-text');
         output = htmlToText(input, { wordwrap: 130 });
       } else if (options.inputFormat === 'html' && options.outputFormat === 'markdown') {
-        output = converter.storageToMarkdown(input);
+        output = converter.htmlToMarkdown(input);
       } else if (options.inputFormat === 'markdown' && options.outputFormat === 'text') {
         const html = converter.markdown.render(input);
         const { convert: htmlToText } = require('html-to-text');

--- a/tests/convert.test.js
+++ b/tests/convert.test.js
@@ -95,6 +95,13 @@ describe('convert command', () => {
     expect(output).toContain('<strong>bold</strong>');
   });
 
+  test('html to markdown', () => {
+    const inputFile = writeInput('input.html', '<p><strong>bold</strong> and <em>italic</em></p>');
+    const output = run(['convert', '--input-file', inputFile, '--input-format', 'html', '--output-format', 'markdown']);
+    expect(output).toContain('**bold**');
+    expect(output).toContain('*italic*');
+  });
+
   test('storage to text', () => {
     const inputFile = writeInput('input.xml', '<h1>Title</h1><p>Content</p>');
     const output = run(['convert', '--input-file', inputFile, '--input-format', 'storage', '--output-format', 'text']);

--- a/tests/convert.test.js
+++ b/tests/convert.test.js
@@ -95,11 +95,17 @@ describe('convert command', () => {
     expect(output).toContain('<strong>bold</strong>');
   });
 
-  test('html to markdown', () => {
-    const inputFile = writeInput('input.html', '<p><strong>bold</strong> and <em>italic</em></p>');
+  test('html to markdown preserves fenced code blocks with language', () => {
+    // Multi-line <pre><code class="language-*"> is the discriminating case
+    // between htmlToMarkdown and storageToMarkdown: the former emits a
+    // fenced block with the language tag, the latter collapses the body
+    // into inline `code` and drops the language. This test fails if the
+    // html → markdown path is ever routed back through storageToMarkdown.
+    const html = '<p><strong>bold</strong></p>\n<pre><code class="language-js">const x = 1;\nconst y = 2;</code></pre>';
+    const inputFile = writeInput('input.html', html);
     const output = run(['convert', '--input-file', inputFile, '--input-format', 'html', '--output-format', 'markdown']);
     expect(output).toContain('**bold**');
-    expect(output).toContain('*italic*');
+    expect(output).toMatch(/```js\nconst x = 1;\nconst y = 2;\n```/);
   });
 
   test('storage to text', () => {


### PR DESCRIPTION
## Summary
- The `convert --input-format html --output-format markdown` path was calling `converter.storageToMarkdown(input)`.
- `storageToMarkdown` is built for Confluence **storage XML** (`<ac:*>` macros, a specific schema). Plain HTML inputs do not match that schema and can be misinterpreted.
- Route the html → markdown path through the existing dedicated `converter.htmlToMarkdown(input)` API instead.

## Test plan
- [x] New CLI test `html to markdown` in `tests/convert.test.js` covers the path
- [x] `npm run lint` passes
- [x] `npm test` — 670 tests across 15 suites pass (was 669)