### PR TITLE
feat: add plantuml macro support to markdown conversion

### DIFF
--- a/lib/storage-walker.js
+++ b/lib/storage-walker.js
@@ -282,6 +282,8 @@ class StorageWalker {
       return this.handlePanel(node);
     case 'mermaid-macro':
       return this.handleMermaid(node);
+    case 'plantuml':
+      return this.handlePlantuml(node);
     case 'include':
       return this.handleInclude(node);
     case 'shared-block':
@@ -352,6 +354,13 @@ class StorageWalker {
     const code = plainBody ? this.getRawText(plainBody).trim() : '';
     const fence = '`'.repeat(fenceLength(code));
     return `\n${fence}mermaid\n${code}\n${fence}\n`;
+  }
+
+  handlePlantuml(node) {
+    const plainBody = this.findChildByName(node, 'ac:plain-text-body');
+    const code = plainBody ? this.getRawText(plainBody).trim() : '';
+    const fence = '`'.repeat(fenceLength(code));
+    return `\n${fence}plantuml\n${code}\n${fence}\n`;
   }
 
   handleInclude(node) {

--- a/tests/fixtures/storage-samples/12-plantuml.expected.md
+++ b/tests/fixtures/storage-samples/12-plantuml.expected.md
@@ -1,0 +1,16 @@
+PlantUML diagram:
+
+```plantuml
+@startuml
+Alice -> Bob: Authentication Request
+Bob --> Alice: Authentication Response
+@enduml
+```
+
+Diagram with backticks:
+
+```plantuml
+@startuml
+:``Main Process``;
+@enduml
+```

--- a/tests/fixtures/storage-samples/12-plantuml.xml
+++ b/tests/fixtures/storage-samples/12-plantuml.xml
@@ -1,0 +1,9 @@
+<p>PlantUML diagram:</p>
+<ac:structured-macro ac:name="plantuml"><ac:plain-text-body><![CDATA[@startuml
+Alice -> Bob: Authentication Request
+Bob --> Alice: Authentication Response
+@enduml]]></ac:plain-text-body></ac:structured-macro>
+<p>Diagram with backticks:</p>
+<ac:structured-macro ac:name="plantuml"><ac:plain-text-body><![CDATA[@startuml
+:``Main Process``;
+@enduml]]></ac:plain-text-body></ac:structured-macro>

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -1206,6 +1206,21 @@ describe('MacroConverter storageToMarkdown fenced code preserves indentation', (
     expect(converter.storageToMarkdown(storage)).toBe('```mermaid\ngraph TD\n    A --> B\n    A --> C\n```');
   });
 
+  test('plantuml macro basic conversion', () => {
+    const storage = '<ac:structured-macro ac:name="plantuml"><ac:plain-text-body><![CDATA[@startuml\nAlice -> Bob: Hello\nBob --> Alice: Hi\n@enduml]]></ac:plain-text-body></ac:structured-macro>';
+    expect(converter.storageToMarkdown(storage)).toBe('```plantuml\n@startuml\nAlice -> Bob: Hello\nBob --> Alice: Hi\n@enduml\n```');
+  });
+
+  test('plantuml macro with backticks in content uses adequate fence', () => {
+    const storage = '<ac:structured-macro ac:name="plantuml"><ac:plain-text-body><![CDATA[@startuml\n:``Main Process``;\n@enduml]]></ac:plain-text-body></ac:structured-macro>';
+    expect(converter.storageToMarkdown(storage)).toBe('```plantuml\n@startuml\n:``Main Process``;\n@enduml\n```');
+  });
+
+  test('plantuml macro with surrounding content is separated by blank lines', () => {
+    const storage = '<p>Before</p><ac:structured-macro ac:name="plantuml"><ac:plain-text-body><![CDATA[@startuml\nA -> B\n@enduml]]></ac:plain-text-body></ac:structured-macro><p>After</p>';
+    expect(converter.storageToMarkdown(storage)).toBe('Before\n\n```plantuml\n@startuml\nA -> B\n@enduml\n```\n\nAfter');
+  });
+
   test('non-fence content still has leading whitespace stripped', () => {
     const storage = '<p>    hello world</p>';
     expect(converter.storageToMarkdown(storage)).toBe('hello world');
@@ -1260,6 +1275,11 @@ describe('MacroConverter storageToMarkdown dynamic fence sizing', () => {
   test('mermaid payload containing ``` uses a 4-backtick fence', () => {
     const storage = '<ac:structured-macro ac:name="mermaid-macro"><ac:plain-text-body><![CDATA[graph TD\n    A["literal ```"] --> B]]></ac:plain-text-body></ac:structured-macro>';
     expect(converter.storageToMarkdown(storage)).toBe('````mermaid\ngraph TD\n    A["literal ```"] --> B\n````');
+  });
+
+  test('plantuml payload containing ``` uses a 4-backtick fence', () => {
+    const storage = '<ac:structured-macro ac:name="plantuml"><ac:plain-text-body><![CDATA[@startuml\n:```Main Process```;\n@enduml]]></ac:plain-text-body></ac:structured-macro>';
+    expect(converter.storageToMarkdown(storage)).toBe('````plantuml\n@startuml\n:```Main Process```;\n@enduml\n````');
   });
 
   test('prose with mid-line ``` before a code macro does not steal fence boundary', () => {


### PR DESCRIPTION
### Description

Add PlantUML macro support to markdown conversion. The storage-walker.js now recognizes ac:name="plantuml" structured macros and converts them to fenced code blocks with the plantuml language tag, following the same pattern as the existing Mermaid macro support.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring

### Testing
- [x] Tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

### Additional Context
- Supports [PlantUML for Confluence macro](https://avono-support.atlassian.net/wiki/spaces/PUML/pages/9699367/Macro+plantuml)
- Built for compatibility with [PlantUML](https://plantuml.com/) diagram syntax
