### PR TITLE
refactor(cli): extract sanitizeFilename to shared lib/file-utils

### DIFF
--- a/bin/commands/attachments.js
+++ b/bin/commands/attachments.js
@@ -2,19 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
 const inquirer = require('inquirer');
-
-function sanitizeFilename(filename) {
-  if (!filename || typeof filename !== 'string') {
-    return 'unnamed';
-  }
-  const stripped = path.basename(filename.replace(/\\/g, '/'));
-  const cleaned = stripped
-    // eslint-disable-next-line no-control-regex
-    .replace(/[\\/:*?"<>|\x00-\x1f]/g, '_')
-    .replace(/^\.+/, '')
-    .trim();
-  return cleaned || 'unnamed';
-}
+const { sanitizeFilename } = require('../../lib/file-utils');
 
 function registerAttachmentCommands(program, { withClient }) {
   program

--- a/bin/commands/export.js
+++ b/bin/commands/export.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
+const { sanitizeFilename } = require('../../lib/file-utils');
 
 const EXPORT_MARKER = '.confluence-export.json';
 
@@ -16,19 +17,6 @@ function writeExportMarker(fs, path, exportDir, meta) {
 
 function isExportDirectory(fs, path, dir) {
   return fs.existsSync(path.join(dir, EXPORT_MARKER));
-}
-
-function sanitizeFilename(filename) {
-  if (!filename || typeof filename !== 'string') {
-    return 'unnamed';
-  }
-  const stripped = path.basename(filename.replace(/\\/g, '/'));
-  const cleaned = stripped
-    // eslint-disable-next-line no-control-regex
-    .replace(/[\\/:*?"<>|\x00-\x1f]/g, '_')
-    .replace(/^\.+/, '')
-    .trim();
-  return cleaned || 'unnamed';
 }
 
 function uniquePathFor(fs, path, dir, filename) {
@@ -342,7 +330,6 @@ module.exports = registerExportCommand;
 module.exports.EXPORT_MARKER = EXPORT_MARKER;
 module.exports.writeExportMarker = writeExportMarker;
 module.exports.isExportDirectory = isExportDirectory;
-module.exports.sanitizeFilename = sanitizeFilename;
 module.exports.uniquePathFor = uniquePathFor;
 module.exports.writeStream = writeStream;
 module.exports.sanitizeTitle = sanitizeTitle;

--- a/lib/file-utils.js
+++ b/lib/file-utils.js
@@ -1,0 +1,16 @@
+const path = require('path');
+
+function sanitizeFilename(filename) {
+  if (!filename || typeof filename !== 'string') {
+    return 'unnamed';
+  }
+  const stripped = path.basename(filename.replace(/\\/g, '/'));
+  const cleaned = stripped
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\\/:*?"<>|\x00-\x1f]/g, '_')
+    .replace(/^\.+/, '')
+    .trim();
+  return cleaned || 'unnamed';
+}
+
+module.exports = { sanitizeFilename };

--- a/tests/export.test.js
+++ b/tests/export.test.js
@@ -7,8 +7,8 @@ const {
   uniquePathFor,
   exportRecursive,
   sanitizeTitle,
-  sanitizeFilename,
 } = require('../bin/commands/export.js');
+const { sanitizeFilename } = require('../lib/file-utils');
 
 // ---------------------------------------------------------------------------
 // Helpers: in-memory fs mock


### PR DESCRIPTION
## Summary
- `sanitizeFilename` was duplicated in `bin/commands/attachments.js` and `bin/commands/export.js`. Bug fixes to one wouldn't propagate to the other.
- Extract the function to a new `lib/file-utils.js` and import it from both call sites.
- Drop the `sanitizeFilename` re-export from `export.js`; update `tests/export.test.js` to import from the new module.

## Test plan
- [x] `npm test` — 682 tests pass
- [x] `npm run lint` — clean