### PR TITLE
fix(api): prevent cross-origin credential leakage

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,7 +818,7 @@ confluence stats
 | `profile use <name>` | Set the active configuration profile | |
 | `profile add <name>` | Add a new configuration profile | `-d, --domain`, `-p, --api-path`, `-a, --auth-type`, `-e, --email`, `-t, --token`, `--protocol`, `--read-only` |
 | `profile remove <name>` | Remove a configuration profile | |
-| `api <endpoint>` | Make an authenticated API request (relative path uses apiPath; absolute path bypasses it) | `-X, --method <method>`, `-f, --field <key=value>`, `-H, --header <key:value>`, `--input <file>`, `--jq <expression>`, `-i, --include`, `--silent` |
+| `api <endpoint>` | Make an authenticated API request (relative path uses apiPath; absolute path bypasses it; full URL must be same-origin) | `-X, --method <method>`, `-f, --field <key=value>`, `-H, --header <key:value>`, `--input <file>`, `--jq <expression>`, `-i, --include`, `--silent` |
 | `convert` | Convert between content formats locally (no server required) | `--input-file <path>`, `--output-file <path>`, `--input-format <markdown\|storage\|html>`, `--output-format <markdown\|storage\|html\|text>` |
 | `stats` | View your usage statistics | |
 

--- a/README.md
+++ b/README.md
@@ -735,7 +735,7 @@ Make arbitrary authenticated requests to any Confluence REST endpoint, modeled a
 
 - **Relative path** (no leading slash) → resolved against the configured `apiPath` (the default for most calls).
 - **Absolute path** (leading `/`) → bypasses `apiPath`; resolved against the host. On Confluence Cloud, `apiPath` is typically `/wiki/rest/api`, so absolute endpoints must include the `/wiki` prefix.
-- **Full URL** (`https://…`) → used as-is.
+- **Full URL** (`https://…`) → used as-is, but only when it is **same-origin** with the configured host. A full URL pointing at a different origin (or an `http://` downgrade of an `https` host) is refused, so your credentials are never sent to an unexpected server.
 
 ```bash
 # List labels on a page (relative — uses apiPath)

--- a/bin/commands/api.js
+++ b/bin/commands/api.js
@@ -29,7 +29,9 @@ Endpoint resolution:
   - Absolute path (leading "/")      → bypasses apiPath; resolved against the host.
     On Confluence Cloud, apiPath is typically /wiki/rest/api, so absolute
     endpoints must include the /wiki prefix (e.g. /wiki/rest/api/content/123).
-  - Full URL (https://...)           → used as-is.
+  - Full URL (https://...)           → used as-is, but only when same-origin
+    with the configured host. A cross-origin URL (or an http:// downgrade of an
+    https host) is refused so credentials are not leaked to another server.
 `)
     .action(async (endpoint, options) => {
       const analytics = new Analytics();

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -2105,6 +2105,13 @@ class ConfluenceClient {
     let url;
     if (/^https?:\/\//i.test(endpoint)) {
       url = endpoint;
+      // A full URL is sent through the authenticated client, whose default
+      // headers carry the Authorization (and Cookie) credentials. Refuse to
+      // send them to anything but the configured origin so a crafted endpoint
+      // (or an http:// downgrade) can't exfiltrate the token. Mirrors the
+      // download-path guard. Relative/absolute-path endpoints resolve against
+      // the configured host below and are unaffected.
+      this.assertSameOrigin(url);
     } else if (endpoint.startsWith('/')) {
       url = `${this.protocol}://${this.domain}${endpoint}`;
     } else {

--- a/plugins/confluence/skills/confluence/SKILL.md
+++ b/plugins/confluence/skills/confluence/SKILL.md
@@ -627,6 +627,29 @@ confluence profile remove staging
 
 ---
 
+### `api <endpoint>`
+
+Make an authenticated request to a Confluence REST endpoint that the CLI does not wrap directly.
+
+```sh
+confluence api <endpoint> [-X <method>] [-f <key=value>] [-H <key:value>] [--input <file>] [--jq <expression>] [-i] [--silent]
+```
+
+Endpoint resolution:
+- Relative paths use the configured `apiPath`.
+- Absolute paths starting with `/` bypass `apiPath` and resolve against the configured host.
+- Full `http://` or `https://` URLs are allowed only when they are same-origin with the configured host; cross-origin URLs and `http://` downgrades from an `https` profile are refused before credentials are sent.
+
+```sh
+confluence api content/123456789/label
+confluence api /wiki/api/v2/pages -f spaceKey=DEV -f limit=10 -X GET
+confluence api content/123456789/label --jq '.results[].name'
+```
+
+Read-only profiles block write methods (`POST`, `PUT`, `PATCH`, `DELETE`) while allowing `GET` and `HEAD`.
+
+---
+
 ### `stats`
 
 Show local usage statistics.

--- a/tests/api-origin-guard.test.js
+++ b/tests/api-origin-guard.test.js
@@ -1,0 +1,88 @@
+const http = require('http');
+const ConfluenceClient = require('../lib/confluence-client');
+
+// Spin up a throwaway HTTP server that records every request it receives,
+// so we can assert whether credentials reached a given origin.
+function startServer() {
+  const received = [];
+  const server = http.createServer((req, res) => {
+    received.push({
+      url: req.url,
+      authorization: req.headers['authorization'] || null,
+      cookie: req.headers['cookie'] || null,
+    });
+    res.statusCode = 200;
+    res.setHeader('content-type', 'application/json');
+    res.end('{}');
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({ server, port: server.address().port, received });
+    });
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+describe('rawRequest cross-origin credential guard', () => {
+  let configured;
+  let attacker;
+
+  beforeEach(async () => {
+    configured = await startServer();
+    attacker = await startServer();
+  });
+
+  afterEach(async () => {
+    await closeServer(configured.server);
+    await closeServer(attacker.server);
+  });
+
+  function makeClient(overrides = {}) {
+    return new ConfluenceClient({
+      domain: `127.0.0.1:${configured.port}`,
+      protocol: 'http',
+      apiPath: '/rest/api',
+      authType: 'basic',
+      email: 'victim@example.com',
+      token: 'SUPER_SECRET_TOKEN',
+      ...overrides,
+    });
+  }
+
+  test('allows a same-origin absolute URL and sends the auth header', async () => {
+    const client = makeClient();
+    const res = await client.rawRequest('GET', `http://127.0.0.1:${configured.port}/rest/api/content/1`);
+    expect(res.status).toBe(200);
+    expect(configured.received).toHaveLength(1);
+    expect(configured.received[0].authorization).toMatch(/^Basic /);
+  });
+
+  test('refuses a cross-origin absolute URL and does NOT leak the auth header', async () => {
+    const client = makeClient();
+    await expect(
+      client.rawRequest('GET', `http://127.0.0.1:${attacker.port}/exfil`)
+    ).rejects.toThrow(/does not match the configured Confluence origin/);
+    // The foreign host must have received nothing — the token was not leaked.
+    expect(attacker.received).toHaveLength(0);
+  });
+
+  test('refuses an http downgrade against an https-configured client', async () => {
+    const client = makeClient({ protocol: 'https' });
+    await expect(
+      client.rawRequest('GET', `http://127.0.0.1:${configured.port}/rest/api/content/1`)
+    ).rejects.toThrow(/does not match the configured Confluence origin/);
+    // No request reached the server over the downgraded scheme.
+    expect(configured.received).toHaveLength(0);
+  });
+
+  test('still resolves relative endpoints against the configured host', async () => {
+    const client = makeClient();
+    const res = await client.rawRequest('GET', 'content/1');
+    expect(res.status).toBe(200);
+    expect(configured.received).toHaveLength(1);
+    expect(configured.received[0].authorization).toMatch(/^Basic /);
+  });
+});

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -2742,13 +2742,28 @@ describe('ConfluenceClient', () => {
       mock.restore();
     });
 
-    test('full URL used as-is', async () => {
+    test('same-origin full URL used as-is', async () => {
       const mock = new MockAdapter(client.client);
-      mock.onGet('https://other.example.com/api/data').reply(200, { ok: true });
+      mock.onGet('https://test.atlassian.net/wiki/api/v2/pages').reply(200, { ok: true });
 
-      const result = await client.rawRequest('GET', 'https://other.example.com/api/data');
+      const result = await client.rawRequest('GET', 'https://test.atlassian.net/wiki/api/v2/pages');
       expect(result.status).toBe(200);
       expect(result.data).toEqual({ ok: true });
+
+      mock.restore();
+    });
+
+    test('refuses a cross-origin full URL so credentials are not leaked', async () => {
+      const mock = new MockAdapter(client.client);
+      // If the guard ever regresses, this mock would let the (now-leaked)
+      // request succeed; the rejection assertion below is what protects us.
+      mock.onGet('https://other.example.com/api/data').reply(200, { ok: true });
+
+      await expect(
+        client.rawRequest('GET', 'https://other.example.com/api/data')
+      ).rejects.toThrow(/does not match the configured Confluence origin/);
+
+      expect(mock.history.get).toHaveLength(0);
 
       mock.restore();
     });


### PR DESCRIPTION
## Intent

The developer first wanted an autonomous, evidence-backed improvement audit of the confluence-cli Node.js codebase, grounded in npm install, tests, lint, npm audit, npm outdated, and direct code investigation, with a standalone prioritized report grouped by High/Medium/Low. After the audit, they promoted only the F1 finding to a shipping task: fix the api/rawRequest credential-origin leak by enforcing same-origin for absolute URLs, starting from a clean base on branch fm/review-confcli-k4 and adding a regression test. They explicitly constrained the work to that single security fix, with no unrelated changes, no pushing or PR during the initial scout phase, and work confined to the disposable worktree except for specified report/status files. For validation, they wanted the no-mistakes pipeline driven through to completion, using the plain git push workaround to trigger the gate, then monitoring/responding to any gate feedback and reporting the final PR URL once checks were green.

## What Changed
- Added a same-origin guard for absolute URLs passed through the API/raw request path so credentials are only sent to the configured Confluence origin.
- Updated API command handling and Confluence client behavior to reject cross-origin full URLs while preserving configured-origin absolute URL support.
- Documented the origin restriction and added regression coverage for both the API origin guard and Confluence client request behavior.

## Risk Assessment

✅ Low: The change is narrowly scoped to applying an existing same-origin guard before authenticated rawRequest full-URL calls, with matching CLI/README messaging and focused regression coverage.

## Testing

Installed dependencies from the lockfile, ran the targeted raw client and API command tests, captured CLI/server evidence showing same-origin absolute URLs succeed with Basic auth while cross-origin absolute URLs are rejected before the foreign server receives a request, then removed transient `node_modules` from the worktree.

<details>
<summary>Evidence: CLI origin guard transcript</summary>

```text
# confluence api origin guard manual verification

Configured origin: http://127.0.0.1:58915
Foreign origin: http://127.0.0.1:58916

$ node bin/index.js api http://127.0.0.1:58915/rest/api/content/1 --include
exit: 0
signal: <none>
error: <none>
timedOut: false
stdout:
HTTP 200
content-type: application/json
date: Wed, 24 Jun 2026 11:45:46 GMT
connection: keep-alive
keep-alive: timeout=5
transfer-encoding: chunked

{
  "ok": true,
  "label": "configured-origin",
  "path": "/rest/api/content/1"
}
stderr:
<empty>

$ node bin/index.js api http://127.0.0.1:58916/exfil
exit: 1
signal: <none>
error: <none>
timedOut: false
stdout:
<empty>
stderr:
Error: Refusing to send credentials to "http://127.0.0.1:58916": origin does not match the configured Confluence origin "http://127.0.0.1:58915". This may indicate a tampered or misconfigured API response, or an http downgrade against an https-configured client.

Observed server requests (credential values redacted at capture time):
{
  "configured": [
    {
      "label": "configured-origin",
      "method": "GET",
      "url": "/rest/api/content/1",
      "authorizationPresent": true,
      "authorizationScheme": "Basic",
      "cookiePresent": false
    }
  ],
  "foreign": []
}

Assertions:
{
  "sameOriginSucceeded": true,
  "sameOriginReachedConfiguredServerWithBasicAuth": true,
  "crossOriginRejected": true,
  "foreignServerReceivedNoRequests": true
}
```
</details>
<details>
<summary>Evidence: Redacted server request log</summary>

```text
{
  "configuredOrigin": "http://127.0.0.1:58915",
  "foreignOrigin": "http://127.0.0.1:58916",
  "sameOrigin": {
    "command": "node bin/index.js api http://127.0.0.1:58915/rest/api/content/1 --include",
    "exitCode": 0,
    "signal": null,
    "error": null,
    "timedOut": false,
    "stdout": "HTTP 200\ncontent-type: application/json\ndate: Wed, 24 Jun 2026 11:45:46 GMT\nconnection: keep-alive\nkeep-alive: timeout=5\ntransfer-encoding: chunked\n\n{\n  \"ok\": true,\n  \"label\": \"configured-origin\",\n  \"path\": \"/rest/api/content/1\"\n}",
    "stderr": ""
  },
  "crossOrigin": {
    "command": "node bin/index.js api http://127.0.0.1:58916/exfil",
    "exitCode": 1,
    "signal": null,
    "error": null,
    "timedOut": false,
    "stdout": "",
    "stderr": "Error: Refusing to send credentials to \"http://127.0.0.1:58916\": origin does not match the configured Confluence origin \"http://127.0.0.1:58915\". This may indicate a tampered or misconfigured API response, or an http downgrade against an https-configured client."
  },
  "receivedRequests": {
    "configured": [
      {
        "label": "configured-origin",
        "method": "GET",
        "url": "/rest/api/content/1",
        "authorizationPresent": true,
        "authorizationScheme": "Basic",
        "cookiePresent": false
      }
    ],
    "foreign": []
  },
  "assertions": {
    "sameOriginSucceeded": true,
    "sameOriginReachedConfiguredServerWithBasicAuth": true,
    "crossOriginRejected": true,
    "foreignServerReceivedNoRequests": true
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm ci`
- `npm test -- --runTestsByPath tests/api-origin-guard.test.js tests/confluence-client.test.js --runInBand`
- `npm test -- --runTestsByPath tests/api-command.test.js --runInBand`
- <code>Manual Node harness started configured and foreign local HTTP origins, then ran `node bin/index.js api http://127.0.0.1:&lt;configured&gt;/rest/api/content/1 --include` and `node bin/index.js api http://127.0.0.1:&lt;foreign&gt;/exfil`; transcript and redacted request log were written to the evidence directory.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
