### PR TITLE
fix(convert): pass through <br> in markdown so table cells can have line breaks

### DIFF
--- a/lib/macro-converter.js
+++ b/lib/macro-converter.js
@@ -21,7 +21,7 @@ const STASH_DELIM = '\uE000';
 // The body alternation `"[^"]*"|'[^']*'|[^>]` makes the match quote-aware
 // so a literal `>` inside a quoted attribute value (e.g.
 // `<mark title="1>0">`) does not terminate the tag prematurely.
-const PASSTHROUGH_TAG_RE = /<\/?(?:u|sub|sup|mark|details|summary)(?=[\s/>])(?:"[^"]*"|'[^']*'|[^>])*>/gi;
+const PASSTHROUGH_TAG_RE = /<\/?(?:br|u|sub|sup|mark|details|summary)(?=[\s/>])(?:"[^"]*"|'[^']*'|[^>])*>/gi;
 // Block-level HTML elements that should pass through WITHOUT markdown processing of their content. 
 const PASSTHROUGH_BLOCK_RE = /<(svg|div)(?:\s[^>]*)?>[\s\S]*?<\/\1>/gi;
 // Single-backtick inline code spans. Block-level code (fenced + indented) is

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -1048,6 +1048,31 @@ describe('MacroConverter <u>/<sub>/<sup>/<mark> passthrough', () => {
   });
 });
 
+describe('MacroConverter <br> passthrough', () => {
+  // `<br>` is the practical way to get a line break inside a table cell via
+  // markdown, since markdown table grammar allows only inline text per cell.
+  const converter = new MacroConverter({ isCloud: true });
+
+  test('<br> in a table cell passes through instead of being escaped', () => {
+    const md = '| 버전 | 변경 |\n| --- | --- |\n| v1 | 가<br>나<br>다 |';
+    const result = converter.markdownToStorage(md);
+    expect(result).toContain('<td><p>가<br>나<br>다</p></td>');
+    expect(result).not.toContain('&lt;br&gt;');
+  });
+
+  test('<br/> and <br /> variants pass through', () => {
+    const result = converter.markdownToStorage('a<br/>b and c<br />d');
+    expect(result).toContain('a<br>b and c<br>d');
+    expect(result).not.toContain('&lt;br');
+  });
+
+  test('literal <br> inside inline code stays escaped, not passed through', () => {
+    const result = converter.markdownToStorage('`<br>`');
+    expect(result).toContain('&lt;br&gt;');
+    expect(result).not.toMatch(/<br>/);
+  });
+});
+
 describe('MacroConverter storageToMarkdown panel formatting', () => {
   const converter = new MacroConverter({ isCloud: true });
 


### PR DESCRIPTION
## Summary

- Add `br` to the inline-HTML passthrough allow-list in `MacroConverter`, so `<br>` survives markdown→storage conversion instead of being escaped to `&lt;br&gt;`.
- `<br>`, `<br/>`, and `<br />` all pass through; a `<br>` inside a code span/block stays escaped as literal text.

## Why

`confluence convert --input-format markdown --output-format storage` (and the markdown input path of `create` / `update`) runs markdown-it with `html: false`, so all raw inline HTML is escaped. The converter works around this by stashing an allow-listed set of inline tags (`u`, `sub`, `sup`, `mark`, `details`, `summary`) around the render and restoring them afterward — but `br` was missing from that list.

As a result a table cell could not contain a line break. `| v1 | 가<br>나<br>다 |` produced `<td><p>가&lt;br&gt;나&lt;br&gt;다</p></td>`. This is the practical way to get a line break inside a table cell, since markdown table grammar allows only inline text per cell. With `br` added, the same input now yields `<td><p>가<br>나<br>다</p></td>`.

## Behavior preservation

- **False positives still rejected** — the `(?=[\s/>])` lookahead keeps `<broken>` and autolink-shaped `<br:foo>` out of the allow-list.
- **Real escaping unchanged** — only allow-listed tags are stashed; `<`, `&`, and non-listed tags (e.g. `<script>`) are still escaped.
- **Code regions unaffected** — `<br>` inside inline / fenced / indented code stays escaped as literal text via the existing code-range exclusion.

## Test plan

- [x] New tests in `tests/macro-converter.test.js`: `<br>` in a table cell passes through; `<br/>` / `<br />` variants pass through; `<br>` inside inline code stays escaped.
- [x] Full suite green (692 tests).

## Out of scope

- The reverse direction (storage→markdown) already renders a `<br>` node as `\n`, so round-tripping a `<br>` back out of a table cell hits a separate, pre-existing markdown-grammar limitation. This PR only fixes the forward (authoring) direction.
