### PR TITLE
chore(ci): bump cycjimmy/semantic-release-action to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Semantic Release
       id: semantic
-      uses: cycjimmy/semantic-release-action@v3
+      uses: cycjimmy/semantic-release-action@v5
       with:
         extra_plugins: |
           @semantic-release/exec


### PR DESCRIPTION
## Summary

Bumps `cycjimmy/semantic-release-action` from `@v3` to `@v5` to resolve the Node.js 20 deprecation warning shown in the last main run.

## Why now

GitHub's runner deprecation notice (surfaced in our 2.11.0 release run):

> Node.js 20 actions are deprecated. … Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

`v5` of the action runs on Node.js 24, which clears the warning and front-runs the forced switch.

## Why v5 and not v6

| Option | Action runtime | semantic-release | Workflow impact |
|---|---|---|---|
| v4 | Node 20 | v23 | Still hits the same deprecation |
| **v5** | Node 24 | v24 | Single-line change |
| v6 | Node 24 | **v25 (breaking)** | Requires also bumping `node-version: '18'` → `'22'+` and pulls in plugin-major upgrades (github, npm, commit-analyzer, etc.) |

v5 keeps `semantic-release` on the same major (`v24`) that `v3` ultimately bundled, so release behavior — CHANGELOG, GitHub release, npm publish, git commit — is expected to be unchanged. v6 was deferred to a separate PR to keep runtime-upgrade and release-behavior changes from being entangled.

## Verification

- [x] Workflow YAML diff is one line; `.releaserc` and other config untouched
- [ ] PR CI passes (this is mostly a no-op on PR — `publish` only runs on `main`)
- [ ] Next merge to `main` produces a clean release without the Node 20 deprecation annotation

## Follow-up (separate work, not this PR)

- Bump `setup-node` in the `publish` job from `'18'` to `'22'` (Node 18 went EOL 2025-04-30)
- Consider going to action `v6` / semantic-release v25 once Node 18 is gone from the workflow