### PR TITLE
feat: add --format auto option for write commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,7 +564,13 @@ confluence create "My New Page" SPACEKEY --content "**Hello** World!" --format m
 
 # Create from a file
 confluence create "Documentation" SPACEKEY --file ./content.md --format markdown
+
+# Auto-detect: keeps storage XHTML as-is, converts plain text/Markdown
+confluence create "My New Page" SPACEKEY --content "**Hello** World!" --format auto
 ```
+
+For create, create-child, update, and comment, `--format auto` detects the content type:
+it preserves content that starts with markup such as `<p>...</p>` or `<ac:structured-macro ...>`, and converts plain text or Markdown to Confluence storage XHTML. This is useful for older Confluence Server/Data Center versions that reject bare text in a `body.storage.value`.
 
 ### Create a Child Page
 ```bash
@@ -772,10 +778,10 @@ confluence stats
 | `spaces` | List available spaces | `--limit <number>`, `--all` |
 | `find <title>` | Find a page by its title | `--space <spaceKey>` |
 | `children <pageId>` | List child pages of a page | `--recursive`, `--max-depth <number>`, `--format <list\|tree\|json>`, `--show-url`, `--show-id` |
-| `create <title> <spaceKey>` | Create a new page or folder | `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>`, `--type <page\|folder>` |
-| `create-child <title> <parentId>` | Create a child page or folder | `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>`, `--type <page\|folder>` |
+| `create <title> <spaceKey>` | Create a new page or folder | `--content <string>`, `--file <path>`, `--format <auto\|storage\|html\|markdown>`, `--type <page\|folder>` |
+| `create-child <title> <parentId>` | Create a child page or folder | `--content <string>`, `--file <path>`, `--format <auto\|storage\|html\|markdown>`, `--type <page\|folder>` |
 | `copy-tree <sourcePageId> <targetParentId> [newTitle]` | Copy page tree with all children | `--max-depth <number>`, `--exclude <patterns>`, `--delay-ms <ms>`, `--copy-suffix <text>`, `--dry-run`, `--fail-on-error`, `--quiet` |
-| `update <pageId>` | Update a page's title or content | `--title <string>`, `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>` |
+| `update <pageId>` | Update a page's title or content | `--title <string>`, `--content <string>`, `--file <path>`, `--format <auto\|storage\|html\|markdown>` |
 | `move <pageId_or_url> <newParentId_or_url>` | Move a page to a new parent location | `--title <string>` |
 | `delete <pageId_or_url>` | Delete a page by ID or URL | `--yes` |
 | `versions <pageId_or_url>` | List historical versions of a page | `--format <text\|json>` |
@@ -786,7 +792,7 @@ confluence stats
 | `attachment-upload <pageId_or_url>` | Upload attachments to a page | `--file <path>`, `--comment <text>`, `--replace`, `--minor-edit` |
 | `attachment-delete <pageId_or_url> <attachmentId>` | Delete an attachment from a page | `--yes` |
 | `comments <pageId_or_url>` | List comments for a page | `--format <text\|markdown\|json>`, `--limit <number>`, `--start <number>`, `--location <inline\|footer\|resolved>`, `--depth <root\|all>`, `--all` |
-| `comment <pageId_or_url>` | Create a comment on a page | `--content <string>`, `--file <path>`, `--format <storage\|html\|markdown>`, `--parent <commentId>`, `--location <inline\|footer>`, `--inline-selection <text>`, `--inline-original-selection <text>`, `--inline-marker-ref <ref>`, `--inline-properties <json>` |
+| `comment <pageId_or_url>` | Create a comment on a page | `--content <string>`, `--file <path>`, `--format <auto\|storage\|html\|markdown>`, `--parent <commentId>`, `--location <inline\|footer>`, `--inline-selection <text>`, `--inline-original-selection <text>`, `--inline-marker-ref <ref>`, `--inline-properties <json>` |
 | `comment-delete <commentId>` | Delete a comment by ID | `--yes` |
 | `property-list <pageId_or_url>` | List all content properties for a page | `--format <text\|json>`, `--limit <number>`, `--start <number>`, `--all` |
 | `property-get <pageId_or_url> <key>` | Get a content property by key | `--format <text\|json>` |

--- a/bin/commands/comment.js
+++ b/bin/commands/comment.js
@@ -191,7 +191,7 @@ function registerCommentCommands(program, { withClient }) {
     .description('Create a comment on a page by ID or URL (footer or inline)')
     .option('-f, --file <file>', 'Read content from file')
     .option('-c, --content <content>', 'Comment content as string')
-    .option('--format <format>', 'Content format (storage, html, markdown)', 'storage')
+    .option('--format <format>', 'Content format (auto, storage, html, markdown)', 'storage')
     .option('--parent <commentId>', 'Reply to a comment by ID')
     .option('--location <location>', 'Comment location (inline or footer)', 'footer')
     .option('--inline-selection <text>', 'Inline selection text')

--- a/bin/confluence.js
+++ b/bin/confluence.js
@@ -46,9 +46,27 @@ function assertNoBodyForFolder(type, options) {
   }
 }
 
+function formatApiErrorBody(data) {
+  if (data === undefined || data === null || data === '') {
+    return null;
+  }
+  if (typeof data === 'string') {
+    return data;
+  }
+  try {
+    return JSON.stringify(data, null, 2);
+  } catch {
+    return String(data);
+  }
+}
+
 function handleCommandError(analytics, commandName, error, onExtra = null) {
   analytics.track(commandName, false);
   console.error(chalk.red('Error:'), error.message);
+  const apiDetail = formatApiErrorBody(error.response?.data);
+  if (apiDetail && !onExtra) {
+    console.error(chalk.red('API response:'), apiDetail);
+  }
   if (onExtra) {
     try { onExtra(error); } catch { /* keep error path robust if hint code throws */ }
   }
@@ -258,7 +276,7 @@ program
   .description('Create a new Confluence page or folder')
   .option('-f, --file <file>', 'Read content from file')
   .option('-c, --content <content>', 'Page content as string')
-  .option('--format <format>', 'Content format (storage, html, markdown)', 'storage')
+  .option('--format <format>', 'Content format (auto, storage, html, markdown)', 'storage')
   .option('--type <type>', 'Content type (page, folder)', 'page')
   .action(withClient('create', async ({ client, analytics }, title, spaceKey, options) => {
     assertNonEmpty(title, 'title');
@@ -297,7 +315,7 @@ program
   .description('Create a new Confluence page or folder as a child of another page')
   .option('-f, --file <file>', 'Read content from file')
   .option('-c, --content <content>', 'Page content as string')
-  .option('--format <format>', 'Content format (storage, html, markdown)', 'storage')
+  .option('--format <format>', 'Content format (auto, storage, html, markdown)', 'storage')
   .option('--type <type>', 'Content type (page, folder)', 'page')
   .action(withClient('create_child', async ({ client, analytics }, title, parentId, options) => {
     assertNonEmpty(title, 'title');
@@ -342,7 +360,7 @@ program
   .option('-t, --title <title>', 'New page title (optional)')
   .option('-f, --file <file>', 'Read content from file')
   .option('-c, --content <content>', 'Page content as string')
-  .option('--format <format>', 'Content format (storage, html, markdown)', 'storage')
+  .option('--format <format>', 'Content format (auto, storage, html, markdown)', 'storage')
   .action(withClient('update', async ({ client, analytics }, pageId, options) => {
     // Check if at least one option is provided
     if (!options.title && !options.file && !options.content) {
@@ -855,6 +873,7 @@ module.exports = {
     assertNonEmpty,
     assertValidType,
     assertNoBodyForFolder,
+    formatApiErrorBody,
     handleCommandError,
     withClient,
     withLocal,

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -7,6 +7,8 @@ const { convert } = require('html-to-text');
 const MacroConverter = require('./macro-converter');
 const { htmlToMarkdown, NAMED_ENTITIES } = require('./html-to-markdown');
 
+const WRITE_FORMATS = ['auto', 'storage', 'html', 'markdown'];
+
 function createSemaphore(limit) {
   let active = 0;
   const waiters = [];
@@ -912,13 +914,7 @@ class ConfluenceClient {
    */
   async createComment(pageIdOrUrl, content, format = 'storage', options = {}) {
     const pageId = await this.extractPageId(pageIdOrUrl);
-    let storageContent = content;
-
-    if (format === 'markdown') {
-      storageContent = this.markdownToStorage(content);
-    } else if (format === 'html') {
-      storageContent = this.htmlToConfluenceStorage(content);
-    }
+    const storageContent = this.toStorageContent(content, format);
 
     const commentData = {
       type: 'comment',
@@ -1250,6 +1246,35 @@ class ConfluenceClient {
     return this.converter.markdownToNativeStorage(markdown);
   }
 
+  normalizeWriteFormat(format = 'storage') {
+    const value = String(format || 'storage').trim().toLowerCase();
+    if (!WRITE_FORMATS.includes(value)) {
+      throw new Error(`Invalid content format "${format}". Valid: ${WRITE_FORMATS.join(', ')}`);
+    }
+    return value;
+  }
+
+  looksLikeMarkupContent(content) {
+    return typeof content === 'string' && /^\s*</.test(content);
+  }
+
+  toStorageContent(content, format = 'storage') {
+    const normalizedFormat = this.normalizeWriteFormat(format);
+
+    if (normalizedFormat === 'auto') {
+      return this.looksLikeMarkupContent(content)
+        ? content
+        : this.markdownToStorage(content || '');
+    }
+    if (normalizedFormat === 'markdown') {
+      return this.markdownToStorage(content || '');
+    }
+    if (normalizedFormat === 'html') {
+      return this.htmlToConfluenceStorage(content || '');
+    }
+    return content;
+  }
+
   setupConfluenceMarkdownExtensions() {
     this.converter.setupConfluenceMarkdownExtensions();
   }
@@ -1279,13 +1304,7 @@ class ConfluenceClient {
     };
 
     if (type !== 'folder') {
-      let storageContent = content;
-
-      if (format === 'markdown') {
-        storageContent = this.markdownToStorage(content);
-      } else if (format === 'html') {
-        storageContent = this.htmlToConfluenceStorage(content);
-      }
+      const storageContent = this.toStorageContent(content, format);
 
       pageData.body = {
         storage: {
@@ -1317,13 +1336,7 @@ class ConfluenceClient {
     };
 
     if (type !== 'folder') {
-      let storageContent = content;
-
-      if (format === 'markdown') {
-        storageContent = this.markdownToStorage(content);
-      } else if (format === 'html') {
-        storageContent = this.htmlToConfluenceStorage(content);
-      }
+      const storageContent = this.toStorageContent(content, format);
 
       pageData.body = {
         storage: {
@@ -1352,14 +1365,7 @@ class ConfluenceClient {
     let storageContent;
 
     if (content !== undefined && content !== null) {
-      // If new content is provided, convert it to storage format
-      if (format === 'markdown') {
-        storageContent = this.markdownToStorage(content);
-      } else if (format === 'html') {
-        storageContent = this.htmlToConfluenceStorage(content); // Using the conversion function for robustness
-      } else { // 'storage' format
-        storageContent = content;
-      }
+      storageContent = this.toStorageContent(content, format);
     } else {
       // If no new content, use the existing content
       storageContent = currentPage.data.body.storage.value;

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -1521,6 +1521,37 @@ describe('ConfluenceClient', () => {
       mock.restore();
     });
 
+    test('createPage with format="auto" converts plain text to storage', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onPost('/content').reply(200, { id: '112' });
+      const spy = jest.spyOn(client, 'markdownToStorage').mockReturnValue('<p>Hello</p>');
+
+      await client.createPage('Test', 'TEST', 'Hello', 'auto');
+
+      expect(spy).toHaveBeenCalledWith('Hello');
+      const body = JSON.parse(mock.history.post[0].data).body.storage;
+      expect(body.value).toBe('<p>Hello</p>');
+      expect(body.representation).toBe('storage');
+
+      spy.mockRestore();
+      mock.restore();
+    });
+
+    test('createPage with format="auto" preserves markup-like storage content', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onPost('/content').reply(200, { id: '113' });
+      const spy = jest.spyOn(client, 'markdownToStorage');
+
+      await client.createPage('Test', 'TEST', '<p>Hello</p>', 'auto');
+
+      expect(spy).not.toHaveBeenCalled();
+      const body = JSON.parse(mock.history.post[0].data).body.storage;
+      expect(body.value).toBe('<p>Hello</p>');
+
+      spy.mockRestore();
+      mock.restore();
+    });
+
     test('createPage should support type "folder" without body', async () => {
       const mock = new MockAdapter(client.client);
       mock.onPost('/content').reply(200, {
@@ -1578,6 +1609,48 @@ describe('ConfluenceClient', () => {
       expect(spy).toHaveBeenCalledWith('<p>x</p>');
       spy.mockRestore();
       mock.restore();
+    });
+
+    test('updatePage with format="auto" converts plain text to storage', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123').reply(200, {
+        id: '123',
+        title: 'Old',
+        body: { storage: { value: '<p>Old</p>' } },
+        version: { number: 2 },
+        space: { key: 'TEST' }
+      });
+      mock.onPut('/content/123').reply(200, { id: '123' });
+      const spy = jest.spyOn(client, 'markdownToStorage').mockReturnValue('<p>New</p>');
+
+      await client.updatePage('123', null, 'New', 'auto');
+
+      expect(spy).toHaveBeenCalledWith('New');
+      const body = JSON.parse(mock.history.put[0].data).body.storage;
+      expect(body.value).toBe('<p>New</p>');
+
+      spy.mockRestore();
+      mock.restore();
+    });
+
+    test('createComment with format="auto" converts plain text to storage', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onPost('/content').reply(200, { id: 'c1' });
+      const spy = jest.spyOn(client, 'markdownToStorage').mockReturnValue('<p>Looks good</p>');
+
+      await client.createComment('123', 'Looks good', 'auto');
+
+      expect(spy).toHaveBeenCalledWith('Looks good');
+      const body = JSON.parse(mock.history.post[0].data).body.storage;
+      expect(body.value).toBe('<p>Looks good</p>');
+
+      spy.mockRestore();
+      mock.restore();
+    });
+
+    test('invalid write format throws a helpful error', () => {
+      expect(() => client.toStorageContent('Hello', 'wiki'))
+        .toThrow('Invalid content format "wiki". Valid: auto, storage, html, markdown');
     });
   });
 

--- a/tests/with-client.test.js
+++ b/tests/with-client.test.js
@@ -93,6 +93,21 @@ describe('withClient wrapper', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
+  test('API response body is logged when no custom error handler is provided', async () => {
+    const error = new Error('Request failed with status code 400');
+    error.response = { data: { message: 'Storage body is invalid' } };
+    const handler = jest.fn().mockRejectedValue(error);
+    const action = withClient('create', handler, { writable: true });
+
+    await expect(action('title', 'KEY', {})).rejects.toThrow('process.exit called');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('API response:'),
+      JSON.stringify({ message: 'Storage body is invalid' }, null, 2)
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
   test('onError receives error + forwarded action args and runs before exit', async () => {
     const onError = jest.fn();
     const handler = jest.fn().mockRejectedValue(new Error('api fail'));


### PR DESCRIPTION
## Summary

Adds an opt-in `--format auto` for `create`, `create-child`, `update`, and `comment`:

- Content that already starts with markup (storage XHTML, e.g. `<p>...\</p>` or `<ac:structured-macro ...>`) is sent as-is
- Plain text or Markdown is converted to Confluence storage XHTML

This is especially useful for older Confluence Server/Data Center versions, which reject bare text in `body.storage.value` (verified against Confluence Server 6.12.1 — create/update/comment all fail without conversion, and work correctly with it).

**The default format remains `storage` — existing behavior is unchanged.**

## Other changes

- Consolidated the duplicated format-conversion logic in `createPage`/`createChildPage`/`updatePage`/`createComment` into a single `toStorageContent()` helper
- Invalid `--format` values now fail with a helpful error listing valid options (previously silently treated as `storage`)
- Command errors now print the API response body, which makes server-side validation failures (common on older Server versions) much easier to diagnose

## Testing

- `npm test`: 734 passed, 18 suites
- New unit tests cover auto-detection for create/update/comment, markup passthrough, and invalid-format errors
- Manually verified end-to-end against a self-hosted Confluence Server 6.12.1: create, create-child, update, comment, and content round-trip (storage and markdown output) all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)