### PR TITLE
fix(deps): bump axios to ~1.16.1 to address high-severity advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.10.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "~1.15.2",
+        "axios": "~1.16.1",
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
         "entities": "^4.5.0",
@@ -1409,6 +1409,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -1504,13 +1516,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -2076,7 +2089,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3005,6 +3017,19 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.1.0",
         "entities": "^4.5.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {
@@ -4307,7 +4332,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "pchuri",
   "license": "MIT",
   "dependencies": {
-    "axios": "~1.15.2",
+    "axios": "~1.16.1",
     "chalk": "^4.1.2",
     "commander": "^11.1.0",
     "entities": "^4.5.0",


### PR DESCRIPTION
## Summary

Bumps `axios` from `~1.15.2` to `~1.16.1` to resolve four newly disclosed high-severity advisories that started failing CI's `security` job on `main` after #193 was merged.

## Why now

CI's `npm audit --audit-level moderate --omit=dev` began failing on the post-merge `main` run because GHSA disclosures for axios <= 1.15.2 landed between the PR build and the merge build. Because the `publish` and `update-homebrew` jobs depend on `[test, security]`, the release pipeline is currently blocked.

This PR is intentionally minimal and **independent of #193** — that PR only touched `lib/html-to-storage.js` and its tests, not dependencies.

## Advisories resolved

| GHSA | Severity | Issue |
|---|---|---|
| [GHSA-pjwm-pj3p-43mv](https://github.com/advisories/GHSA-pjwm-pj3p-43mv) | high | NO_PROXY bypass via IPv4-mapped IPv6 addresses (incomplete fix for CVE-2025-62718) |
| [GHSA-898c-q2cr-xwhg](https://github.com/advisories/GHSA-898c-q2cr-xwhg) | high | DoS and header injection via prototype pollution in axios merge functions |
| [GHSA-654m-c8p4-x5fp](https://github.com/advisories/GHSA-654m-c8p4-x5fp) | high | Proxy-Authorization header injection via prototype pollution (incomplete null-prototype fix) |
| [GHSA-35jp-ww65-95wh](https://github.com/advisories/GHSA-35jp-ww65-95wh) | high | Full MITM via prototype pollution gadget in `config.proxy` |

## Range choice

`~1.16.1` (tilde, patch-only) preserves the existing pinning policy. Not bumping to `^1.16.1` to avoid widening the constraint.

## Test plan

- [x] `npm audit --audit-level moderate --omit=dev` → `0 vulnerabilities`
- [x] `npm test` → 724/724 passing
- [x] `axios-mock-adapter@2.1.0` deduped on `axios@1.16.1` (no duplicate trees)
- [ ] CI `security` job goes green on this PR
- [ ] After merge, `publish` and `update-homebrew` resume on `main`