### PR TITLE
fix: clarify bodyless Confluence content errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ confluence read "https://your-domain.atlassian.net/wiki/viewpage.action?pageId=1
 
 Use `--format storage` when you need Confluence's native storage representation, especially for macros and other Confluence-specific markup.
 
+Reading requires content with a storage body. Folders and other bodyless content return `Page <id> has no readable body (it may be a folder or an unsupported content type).`; use `confluence info <id>` to inspect their metadata.
+
 ### Get Page Information
 ```bash
 confluence info 123456789
@@ -380,6 +382,8 @@ confluence info 123456789
 # Emit machine-readable metadata
 confluence info 123456789 --json
 ```
+
+`info` can inspect folders and other bodyless content because it only reads metadata.
 
 Example JSON shape:
 ```json
@@ -640,6 +644,8 @@ confluence update 123456789 --file ./updated-content.md --format markdown
 confluence update 123456789 --title "New Title" --content "And new content"
 ```
 
+Title-only updates reuse the target's existing storage body. Folders and other bodyless content cannot be updated this way and return `Page <id> has no readable body (it may be a folder or an unsupported content type).`.
+
 ### Move a Page to New Parent
 
 ```bash
@@ -680,6 +686,8 @@ vim ./page-to-edit.xml
 # 3. Update the page with your changes
 confluence update 123456789 --file ./page-to-edit.xml --format storage
 ```
+
+Only content with a storage body can be exported for editing. Folders and other bodyless content return `Page <id> has no readable body (it may be a folder or an unsupported content type).`.
 
 ### Profile Management
 ```bash

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -335,6 +335,7 @@ class ConfluenceClient {
    * @param {object} data - The `response.data` from a /content/:id request
    * @param {string} pageId - The content ID, used in the error message
    * @returns {string} The storage representation HTML
+   * @throws {Error} When the content has no storage body
    */
   requireStorageBody(data, pageId) {
     const value = data?.body?.storage?.value;
@@ -351,6 +352,7 @@ class ConfluenceClient {
    * @param {object} options - Additional options
    * @param {boolean} options.resolveUsers - Whether to resolve userkeys to display names (default: true for markdown)
    * @param {boolean} options.extractReferencedAttachments - Whether to extract referenced attachments (default: false)
+   * @throws {Error} When the target content has no storage body
    */
   async readPage(pageIdOrUrl, format = 'text', options = {}) {
     const pageId = await this.extractPageId(pageIdOrUrl);
@@ -1367,6 +1369,11 @@ class ConfluenceClient {
 
   /**
    * Update an existing Confluence page
+   * @param {string} pageId - Page ID
+   * @param {string|null|undefined} title - New title; when omitted, current title is reused
+   * @param {string|null|undefined} content - New content; when omitted, existing storage body is reused
+   * @param {string} format - Input format: 'storage', 'html', 'markdown', or 'auto'
+   * @throws {Error} When content is omitted and the target has no storage body
    */
   async updatePage(pageId, title, content, format = 'storage') {
     // First, get the current page to get the version number and existing content
@@ -1457,6 +1464,8 @@ class ConfluenceClient {
 
   /**
    * Get page content for editing
+   * @param {string} pageIdOrUrl - Page ID or URL
+   * @throws {Error} When the target content has no storage body
    */
   async getPageForEdit(pageIdOrUrl) {
     const pageId = await this.extractPageId(pageIdOrUrl);

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -330,6 +330,21 @@ class ConfluenceClient {
   }
 
   /**
+   * Extract the storage body value from a content API response, throwing a clear
+   * error when the content has no body (e.g. a folder or unsupported content type).
+   * @param {object} data - The `response.data` from a /content/:id request
+   * @param {string} pageId - The content ID, used in the error message
+   * @returns {string} The storage representation HTML
+   */
+  requireStorageBody(data, pageId) {
+    const value = data?.body?.storage?.value;
+    if (value === undefined || value === null) {
+      throw new Error(`Page ${pageId} has no readable body (it may be a folder or an unsupported content type).`);
+    }
+    return value;
+  }
+
+  /**
    * Read a Confluence page content
    * @param {string} pageIdOrUrl - Page ID or URL
    * @param {string} format - Output format: 'text', 'html', 'storage', or 'markdown'
@@ -346,8 +361,8 @@ class ConfluenceClient {
       }
     });
 
-    let htmlContent = response.data.body.storage.value;
-    
+    let htmlContent = this.requireStorageBody(response.data, pageId);
+
     // Extract referenced attachments if requested
     if (options.extractReferencedAttachments) {
       this._referencedAttachments = this.extractReferencedAttachments(htmlContent);
@@ -1368,7 +1383,7 @@ class ConfluenceClient {
       storageContent = this.toStorageContent(content, format);
     } else {
       // If no new content, use the existing content
-      storageContent = currentPage.data.body.storage.value;
+      storageContent = this.requireStorageBody(currentPage.data, pageId);
     }
 
     const pageData = {
@@ -1455,7 +1470,7 @@ class ConfluenceClient {
     return {
       id: response.data.id,
       title: response.data.title,
-      content: response.data.body.storage.value,
+      content: this.requireStorageBody(response.data, pageId),
       version: response.data.version.number,
       space: response.data.space
     };

--- a/llms.txt
+++ b/llms.txt
@@ -24,6 +24,10 @@ confluence init
 
 This section summarizes recent improvements to align the codebase with its documentation and fix bugs.
 
+### Bodyless Content Error Handling:
+- **Inconsistency:** `confluence info` could inspect folders, but `read`, `edit`, and title-only `update` crashed when Confluence returned content without `body.storage.value`.
+- **Fix:** Added a shared storage-body guard in `lib/confluence-client.js` so these commands fail with `Page <id> has no readable body (it may be a folder or an unsupported content type).`.
+
 ### `update` Command Logic and Documentation:
 - **Inconsistency:** The `README.md` suggested that updating a page's title without changing its content was possible. However, the implementation in `bin/confluence.js` incorrectly threw an error if the `--content` or `--file` flags were not provided, making title-only updates impossible.
 - **Fix:**

--- a/plugins/confluence/skills/confluence/SKILL.md
+++ b/plugins/confluence/skills/confluence/SKILL.md
@@ -163,6 +163,8 @@ confluence read 123456789 --format storage
 confluence read 123456789 --format markdown
 ```
 
+Requires content with a storage body. Folders and other bodyless content return `Page <id> has no readable body (it may be a folder or an unsupported content type).`; use `confluence info <id>` to inspect their metadata.
+
 ---
 
 ### `info <pageId>`
@@ -177,6 +179,8 @@ confluence info <pageId> [--format text|json]
 confluence info 123456789
 confluence info 123456789 --format json
 ```
+
+Works for folders and other bodyless content because it only reads metadata.
 
 ---
 
@@ -319,6 +323,8 @@ confluence update 123456789 --file ./updated.md --format markdown
 confluence update 123456789 --title "New Title" --file ./updated.xml --format storage
 ```
 
+Title-only updates reuse the target's existing storage body. Folders and other bodyless content cannot be updated this way and return `Page <id> has no readable body (it may be a folder or an unsupported content type).`.
+
 ---
 
 ### `move <pageId_or_url> <newParentId_or_url>`
@@ -375,6 +381,8 @@ confluence edit 123456789 --output ./page.xml
 # Edit page.xml, then:
 confluence update 123456789 --file ./page.xml --format storage
 ```
+
+Only content with a storage body can be exported for editing. Folders and other bodyless content return `Page <id> has no readable body (it may be a folder or an unsupported content type).`.
 
 ---
 
@@ -700,6 +708,8 @@ confluence edit 123456789 --output ./page.xml
 confluence update 123456789 --file ./page.xml --format storage
 ```
 
+Requires content with a storage body; folders and other bodyless content should be inspected with `confluence info <id>` instead.
+
 ### Build a documentation hierarchy
 
 ```sh
@@ -773,6 +783,7 @@ confluence search --cql 'siteSearch ~ "release notes" and space = "MYSPACE"' --l
 | 400 on inline comment creation | Editor metadata required | Use `--location footer` or reply to existing inline comment with `--parent` |
 | `File not found: <path>` | `--file` path doesn't exist | Check the path before calling the command |
 | `At least one of --title, --file, or --content must be provided` | `update` called with no content options | Provide at least one of the required options |
+| `Page <id> has no readable body (it may be a folder or an unsupported content type).` | `read`, `edit`, or title-only `update` targeted a folder or other bodyless content | Use `info` for metadata, or target a page with a storage body |
 | `Profile "<name>" not found!` | Specified profile doesn't exist | Run `confluence profile list` to see available profiles |
 | `Cannot delete the only remaining profile.` | Tried to remove the last profile | Add another profile before removing |
 | `This profile is in read-only mode` | Write command used with a read-only profile | Use a writable profile or remove `readOnly` from config |

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -478,6 +478,51 @@ describe('ConfluenceClient', () => {
       mock.restore();
     });
 
+    describe('bodyless content (folder) handling', () => {
+      const NO_BODY_MESSAGE = /Page 123 has no readable body \(it may be a folder or an unsupported content type\)\./;
+
+      test('readPage throws a clear error instead of a TypeError', async () => {
+        const mock = new MockAdapter(client.client);
+        mock.onGet('/content/123').reply(200, { id: '123', type: 'folder', body: {} });
+
+        await expect(client.readPage('123', 'markdown')).rejects.toThrow(NO_BODY_MESSAGE);
+        await expect(client.readPage('123', 'markdown')).rejects.not.toThrow(/reading 'value'/);
+
+        mock.restore();
+      });
+
+      test('getPageForEdit throws a clear error instead of a TypeError', async () => {
+        const mock = new MockAdapter(client.client);
+        mock.onGet('/content/123').reply(200, {
+          id: '123',
+          type: 'folder',
+          body: {},
+          version: { number: 1 }
+        });
+
+        await expect(client.getPageForEdit('123')).rejects.toThrow(NO_BODY_MESSAGE);
+
+        mock.restore();
+      });
+
+      test('updatePage reuse-content path throws a clear error instead of a TypeError', async () => {
+        const mock = new MockAdapter(client.client);
+        mock.onGet('/content/123').reply(200, {
+          id: '123',
+          title: 'A folder',
+          type: 'folder',
+          body: {},
+          version: { number: 1 },
+          space: { key: 'ENG' }
+        });
+
+        // content omitted -> reuse-existing-content branch
+        await expect(client.updatePage('123', 'A folder', undefined)).rejects.toThrow(NO_BODY_MESSAGE);
+
+        mock.restore();
+      });
+    });
+
     test('getPageInfo should normalize machine-readable metadata', async () => {
       const mock = new MockAdapter(client.client);
       mock.onGet('/content/123').reply(config => {


### PR DESCRIPTION
## Intent

Fix a reproduced crash where 'confluence read'/'edit'/'update' die with an opaque 'TypeError: Cannot read properties of undefined (reading value)' when the target content has no body (e.g. a Confluence folder, creatable via 'confluence create --type folder'). Root cause: three unguarded accesses to response.data.body.storage.value in lib/confluence-client.js — readPage, updatePage's reuse-existing-content path, and getPageForEdit. Folder content has no body.storage so .value throws; 'confluence info' already works on folders via the null-safe normalizePage, making this an internal inconsistency. Fix: added a shared helper requireStorageBody(data, pageId) that null-safely reads body.storage.value and throws a clear, consistent, actionable message ('Page <id> has no readable body (it may be a folder or an unsupported content type).') instead of the cryptic TypeError, and routed all three sites through it. Deliberately kept one shared helper for message consistency; normal pages with a body are intentionally unchanged. Added focused regression tests in tests/confluence-client.test.js ('bodyless content (folder) handling') covering readPage, getPageForEdit, and the updatePage reuse-content path, asserting the clear message and that the TypeError no longer surfaces. Full suite (747 tests) green and eslint clean.

## What Changed
- Added a shared storage-body guard so Confluence folders and other bodyless content return a clear error instead of an opaque `TypeError`.
- Applied the guard to `read`, `edit`, and title-only `update` flows while preserving normal page storage-body behavior.
- Documented the bodyless-content behavior and added focused regression coverage for the affected Confluence client paths.

## Risk Assessment

✅ Low: The change is narrowly scoped to replacing three unsafe body lookups with a null-safe helper and focused regression coverage, and I found no material risks introduced by the branch.

## Testing

After fixing the setup issue with `npm ci`, the focused regression selector and full `tests/confluence-client.test.js` passed; the CLI transcript shows `read`, `edit`, and title-only `update` now return the clear bodyless-content error with no TypeError, while normal page read/edit/update still succeed and title-only update reuses the existing storage body. `node_modules` was removed afterward and the worktree is clean.

<details>
<summary>Evidence: Confluence CLI bodyless and normal transcript</summary>

```text
# Confluence CLI Bodyless And Normal Body Evidence
Stub API: http://127.0.0.1:56442/rest/api
Stub content 123: folder-like content with body: {} and no body.storage.value.
Stub content 456: normal page with body.storage.value = <p>Storage body</p>.
$ CONFLUENCE_AUTH_TYPE=none CONFLUENCE_PROTOCOL=http CONFLUENCE_DOMAIN=127.0.0.1:56442 CONFLUENCE_API_PATH=/rest/api CONFLUENCE_CLI_ANALYTICS=false node bin/index.js read 123 --format storage
exit: 1
stdout:
(empty)
stderr:
Error: Page 123 has no readable body (it may be a folder or an unsupported content type).
$ CONFLUENCE_AUTH_TYPE=none CONFLUENCE_PROTOCOL=http CONFLUENCE_DOMAIN=127.0.0.1:56442 CONFLUENCE_API_PATH=/rest/api CONFLUENCE_CLI_ANALYTICS=false node bin/index.js edit 123
exit: 1
stdout:
(empty)
stderr:
Error: Page 123 has no readable body (it may be a folder or an unsupported content type).
$ CONFLUENCE_AUTH_TYPE=none CONFLUENCE_PROTOCOL=http CONFLUENCE_DOMAIN=127.0.0.1:56442 CONFLUENCE_API_PATH=/rest/api CONFLUENCE_CLI_ANALYTICS=false node bin/index.js update 123 --title Renamed folder
exit: 1
stdout:
(empty)
stderr:
Error: Page 123 has no readable body (it may be a folder or an unsupported content type).
$ CONFLUENCE_AUTH_TYPE=none CONFLUENCE_PROTOCOL=http CONFLUENCE_DOMAIN=127.0.0.1:56442 CONFLUENCE_API_PATH=/rest/api CONFLUENCE_CLI_ANALYTICS=false node bin/index.js read 456 --format storage
exit: 0
stdout:
<p>Storage body</p>
stderr:
(empty)
$ CONFLUENCE_AUTH_TYPE=none CONFLUENCE_PROTOCOL=http CONFLUENCE_DOMAIN=127.0.0.1:56442 CONFLUENCE_API_PATH=/rest/api CONFLUENCE_CLI_ANALYTICS=false node bin/index.js edit 456
exit: 0
stdout:
Page Information:
Title: Normal Page
ID: 456
Version: 7
Space: Engineering (ENG)

Page Content:
<p>Storage body</p>
stderr:
(empty)
$ CONFLUENCE_AUTH_TYPE=none CONFLUENCE_PROTOCOL=http CONFLUENCE_DOMAIN=127.0.0.1:56442 CONFLUENCE_API_PATH=/rest/api CONFLUENCE_CLI_ANALYTICS=false node bin/index.js update 456 --title Renamed page
exit: 0
stdout:
✅ Page updated successfully!
Title: Renamed page
ID: 456
Version: 8
URL: http://127.0.0.1:56442/pages/456
stderr:
(empty)
Server requests observed:
[
  {
    "method": "GET",
    "url": "/rest/api/content/123?expand=body.storage"
  },
  {
    "method": "GET",
    "url": "/rest/api/content/123?expand=body.storage,version,space"
  },
  {
    "method": "GET",
    "url": "/rest/api/content/123?expand=body.storage,version,space"
  },
  {
    "method": "GET",
    "url": "/rest/api/content/456?expand=body.storage"
  },
  {
    "method": "GET",
    "url": "/rest/api/content/456?expand=body.storage,version,space"
  },
  {
    "method": "GET",
    "url": "/rest/api/content/456?expand=body.storage,version,space"
  },
  {
    "method": "PUT",
    "url": "/rest/api/content/456"
  }
]
Normal page PUT bodies captured:
[
  {
    "id": "456",
    "type": "page",
    "title": "Renamed page",
    "space": {
      "key": "ENG",
      "name": "Engineering"
    },
    "body": {
      "storage": {
        "value": "<p>Storage body</p>",
        "representation": "storage"
      }
    },
    "version": {
      "number": 8
    }
  }
]
Old TypeError text surfaced: no
Unexpected PUT during bodyless title-only update: no
Overall result: PASS
```
</details>
<details>
<summary>Evidence: Bodyless folder CLI transcript</summary>

```text
# Bodyless Confluence Content CLI Evidence
Stub API: http://127.0.0.1:56388/rest/api
Stub response for GET /rest/api/content/123: folder-like content with body: {} and no body.storage.value.
$ CONFLUENCE_AUTH_TYPE=none CONFLUENCE_PROTOCOL=http CONFLUENCE_DOMAIN=127.0.0.1:56388 CONFLUENCE_API_PATH=/rest/api CONFLUENCE_CLI_ANALYTICS=false node bin/index.js read 123 --format storage
exit: 1
stdout:
(empty)
stderr:
Error: Page 123 has no readable body (it may be a folder or an unsupported content type).
$ CONFLUENCE_AUTH_TYPE=none CONFLUENCE_PROTOCOL=http CONFLUENCE_DOMAIN=127.0.0.1:56388 CONFLUENCE_API_PATH=/rest/api CONFLUENCE_CLI_ANALYTICS=false node bin/index.js edit 123
exit: 1
stdout:
(empty)
stderr:
Error: Page 123 has no readable body (it may be a folder or an unsupported content type).
$ CONFLUENCE_AUTH_TYPE=none CONFLUENCE_PROTOCOL=http CONFLUENCE_DOMAIN=127.0.0.1:56388 CONFLUENCE_API_PATH=/rest/api CONFLUENCE_CLI_ANALYTICS=false node bin/index.js update 123 --title Renamed folder
exit: 1
stdout:
(empty)
stderr:
Error: Page 123 has no readable body (it may be a folder or an unsupported content type).
Server requests observed:
[
  {
    "method": "GET",
    "url": "/rest/api/content/123?expand=body.storage"
  },
  {
    "method": "GET",
    "url": "/rest/api/content/123?expand=body.storage,version,space"
  },
  {
    "method": "GET",
    "url": "/rest/api/content/123?expand=body.storage,version,space"
  }
]
Old TypeError text surfaced: no
Unexpected PUT during title-only update: no
Overall result: PASS
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npm test -- --runTestsByPath tests/confluence-client.test.js -t &#34;bodyless content \\(folder\\) handling|readPage should return storage content when format is storage|updatePage with format=\\\&#34;auto\\\&#34; converts plain text to storage&#34;` initially exposed missing local dependencies (`jest: command not found`).</code>
- <code>`npm ci` to install project dependencies for testing.</code>
- <code>`npm test -- --runTestsByPath tests/confluence-client.test.js -t &#34;bodyless content \\(folder\\) handling|readPage should return storage content when format is storage|updatePage with format=\\\&#34;auto\\\&#34; converts plain text to storage&#34;` after dependency install.</code>
- <code>`node &lt;&lt;&#39;NODE&#39; ...` evidence generator running real `node bin/index.js read/edit/update` commands against a local HTTP Confluence stub for bodyless folder content and normal page content; transcript saved under the requested evidence directory.</code>
- <code>`npm test -- --runTestsByPath tests/confluence-client.test.js`.</code>
- <code>`rm -rf node_modules` cleanup, followed by `git status --short` and evidence-directory checks.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
