### PR TITLE
feat(auth): add 'none' auth type for reverse-proxy injected credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ confluence --profile sso init \
   --cookie "JSESSIONID=abc123; XSRF-TOKEN=xyz789"
 ```
 
+**Reverse-proxy / no-auth profile** (credentials injected upstream):
+```bash
+confluence --profile proxy init \
+  --domain "confluence.internal" \
+  --api-path "/rest/api" \
+  --auth-type "none"
+```
+
 **Hybrid mode** (some fields provided, rest via prompts):
 ```bash
 # Domain and token provided, will prompt for auth method and email
@@ -176,7 +184,7 @@ confluence init --email "user@example.com" --token "your-api-token"
 **Available flags:**
 - `-d, --domain <domain>` - Confluence domain (e.g., `company.atlassian.net`)
 - `-p, --api-path <path>` - REST API path (e.g., `/wiki/rest/api`)
-- `-a, --auth-type <type>` - Authentication type: `basic`, `bearer`, `mtls`, or `cookie`
+- `-a, --auth-type <type>` - Authentication type: `basic`, `bearer`, `mtls`, `cookie`, or `none`
 - `-e, --email <email>` - Email or username for basic authentication
 - `-t, --token <token>` - API token or password
 - `-c, --cookie <cookie>` - Cookie for Enterprise SSO authentication (e.g., `"JSESSIONID=..."`)
@@ -215,6 +223,13 @@ export CONFLUENCE_DOMAIN="confluence.company.com"
 export CONFLUENCE_API_PATH="/rest/api"
 export CONFLUENCE_AUTH_TYPE="cookie"
 export CONFLUENCE_COOKIE="JSESSIONID=abc123xyz..."
+```
+
+**Reverse-proxy / no-auth environment variables**:
+```bash
+export CONFLUENCE_DOMAIN="confluence.internal"
+export CONFLUENCE_API_PATH="/rest/api"
+export CONFLUENCE_AUTH_TYPE="none"
 ```
 
 **Scoped API token** (recommended for agents):
@@ -320,6 +335,8 @@ For **read-only** usage, select at minimum: `read:confluence-content.all`, `read
 **mTLS-protected Confluence APIs:** Some self-hosted or reverse-proxied deployments authenticate at the TLS layer with a client certificate instead of sending an application-level token. In these environments, configure `authType=mtls` and provide certificate paths via CLI flags or environment variables. No `Authorization` header will be sent in mTLS mode.
 
 **Enterprise SSO with Cookie Authentication:** For Confluence instances behind Enterprise SSO (SAML, OAuth, Okta, etc.) where API tokens or Basic/Bearer auth are not available, you can authenticate using session cookies. After logging in through your browser, extract the session cookie (typically `JSESSIONID` or similar) from your browser's dev tools and configure it via the `--cookie` flag or `CONFLUENCE_COOKIE` environment variable. The cookie is sent in the `Cookie` header instead of an `Authorization` header. Note that session cookies typically expire, so you'll need to refresh them periodically. For security, prefer `CONFLUENCE_COOKIE` env var or interactive prompt over `--cookie` flag since command-line arguments may be visible in shell history and process listings.
+
+**Reverse-proxy injected authentication:** For deployments where a local reverse proxy injects credentials on the wire (e.g. SPNEGO/Kerberos, mTLS terminated at the proxy edge, or header injection), set `authType=none`. In this mode the CLI sends no `Authorization` or `Cookie` header — authentication is entirely the proxy's responsibility. Point `CONFLUENCE_DOMAIN` at the proxy and ensure no credentials are configured on the CLI side.
 
 ## Usage
 

--- a/bin/confluence.js
+++ b/bin/confluence.js
@@ -114,7 +114,7 @@ program
   .option('-d, --domain <domain>', 'Confluence domain')
   .option('--protocol <protocol>', 'Protocol (http or https)')
   .option('-p, --api-path <path>', 'REST API path')
-  .option('-a, --auth-type <type>', 'Authentication type (basic, bearer, mtls, or cookie)')
+  .option('-a, --auth-type <type>', 'Authentication type (basic, bearer, mtls, cookie, or none)')
   .option('-e, --email <email>', 'Email or username for basic auth')
   .option('-t, --token <token>', 'API token')
   .option('-c, --cookie <cookie>', 'Cookie for Enterprise SSO authentication (e.g., "JSESSIONID=...")')

--- a/lib/config.js
+++ b/lib/config.js
@@ -12,10 +12,11 @@ const AUTH_CHOICES = [
   { name: 'Basic (credentials)', value: 'basic' },
   { name: 'Bearer token', value: 'bearer' },
   { name: 'Client certificate (mTLS)', value: 'mtls' },
-  { name: 'Cookie (Enterprise SSO)', value: 'cookie' }
+  { name: 'Cookie (Enterprise SSO)', value: 'cookie' },
+  { name: 'None (auth injected by reverse proxy)', value: 'none' }
 ];
 
-const AUTH_TYPES = ['basic', 'bearer', 'mtls', 'cookie'];
+const AUTH_TYPES = ['basic', 'bearer', 'mtls', 'cookie', 'none'];
 
 const { VALID_LINK_STYLES } = require('./macro-converter');
 
@@ -124,6 +125,10 @@ const validateMtlsProtocol = (protocol) => {
 // Returns error messages only; callers format source-specific hints.
 const validateAuthConfig = (auth, mtlsSourceLabel) => {
   const errors = [];
+
+  if (auth.authType === 'none') {
+    return errors;
+  }
 
   if (auth.authType === 'basic' && !auth.email) {
     errors.push('Basic authentication requires an email address or username.');
@@ -287,7 +292,7 @@ const validateCliOptions = (options) => {
   }
 
   if (options.authType && (typeof options.authType !== 'string' || !AUTH_TYPES.includes(options.authType.toLowerCase()))) {
-    errors.push('--auth-type must be "basic", "bearer", "mtls", or "cookie"');
+    errors.push('--auth-type must be "basic", "bearer", "mtls", "cookie", or "none"');
   }
 
   // Check if basic auth is provided with email
@@ -451,7 +456,7 @@ const promptForMissingValues = async (providedValues) => {
       message: 'API token / password:',
       when: (responses) => {
         const authType = providedValues.authType || responses.authType;
-        return authType !== 'mtls' && authType !== 'cookie';
+        return authType !== 'mtls' && authType !== 'cookie' && authType !== 'none';
       },
       validate: requiredInput('API token / password')
     });
@@ -591,7 +596,7 @@ async function initConfig(cliOptions = {}) {
         type: 'password',
         name: 'token',
         message: 'API token / password:',
-        when: (responses) => responses.authType !== 'mtls' && responses.authType !== 'cookie',
+        when: (responses) => responses.authType !== 'mtls' && responses.authType !== 'cookie' && responses.authType !== 'none',
         validate: requiredInput('API token / password')
       },
       {
@@ -639,6 +644,7 @@ async function initConfig(cliOptions = {}) {
     providedValues.domain &&
     (
       providedValues.authType === 'mtls'
+      || providedValues.authType === 'none'
       || (providedValues.authType === 'cookie' && providedValues.cookie)
       || (
         providedValues.token &&
@@ -665,7 +671,12 @@ async function initConfig(cliOptions = {}) {
         process.exit(1);
       }
 
-      if (normalizedAuthType !== 'mtls' && normalizedAuthType !== 'cookie' && !providedValues.token) {
+      if (
+        normalizedAuthType !== 'mtls'
+        && normalizedAuthType !== 'cookie'
+        && normalizedAuthType !== 'none'
+        && !providedValues.token
+      ) {
         console.error(chalk.red('❌ Token is required for basic or bearer authentication'));
         process.exit(1);
       }
@@ -752,7 +763,8 @@ function getConfig(profileName) {
 
   const hasEnvAuth = envToken
     || envAuthType === 'mtls' || envMtls
-    || envAuthType === 'cookie' || envCookie;
+    || envAuthType === 'cookie' || envCookie
+    || envAuthType === 'none';
 
   if (envDomain && hasEnvAuth) {
     const inferredAuthType = envAuthType

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -98,6 +98,11 @@ class ConfluenceClient {
               'Please verify your cookie is valid and not expired.',
               'You may need to re-authenticate through your Enterprise SSO to get a fresh cookie.'
             );
+          } else if (this.authType === 'none') {
+            hints.push(
+              'No credentials are sent by the CLI in this mode — auth is expected from a reverse proxy.',
+              'Verify the proxy is reachable and is injecting a valid Authorization header.'
+            );
           } else {
             hints.push(
               'Please verify your personal access token is valid and not expired.'
@@ -142,7 +147,7 @@ class ConfluenceClient {
   }
 
   buildAuthHeader() {
-    if (this.authType === 'mtls' || this.authType === 'cookie') {
+    if (this.authType === 'mtls' || this.authType === 'cookie' || this.authType === 'none') {
       return null;
     }
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -281,6 +281,27 @@ describe('getConfig env var aliases', () => {
       logSpy.mockRestore();
     }
   });
+
+  test('CONFLUENCE_AUTH_TYPE=none with just a domain resolves with no credentials', () => {
+    process.env.CONFLUENCE_DOMAIN = 'confluence.internal';
+    process.env.CONFLUENCE_AUTH_TYPE = 'none';
+
+    const config = getConfig();
+    expect(config.authType).toBe('none');
+    expect(config.domain).toBe('confluence.internal');
+    expect(config.token).toBeUndefined();
+    expect(config.email).toBeUndefined();
+    expect(config.cookie).toBeUndefined();
+    expect(config.mtls).toBeUndefined();
+  });
+
+  test('CONFLUENCE_AUTH_TYPE=NONE (uppercase) normalizes to none', () => {
+    process.env.CONFLUENCE_DOMAIN = 'confluence.internal';
+    process.env.CONFLUENCE_AUTH_TYPE = 'NONE';
+
+    const config = getConfig();
+    expect(config.authType).toBe('none');
+  });
 });
 
 describe('initConfig CLI option validation', () => {

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -323,6 +323,28 @@ describe('ConfluenceClient', () => {
 
       expect(cookieClient.client.defaults.headers.Cookie).toBe('JSESSIONID=abc; XSRF-TOKEN=xyz');
     });
+
+    test('sends no Authorization or Cookie header when authType is none', () => {
+      const noneClient = new ConfluenceClient({
+        domain: 'confluence.internal',
+        authType: 'none',
+        apiPath: '/rest/api'
+      });
+
+      expect(noneClient.authType).toBe('none');
+      expect(noneClient.client.defaults.headers.Authorization).toBeUndefined();
+      expect(noneClient.client.defaults.headers.Cookie).toBeUndefined();
+    });
+
+    test('buildAuthHeader returns null for none auth', () => {
+      const noneClient = new ConfluenceClient({
+        domain: 'confluence.internal',
+        authType: 'none'
+      });
+
+      expect(noneClient.buildAuthHeader()).toBeNull();
+      expect(noneClient.buildAuthHeaders()).toEqual({});
+    });
   });
 
   describe('401 error handling (cookie auth)', () => {
@@ -338,6 +360,21 @@ describe('ConfluenceClient', () => {
 
       await expect(cookieClient.readPage('123')).rejects.toThrow(/cookie is valid and not expired/);
       await expect(cookieClient.readPage('123')).rejects.toThrow(/Enterprise SSO/);
+      mock.restore();
+    });
+  });
+
+  describe('401 error handling (none auth)', () => {
+    test('provides reverse-proxy hint for none auth', async () => {
+      const noneClient = new ConfluenceClient({
+        domain: 'confluence.internal',
+        authType: 'none',
+        apiPath: '/rest/api'
+      });
+      const mock = new MockAdapter(noneClient.client);
+      mock.onGet(/\/content\/123/).reply(401);
+
+      await expect(noneClient.readPage('123')).rejects.toThrow(/reverse proxy/);
       mock.restore();
     });
   });


### PR DESCRIPTION
## Summary

- Add `none` as a new value for `--auth-type` / `CONFLUENCE_AUTH_TYPE`.
- When `authType === 'none'`, the client builds requests with no `Authorization` or `Cookie` header. Designed for setups where a local reverse proxy injects credentials on the wire (SPNEGO/Kerberos, mTLS-at-edge, header injection).
- `validateAuthConfig` short-circuits for `none`, so token / email / cookie / mTLS fields are not required at any layer (CLI flags, env vars, profile file, interactive prompts).
- `hasEnvAuth` in `getConfig` accepts `CONFLUENCE_AUTH_TYPE=none` alone — `CONFLUENCE_DOMAIN` + `CONFLUENCE_AUTH_TYPE=none` is enough to drive the env path.
- README: add profile-init example, env-var example, and an explanatory paragraph matching the existing `mtls` / `cookie` sections; update the `--auth-type` flag listing.

## Why

Behind a reverse proxy that auto-injects auth headers, users had to invent a placeholder token to satisfy the existing required-credentials checks. A first-class `none` mode makes the intent explicit and removes the workaround.

## Behavior preservation

- All existing auth types (`basic`, `bearer`, `mtls`, `cookie`) are unchanged.
- `none` is only selected explicitly — `normalizeAuthType` still defaults to `basic` / `bearer` based on email presence.
- The 401 interceptor gains a `none`-specific hint pointing at the proxy; other hints are untouched.

## Test plan

- [x] `npm test` — 689/689 pass (+4 new: 2 in `tests/config.test.js`, 2 in `tests/confluence-client.test.js`)
- [x] `npm run lint` — clean
- [x] Manual: `node bin/confluence.js init --auth-type none --domain confluence.example.com --protocol https` succeeds without prompting
- [x] Manual: pointed CLI at a local Node HTTP inspector with `CONFLUENCE_AUTH_TYPE=none` — confirmed no `authorization` / `cookie` on the outgoing request
- [x] Manual: real round-trip through a reverse-proxy setup works