### PR TITLE
fix(convert): read stdin as a stream and guard against TTY-only invocations

### DIFF
--- a/bin/confluence.js
+++ b/bin/confluence.js
@@ -47,6 +47,15 @@ function handleCommandError(analytics, commandName, error, onExtra = null) {
   process.exit(1);
 }
 
+async function readStdin() {
+  process.stdin.setEncoding('utf8');
+  let data = '';
+  for await (const chunk of process.stdin) {
+    data += chunk;
+  }
+  return data;
+}
+
 // Wraps a command action with the standard analytics + client + error pipeline.
 // The handler still calls analytics.track(name, true) on success so it can opt
 // into alternative tracking keys (e.g. *_cancel, *_dry_run).
@@ -1987,7 +1996,11 @@ program
       if (options.inputFile) {
         input = fs.readFileSync(options.inputFile, 'utf-8');
       } else {
-        input = fs.readFileSync(process.stdin.fd, 'utf-8');
+        if (process.stdin.isTTY) {
+          console.error(chalk.red('Error: No input provided. Use --input-file <path> or pipe content via stdin.'));
+          process.exit(1);
+        }
+        input = await readStdin();
       }
 
       const converter = ConfluenceClient.createLocalConverter();

--- a/tests/convert.test.js
+++ b/tests/convert.test.js
@@ -73,6 +73,24 @@ describe('convert command', () => {
     expect(output).toContain('World');
   });
 
+  test('reads input from stdin when --input-file is omitted', () => {
+    const output = run(
+      ['convert', '--input-format', 'markdown', '--output-format', 'storage'],
+      '# Piped\n\nbody\n'
+    );
+    expect(output).toContain('<h1>');
+    expect(output).toContain('Piped');
+    expect(output).toContain('body');
+  });
+
+  test('handles empty stdin without hanging or crashing', () => {
+    const output = run(
+      ['convert', '--input-format', 'markdown', '--output-format', 'storage'],
+      ''
+    );
+    expect(output).toBe('');
+  });
+
   test('markdown to storage via files', () => {
     const inputFile = writeInput('input.md', '# Test\n\nParagraph\n');
     const outputFile = path.join(tmpDir, 'output.xml');


### PR DESCRIPTION
## Summary

- The `convert` command read stdin via `fs.readFileSync(process.stdin.fd, 'utf-8')`. That's a known-fragile pattern: it can hit `EAGAIN` on some platforms, and when the user invokes the command interactively (no pipe, no `--input-file`) the process just hangs forever waiting on the TTY.
- Switch to an async stream consumer for stdin, and fail fast with a clear error when `process.stdin.isTTY` is true.

## Test plan

- [x] `npm test` — 680/680 pass
- [x] `npm run lint` — clean
- [x] Added regression tests covering the piped paths: `# Piped\n...` reads via stdin, empty pipe (`input: ''`) returns empty output without hanging
- [x] Manual: `echo '# Hi' | confluence convert --input-format markdown --output-format storage` works; `... </dev/null` returns empty

### Not in automated tests

The TTY guard itself isn't covered by Jest — `execFileSync` always attaches pipes to the child, so `process.stdin.isTTY` is always `false` in the test harness. Verifying the TTY branch would require a pty wrapper (`node-pty` or similar), which felt like overkill for a 4-line `if (isTTY) { console.error; exit(1) }`. Reviewed by inspection instead.