### PR TITLE
fix(client): route createPage/createChildPage html through htmlToConfluenceStorage

### DIFF
--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -1260,8 +1260,7 @@ class ConfluenceClient {
       if (format === 'markdown') {
         storageContent = this.markdownToStorage(content);
       } else if (format === 'html') {
-        // Convert HTML directly to storage format (no macro wrapper)
-        storageContent = content;
+        storageContent = this.htmlToConfluenceStorage(content);
       }
 
       pageData.body = {
@@ -1299,8 +1298,7 @@ class ConfluenceClient {
       if (format === 'markdown') {
         storageContent = this.markdownToStorage(content);
       } else if (format === 'html') {
-        // Convert HTML directly to storage format (no macro wrapper)
-        storageContent = content;
+        storageContent = this.htmlToConfluenceStorage(content);
       }
 
       pageData.body = {

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -1501,6 +1501,34 @@ describe('ConfluenceClient', () => {
       expect(requestData.body).toBeUndefined();
       mock.restore();
     });
+
+    test('createPage with format="html" routes through htmlToConfluenceStorage', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onPost('/content').reply(200, { id: '444' });
+      const spy = jest.spyOn(client, 'htmlToConfluenceStorage');
+
+      await client.createPage('T', 'TEST', '<p>x</p>', 'html');
+
+      expect(spy).toHaveBeenCalledWith('<p>x</p>');
+      const body = JSON.parse(mock.history.post[0].data).body.storage;
+      expect(body.representation).toBe('storage');
+      expect(body.value).toBe('<p>x</p>');
+
+      spy.mockRestore();
+      mock.restore();
+    });
+
+    test('createChildPage with format="html" routes through htmlToConfluenceStorage', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onPost('/content').reply(200, { id: '555' });
+      const spy = jest.spyOn(client, 'htmlToConfluenceStorage');
+
+      await client.createChildPage('T', 'TEST', '100', '<p>x</p>', 'html');
+
+      expect(spy).toHaveBeenCalledWith('<p>x</p>');
+      spy.mockRestore();
+      mock.restore();
+    });
   });
 
   describe('deletePage', () => {


### PR DESCRIPTION
## Summary

`createComment` and `updatePage` already normalize HTML input via `htmlToConfluenceStorage`, but `createPage` and `createChildPage` were passing HTML straight to storage. Confluence storage is strict XHTML, so inputs with `<br>`, `<u>`, or unclosed tags would 422 on the server. Follow-up to #180, which fixed the analogous gap in the `convert` command.

Result: a page created with `--format html` and then updated with the same content no longer mutates between the two calls.

## Behavior change

Calling `createPage`/`createChildPage` with `format='html'` previously inserted the HTML byte-for-byte. The converter now runs on it, so callers feeding pre-formed storage XHTML will see normalization:

| Input | Output |
|---|---|
| `<ri:user ri:account-id="…"/>` | `<ri:user ri:account-id="…"></ri:user>` (self-closing expanded) |
| `<ul><li>a</li></ul>` | `<ul><li><p>a</p></li></ul>` (`<p>` wrap) |
| `<div class="raw">stuff</div>` | wrapped in an `ac:structured-macro ac:name="html"` block |

`updatePage` already does all of this — so the change just removes a divergence between create and update, not introduces a new transform. The removed `// (no macro wrapper)` comment marked the previous deliberate bypass; we're dropping it on purpose.

## Test plan

- [x] `npm test` — 678/678 pass (added 2 regression tests for the html paths in `createPage` / `createChildPage`)
- [x] `npm run lint` — clean
- [x] Manual edge-case check on the converter: `<br>`, `<u>`, `<sub>`, `<img>`, empty/whitespace, `ac:structured-macro`, `<ul>/<li>`, `<table>`, `<div>` — confirmed the transforms above