### PR TITLE
fix(attachments): use REST download endpoint on Cloud to fix 401

### DIFF
--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -1023,18 +1023,36 @@ class ConfluenceClient {
 
   /**
    * Download an attachment's data stream
-   * Now uses the download link from attachment metadata instead of the broken REST API endpoint
+   *
+   * Cloud and Data Center expose different working download paths:
+   *  - Cloud: the REST endpoint /content/{id}/child/attachment/{id}/download accepts
+   *    API-token auth and 302-redirects to a JWT-signed media URL. The web servlet path
+   *    (_links.download, /download/attachments/...) returns 401 for API tokens (issue #198).
+   *  - Data Center/Server: the servlet _links.download path is what works (issue #80);
+   *    the REST /download endpoint is Cloud-only.
    */
   async downloadAttachment(pageIdOrUrl, attachmentIdOrAttachment, options = {}) {
-    let downloadUrl;
+    const responseType = options.responseType || 'stream';
+    const isAttachmentObject = typeof attachmentIdOrAttachment === 'object' && attachmentIdOrAttachment !== null;
+    const attachmentId = isAttachmentObject ? attachmentIdOrAttachment.id : attachmentIdOrAttachment;
 
-    // If the second argument is an attachment object with downloadLink, use it directly
-    if (typeof attachmentIdOrAttachment === 'object' && attachmentIdOrAttachment.downloadLink) {
-      downloadUrl = attachmentIdOrAttachment.downloadLink;
-    } else {
-      // Otherwise, fetch attachment info to get the download link
+    // Cloud: go through the authenticated REST client. It carries the configured
+    // credentials, baseURL, https agent, and 401-hint interceptor, and axios follows
+    // the cross-host redirect to the media host (where the Authorization header is
+    // dropped as expected, since that URL is JWT-signed).
+    if (this.isCloud() && attachmentId) {
       const pageId = await this.extractPageId(pageIdOrUrl);
-      const attachmentId = attachmentIdOrAttachment;
+      const response = await this.client.get(
+        `/content/${pageId}/child/attachment/${attachmentId}/download`,
+        { responseType }
+      );
+      return response.data;
+    }
+
+    // Data Center/Server: resolve the servlet download link from attachment metadata.
+    let downloadUrl = isAttachmentObject ? attachmentIdOrAttachment.downloadLink : null;
+    if (!downloadUrl) {
+      const pageId = await this.extractPageId(pageIdOrUrl);
       const response = await this.client.get(`/content/${pageId}/child/attachment`, {
         params: { limit: 500 }
       });
@@ -1057,7 +1075,7 @@ class ConfluenceClient {
 
     // Download directly using axios with the same auth headers
     const downloadRequestConfig = {
-      responseType: options.responseType || 'stream',
+      responseType,
       headers: this.buildAuthHeaders()
     };
     const httpsAgent = this.buildHttpsAgent();

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const FormData = require('form-data');
+const axios = require('axios');
 const ConfluenceClient = require('../lib/confluence-client');
 const MockAdapter = require('axios-mock-adapter');
 
@@ -2329,8 +2330,13 @@ describe('ConfluenceClient', () => {
         ).rejects.toThrow(/Refusing to send credentials to "http:\/\/test\.atlassian\.net"/);
       });
 
-      test('downloadAttachment refuses when the API returns a foreign-origin _links.download', async () => {
-        const mock = new MockAdapter(client.client);
+      test('downloadAttachment refuses when the API returns a foreign-origin _links.download (Server)', async () => {
+        const serverClient = new ConfluenceClient({
+          domain: 'confluence.example.com',
+          token: 'pat',
+          authType: 'bearer'
+        });
+        const mock = new MockAdapter(serverClient.client);
         mock.onGet('/content/123/child/attachment').reply(200, {
           results: [{
             id: '777',
@@ -2339,10 +2345,53 @@ describe('ConfluenceClient', () => {
           }]
         });
 
-        await expect(client.downloadAttachment('123', '777'))
+        await expect(serverClient.downloadAttachment('123', '777'))
           .rejects.toThrow(/Refusing to send credentials to "https:\/\/evil\.example"/);
 
         mock.restore();
+      });
+
+      test('downloadAttachment uses the REST download endpoint on Cloud (attachment object)', async () => {
+        const mock = new MockAdapter(client.client);
+        mock.onGet('/content/123/child/attachment/att456/download').reply(200, 'BINARY');
+
+        const data = await client.downloadAttachment('123', {
+          id: 'att456',
+          title: 'diagram.png',
+          downloadLink: 'https://test.atlassian.net/wiki/download/attachments/123/diagram.png'
+        });
+
+        expect(data).toBe('BINARY');
+        mock.restore();
+      });
+
+      test('downloadAttachment uses the REST download endpoint on Cloud (attachment id)', async () => {
+        const mock = new MockAdapter(client.client);
+        mock.onGet('/content/123/child/attachment/777/download').reply(200, 'PNGDATA');
+
+        const data = await client.downloadAttachment('123', '777');
+
+        expect(data).toBe('PNGDATA');
+        mock.restore();
+      });
+
+      test('downloadAttachment uses the servlet download link on Server', async () => {
+        const serverClient = new ConfluenceClient({
+          domain: 'confluence.example.com',
+          token: 'pat',
+          authType: 'bearer'
+        });
+        const axiosMock = new MockAdapter(axios);
+        axiosMock.onGet('https://confluence.example.com/download/attachments/123/diagram.png').reply(200, 'SERVERBYTES');
+
+        const data = await serverClient.downloadAttachment('123', {
+          id: '777',
+          title: 'diagram.png',
+          downloadLink: 'https://confluence.example.com/download/attachments/123/diagram.png'
+        });
+
+        expect(data).toBe('SERVERBYTES');
+        axiosMock.restore();
       });
     });
   });


### PR DESCRIPTION
## Summary
Fixes #198 — attachment downloads fail with HTTP 401 on Atlassian Cloud (Basic auth, API token), even though listing the same attachments succeeds.

## Root cause
The CLI builds its download URL from each attachment's `_links.download`, which on Cloud is the **web servlet path** `/wiki/download/attachments/<pageId>/<file>?...`. That servlet path returns **401** for API-token Basic auth. The reporter confirmed the split with `curl`:

- `/wiki/download/attachments/...` (servlet, what the CLI used) → **401**
- `/wiki/rest/api/content/<id>/child/attachment/<id>/download` (REST) → **302 → 200**

The REST endpoint 302-redirects to a JWT-signed media URL (`api.media.atlassian.com`), so it works without re-sending Confluence credentials across the redirect.

## Change
In `downloadAttachment`:
- **Cloud** (`isCloud()`): download via the authenticated client at `/content/{pageId}/child/attachment/{id}/download`. This carries the configured auth, baseURL, https agent, and 401-hint interceptor, and axios follows the cross-host redirect to the media host.
- **Data Center/Server**: unchanged — keeps the servlet `_links.download` path (which works there, #80; the REST `/download` endpoint is Cloud-only) along with the existing `assertSameOrigin` credential guard.

Cloud was already broken (401), so re-routing it cannot regress; the DC/Server path is untouched.

## Test plan
- [x] Added: Cloud uses the REST `/download` endpoint (attachment-object form and id form)
- [x] Updated: foreign-origin `_links.download` rejection now exercised via a Server client (servlet fallback path)
- [x] Added: Server still uses the servlet download link end-to-end
- [x] `npx jest` — 728 passed
- [x] `npx eslint` — clean