### PR TITLE
feat: convert markdown plantuml fences to confluence plantuml macro

### DIFF
--- a/lib/html-to-storage.js
+++ b/lib/html-to-storage.js
@@ -272,7 +272,12 @@ function convertCodeBlock(node, ctx) {
   }
   body = decodeEntities(body.replace(/\n$/, ''), { preserveDouble: true })
     .replace(/]]>/g, ']]]]><![CDATA[>');
-  return `<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">${language}</ac:parameter><ac:plain-text-body><![CDATA[${body}]]></ac:plain-text-body></ac:structured-macro>`;
+  switch (language) {
+  case 'plantuml':
+    return `<ac:structured-macro ac:name="plantuml"><ac:plain-text-body><![CDATA[${body}]]></ac:plain-text-body></ac:structured-macro>`;
+  default:
+    return `<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">${language}</ac:parameter><ac:plain-text-body><![CDATA[${body}]]></ac:plain-text-body></ac:structured-macro>`;
+  }
 }
 
 // Wrap allowlisted HTML tags (svg, div) in Confluence HTML macro with CDATA.

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -1369,6 +1369,32 @@ console.log("test");
   });
 });
 
+describe('MacroConverter markdownToStorage plantuml code blocks', () => {
+  const converter = new MacroConverter({ isCloud: true });
+
+  test('basic plantuml fenced code block produces plantuml macro', () => {
+    const result = converter.markdownToStorage('```plantuml\n@startuml\nA -> B\n@enduml\n```');
+    expect(result).toContain('<ac:structured-macro ac:name="plantuml">');
+    expect(result).toContain('<![CDATA[@startuml\nA -> B\n@enduml]]>');
+    expect(result).not.toContain('ac:parameter ac:name="language"');
+  });
+
+  test('plantuml block surrounded by content is separated correctly', () => {
+    const result = converter.markdownToStorage('Before\n\n```plantuml\nA -> B\n```\n\nAfter');
+    expect(result).toContain('<ac:structured-macro ac:name="plantuml">');
+    expect(result).toContain('<![CDATA[A -> B]]>');
+    expect(result).toContain('Before');
+    expect(result).toContain('After');
+  });
+
+  test('other languages still produce code macro with language param', () => {
+    const result = converter.markdownToStorage('```python\nx = 1\n```');
+    expect(result).toContain('<ac:structured-macro ac:name="code">');
+    expect(result).toContain('<ac:parameter ac:name="language">python</ac:parameter>');
+    expect(result).not.toContain('ac:name="plantuml"');
+  });
+});
+
 describe('markdown with HTML blocks', () => {
   const converter = new MacroConverter({ isCloud: true });
 


### PR DESCRIPTION
### Description
Add support for converting Markdown fenced code blocks with `plantuml` language identifier into Confluence PlantUML macros (`ac:name="plantuml"`) in the storage format.

Previously, ` ```plantuml ` blocks in Markdown were converted to generic `<ac:structured-macro ac:name="code">` elements, which broke round-trips (storage → markdown already handled PlantUML correctly). Now, a `switch` on the extracted language in `convertCodeBlock()` dispatches `plantuml` to the dedicated macro.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

### Testing
- [x] Tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

### Screenshots (if applicable)
N/A

### Additional Context
- Supports [PlantUML for Confluence macro](https://avono-support.atlassian.net/wiki/spaces/PUML/pages/9699367/Macro+plantuml)
- Built for compatibility with [PlantUML](https://plantuml.com/) diagram syntax