### PR TITLE
fix(config): prevent init crash when existing config lacks a profiles key

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -353,6 +353,14 @@ const saveConfig = (configData, profileName) => {
   // Read existing config file (or create new structure)
   const fileData = readConfigFile() || { activeProfile: DEFAULT_PROFILE, profiles: {} };
 
+  // Guard against a pre-existing config file in an unrecognized/legacy shape that
+  // has no usable `profiles` object (e.g. an old flat config that readConfigFile
+  // could not migrate). Without this, the assignment below throws
+  // "Cannot set properties of undefined (setting 'default')".
+  if (!fileData.profiles || typeof fileData.profiles !== 'object') {
+    fileData.profiles = {};
+  }
+
   const targetProfile = profileName || fileData.activeProfile || DEFAULT_PROFILE;
   fileData.profiles[targetProfile] = config;
 

--- a/tests/init-legacy-config.test.js
+++ b/tests/init-legacy-config.test.js
@@ -1,0 +1,97 @@
+const fs = require('fs');
+
+// Mock fs so we can simulate the on-disk config file without touching ~/.confluence-cli
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    existsSync: jest.fn((...args) => actual.existsSync(...args)),
+    readFileSync: jest.fn((...args) => actual.readFileSync(...args)),
+    writeFileSync: jest.fn((...args) => actual.writeFileSync(...args)),
+    mkdirSync: jest.fn((...args) => actual.mkdirSync(...args)),
+    chmodSync: jest.fn(),
+  };
+});
+
+const { initConfig, CONFIG_FILE } = require('../lib/config');
+
+// Make CONFIG_FILE reads/writes hit our in-memory data instead of disk.
+function mockConfigFile(data) {
+  fs.existsSync.mockImplementation((filePath) => {
+    if (filePath === CONFIG_FILE) return data !== null;
+    return jest.requireActual('fs').existsSync(filePath);
+  });
+  fs.readFileSync.mockImplementation((filePath, encoding) => {
+    if (filePath === CONFIG_FILE) {
+      if (data === null) throw new Error('ENOENT: no such file');
+      return JSON.stringify(data);
+    }
+    return jest.requireActual('fs').readFileSync(filePath, encoding);
+  });
+}
+
+function captureConfigWrite() {
+  let captured = null;
+  fs.writeFileSync.mockImplementation((filePath, content) => {
+    if (filePath === CONFIG_FILE) {
+      captured = JSON.parse(content);
+    }
+  });
+  fs.mkdirSync.mockImplementation(() => {});
+  return { getWritten: () => captured };
+}
+
+describe('initConfig with a pre-existing config file that lacks a profiles key', () => {
+  let exitSpy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit called with ${code}`);
+    });
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // Regression: an older flat config using baseUrl/apiToken (no `domain`, no `profiles`)
+  // is returned as-is by readConfigFile, then saveConfig does
+  // `fileData.profiles[targetProfile] = ...` on an undefined `profiles`, crashing with
+  // "Cannot set properties of undefined (setting 'default')".
+  test('does not crash and writes a valid profiles structure', async () => {
+    mockConfigFile({
+      baseUrl: 'https://old.atlassian.net/wiki',
+      restApiPath: '/rest/api',
+      email: 'old@example.com',
+      apiToken: 'old-token',
+    });
+    const writer = captureConfigWrite();
+
+    let error;
+    try {
+      await initConfig({
+        domain: 'new.atlassian.net',
+        apiPath: '/wiki/rest/api',
+        authType: 'basic',
+        email: 'new@example.com',
+        token: 'new-token',
+        protocol: 'https',
+      });
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+
+    const written = writer.getWritten();
+    expect(written).toBeTruthy();
+    expect(written.profiles).toBeDefined();
+    expect(written.profiles.default.domain).toBe('new.atlassian.net');
+    expect(written.profiles.default.token).toBe('new-token');
+    expect(written.activeProfile).toBe('default');
+  });
+});


### PR DESCRIPTION
### Description

Fixes #196.

`confluence init` crashed with `Cannot set properties of undefined (setting 'default')` when `~/.confluence-cli/config.json` already existed in an unrecognized/legacy **flat** shape with no `profiles` key (e.g. an old config using `baseUrl`/`apiToken`, which `readConfigFile()` does not migrate because it only handles the `domain`-based flat format).

In that case `readConfigFile()` returns the raw object as-is, and `saveConfig()` then assigns `fileData.profiles[targetProfile] = config` against an `undefined` `profiles`, throwing.

This PR guards `fileData.profiles` in `saveConfig()` before the assignment, so `init` recovers any unrecognized legacy config into the multi-profile structure instead of crashing. Minimal, defensive change — no behavior change for valid `profiles` configs.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

### Testing
- [x] Tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Added `tests/init-legacy-config.test.js`, which drives `initConfig` non-interactively over a pre-existing no-profiles config file. It fails before the fix (init exits 1 via the crash) and passes after. Full suite: **725 passing** across 18 suites; ESLint clean.

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

### Additional Context

The reproducing config has neither a top-level `domain` (so the existing flat-format migration is skipped) nor a `profiles` key, which is exactly the gap this guard closes.
