### PR TITLE
fix: preserve same-space page links in Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A powerful command-line interface for Atlassian Confluence that allows you to re
 
 ## Features
 
-- 📖 **Read pages** - Get page content in text or HTML format
+- 📖 **Read pages** - Get page content in text, HTML, storage, or Markdown format
 - 🔍 **Search** - Find pages using Confluence's powerful search
 - ℹ️ **Page info** - Get detailed information about pages
 - 🏠 **List spaces** - View available Confluence spaces
@@ -390,6 +390,8 @@ confluence read "https://your-domain.atlassian.net/wiki/viewpage.action?pageId=1
 ```
 
 Use `--format storage` when you need Confluence's native storage representation, especially for macros and other Confluence-specific markup.
+
+Markdown reads resolve accessible Confluence page links, including links that omit a space key because they target the same space, to absolute URLs. Custom link text and inline formatting are preserved. Markdown exports use the same link resolution.
 
 Reading requires content with a storage body. Folders and other bodyless content return `Page <id> has no readable body (it may be a folder or an unsupported content type).`; use `confluence info <id>` to inspect their metadata.
 

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -4,7 +4,7 @@ const https = require('https');
 const path = require('path');
 const FormData = require('form-data');
 const { convert } = require('html-to-text');
-const { parseDocument } = require('htmlparser2');
+const { Parser, DomHandler } = require('htmlparser2');
 const { decodeHTML } = require('entities');
 const MacroConverter = require('./macro-converter');
 const { htmlToMarkdown, NAMED_ENTITIES } = require('./html-to-markdown');
@@ -48,6 +48,28 @@ const readElementContents = (source, node) => {
   }
 
   return source.slice(first.startIndex, last.endIndex + 1);
+};
+
+const parseDocumentWithExplicitClosures = (source) => {
+  const options = {
+    xmlMode: true,
+    decodeEntities: false,
+    recognizeSelfClosing: true,
+    withStartIndices: true,
+    withEndIndices: true
+  };
+  const explicitlyClosedNodes = new WeakSet();
+  const handler = new DomHandler(undefined, options);
+  const closeTag = handler.onclosetag.bind(handler);
+  handler.onclosetag = (name, isImplied) => {
+    const node = handler.tagStack[handler.tagStack.length - 1];
+    if (!isImplied) {
+      explicitlyClosedNodes.add(node);
+    }
+    closeTag(name, isImplied);
+  };
+  new Parser(handler, options).end(source);
+  return { document: handler.root, explicitlyClosedNodes };
 };
 
 function createSemaphore(limit) {
@@ -670,12 +692,7 @@ class ConfluenceClient {
    * @returns {Promise<string>} - HTML with resolved page links
    */
   async resolvePageLinksInHtml(html, defaultSpaceKey) {
-    const document = parseDocument(html, {
-      xmlMode: true,
-      decodeEntities: false,
-      withStartIndices: true,
-      withEndIndices: true
-    });
+    const { document, explicitlyClosedNodes } = parseDocumentWithExplicitClosures(html);
     const pageLinks = [];
 
     const nodesToVisit = [document];
@@ -684,6 +701,7 @@ class ConfluenceClient {
       if (
         node.type === 'tag'
         && node.name === 'ac:link'
+        && explicitlyClosedNodes.has(node)
         && !node.attribs?.['ac:anchor']
         && !isSemanticMacroPageReference(node)
       ) {

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -414,6 +414,7 @@ class ConfluenceClient {
    * @param {string} format - Output format: 'text', 'html', 'storage', or 'markdown'
    * @param {object} options - Additional options
    * @param {boolean} options.resolveUsers - Whether to resolve userkeys to display names (default: true for markdown)
+   * @param {boolean} options.resolvePageLinks - Whether to replace resolvable Confluence page links with absolute URLs (default: true for markdown)
    * @param {boolean} options.extractReferencedAttachments - Whether to extract referenced attachments (default: false)
    * @throws {Error} When the target content has no storage body
    */
@@ -663,7 +664,7 @@ class ConfluenceClient {
    * Find a page by title and space key, return page info with URL
    * @param {string} spaceKey - Space key (e.g., "~huotui" or "TECH")
    * @param {string} title - Page title
-   * @param {string} defaultBaseUrl - Base URL to use when the result omits one
+   * @param {string} [defaultBaseUrl] - Base URL to use when the result omits one
    * @returns {Promise<{title: string, url: string} | null>}
    */
   async findPageByTitleAndSpace(spaceKey, title, defaultBaseUrl) {
@@ -691,11 +692,11 @@ class ConfluenceClient {
   }
 
   /**
-   * Resolve all page links in HTML to full URLs
+   * Resolve ordinary Confluence page links in storage HTML to absolute URLs
    * @param {string} html - HTML content with ri:page elements
-   * @param {string} defaultSpaceKey - Space key of the page containing the links
-   * @param {string} defaultBaseUrl - Base URL of the page containing the links
-   * @returns {Promise<string>} - HTML with resolved page links
+   * @param {string} [defaultSpaceKey] - Space key of the page containing the links
+   * @param {string} [defaultBaseUrl] - Base URL of the page containing the links
+   * @returns {Promise<string>} - HTML with resolvable page links replaced by anchors
    */
   async resolvePageLinksInHtml(html, defaultSpaceKey, defaultBaseUrl) {
     const { document, explicitlyClosedNodes } = parseDocumentWithExplicitClosures(html);

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -10,6 +10,7 @@ const MacroConverter = require('./macro-converter');
 const { htmlToMarkdown, NAMED_ENTITIES } = require('./html-to-markdown');
 
 const WRITE_FORMATS = ['auto', 'storage', 'html', 'markdown'];
+const PAGE_LINK_LOOKUP_CONCURRENCY = 10;
 
 const escapeXmlText = (value) => String(value)
   .replace(/&/g, '&amp;')
@@ -20,6 +21,19 @@ const escapeXmlAttribute = (value) => escapeXmlText(value).replace(/"/g, '&quot;
 
 const findDirectChild = (node, name) => (node.children || [])
   .find(child => child.type === 'tag' && child.name === name);
+
+const isSemanticMacroPageReference = (node) => {
+  const parameter = node.parent;
+  const macro = parameter?.parent;
+  if (parameter?.name !== 'ac:parameter' || macro?.name !== 'ac:structured-macro') {
+    return false;
+  }
+
+  const macroName = macro.attribs?.['ac:name'];
+  const parameterName = parameter.attribs?.['ac:name'];
+  return (macroName === 'include' && parameterName === '')
+    || (macroName === 'include-shared-block' && parameterName === 'page');
+};
 
 const readElementContents = (source, node) => {
   const children = node && node.children;
@@ -665,7 +679,12 @@ class ConfluenceClient {
     const pageLinks = [];
 
     const collectPageLinks = (node) => {
-      if (node.type === 'tag' && node.name === 'ac:link' && !node.attribs?.['ac:anchor']) {
+      if (
+        node.type === 'tag'
+        && node.name === 'ac:link'
+        && !node.attribs?.['ac:anchor']
+        && !isSemanticMacroPageReference(node)
+      ) {
         const page = findDirectChild(node, 'ri:page');
         const title = decodeHTML(page?.attribs?.['ri:content-title'] || '');
         const spaceKey = decodeHTML(page?.attribs?.['ri:space-key'] || defaultSpaceKey || '');
@@ -694,10 +713,18 @@ class ConfluenceClient {
     }
 
     const pageLookups = new Map();
+    const semaphore = createSemaphore(PAGE_LINK_LOOKUP_CONCURRENCY);
     const pagePromises = pageLinks.map(async (link) => {
       const lookupKey = `${link.spaceKey}\0${link.title}`;
       if (!pageLookups.has(lookupKey)) {
-        pageLookups.set(lookupKey, this.findPageByTitleAndSpace(link.spaceKey, link.title));
+        pageLookups.set(lookupKey, (async () => {
+          await semaphore.acquire();
+          try {
+            return await this.findPageByTitleAndSpace(link.spaceKey, link.title);
+          } finally {
+            semaphore.release();
+          }
+        })());
       }
       return {
         ...link,

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -448,7 +448,11 @@ class ConfluenceClient {
       
       // Resolve page links to full URLs
       if (shouldResolvePageLinks) {
-        htmlContent = await this.resolvePageLinksInHtml(htmlContent, response.data.space?.key);
+        htmlContent = await this.resolvePageLinksInHtml(
+          htmlContent,
+          response.data.space?.key,
+          response.data._links?.base
+        );
       }
       
       // Resolve children macro to child pages list
@@ -659,9 +663,10 @@ class ConfluenceClient {
    * Find a page by title and space key, return page info with URL
    * @param {string} spaceKey - Space key (e.g., "~huotui" or "TECH")
    * @param {string} title - Page title
+   * @param {string} defaultBaseUrl - Base URL to use when the result omits one
    * @returns {Promise<{title: string, url: string} | null>}
    */
-  async findPageByTitleAndSpace(spaceKey, title) {
+  async findPageByTitleAndSpace(spaceKey, title, defaultBaseUrl) {
     try {
       const response = await this.client.get('/content', {
         params: {
@@ -676,7 +681,7 @@ class ConfluenceClient {
         const webui = page._links?.webui || '';
         return {
           title: page.title,
-          url: webui ? this.toAbsoluteUrl(webui, page._links?.base) : ''
+          url: webui ? this.toAbsoluteUrl(webui, page._links?.base || defaultBaseUrl) : ''
         };
       }
       return null;
@@ -689,9 +694,10 @@ class ConfluenceClient {
    * Resolve all page links in HTML to full URLs
    * @param {string} html - HTML content with ri:page elements
    * @param {string} defaultSpaceKey - Space key of the page containing the links
+   * @param {string} defaultBaseUrl - Base URL of the page containing the links
    * @returns {Promise<string>} - HTML with resolved page links
    */
-  async resolvePageLinksInHtml(html, defaultSpaceKey) {
+  async resolvePageLinksInHtml(html, defaultSpaceKey, defaultBaseUrl) {
     const { document, explicitlyClosedNodes } = parseDocumentWithExplicitClosures(html);
     const pageLinks = [];
 
@@ -741,7 +747,7 @@ class ConfluenceClient {
         pageLookups.set(lookupKey, (async () => {
           await semaphore.acquire();
           try {
-            return await this.findPageByTitleAndSpace(link.spaceKey, link.title);
+            return await this.findPageByTitleAndSpace(link.spaceKey, link.title, defaultBaseUrl);
           } finally {
             semaphore.release();
           }

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -4,10 +4,37 @@ const https = require('https');
 const path = require('path');
 const FormData = require('form-data');
 const { convert } = require('html-to-text');
+const { parseDocument } = require('htmlparser2');
+const { decodeHTML } = require('entities');
 const MacroConverter = require('./macro-converter');
 const { htmlToMarkdown, NAMED_ENTITIES } = require('./html-to-markdown');
 
 const WRITE_FORMATS = ['auto', 'storage', 'html', 'markdown'];
+
+const escapeXmlText = (value) => String(value)
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;');
+
+const escapeXmlAttribute = (value) => escapeXmlText(value).replace(/"/g, '&quot;');
+
+const findDirectChild = (node, name) => (node.children || [])
+  .find(child => child.type === 'tag' && child.name === name);
+
+const readElementContents = (source, node) => {
+  const children = node && node.children;
+  if (!children || children.length === 0) {
+    return '';
+  }
+
+  const first = children[0];
+  const last = children[children.length - 1];
+  if (!Number.isInteger(first.startIndex) || !Number.isInteger(last.endIndex)) {
+    return '';
+  }
+
+  return source.slice(first.startIndex, last.endIndex + 1);
+};
 
 function createSemaphore(limit) {
   let active = 0;
@@ -356,10 +383,11 @@ class ConfluenceClient {
    */
   async readPage(pageIdOrUrl, format = 'text', options = {}) {
     const pageId = await this.extractPageId(pageIdOrUrl);
+    const shouldResolvePageLinks = format === 'markdown' && options.resolvePageLinks !== false;
     
     const response = await this.client.get(`/content/${pageId}`, {
       params: {
-        expand: 'body.storage'
+        expand: shouldResolvePageLinks ? 'body.storage,space' : 'body.storage'
       }
     });
 
@@ -383,9 +411,8 @@ class ConfluenceClient {
       }
       
       // Resolve page links to full URLs
-      const resolvePageLinks = options.resolvePageLinks !== false;
-      if (resolvePageLinks) {
-        htmlContent = await this.resolvePageLinksInHtml(htmlContent);
+      if (shouldResolvePageLinks) {
+        htmlContent = await this.resolvePageLinksInHtml(htmlContent, response.data.space?.key);
       }
       
       // Resolve children macro to child pages list
@@ -625,49 +652,72 @@ class ConfluenceClient {
   /**
    * Resolve all page links in HTML to full URLs
    * @param {string} html - HTML content with ri:page elements
+   * @param {string} defaultSpaceKey - Space key of the page containing the links
    * @returns {Promise<string>} - HTML with resolved page links
    */
-  async resolvePageLinksInHtml(html) {
-    // Extract all page links: <ri:page ri:space-key="xxx" ri:content-title="yyy" />
-    const pageLinkRegex = /<ac:link>\s*<ri:page\s+ri:space-key="([^"]+)"\s+ri:content-title="([^"]+)"[^>]*(?:\/>|><\/ri:page>)\s*<\/ac:link>/g;
+  async resolvePageLinksInHtml(html, defaultSpaceKey) {
+    const document = parseDocument(html, {
+      xmlMode: true,
+      decodeEntities: false,
+      withStartIndices: true,
+      withEndIndices: true
+    });
     const pageLinks = [];
-    let match;
-    
-    while ((match = pageLinkRegex.exec(html)) !== null) {
-      pageLinks.push({
-        fullMatch: match[0],
-        spaceKey: match[1],
-        title: match[2]
-      });
-    }
+
+    const collectPageLinks = (node) => {
+      if (node.type === 'tag' && node.name === 'ac:link' && !node.attribs?.['ac:anchor']) {
+        const page = findDirectChild(node, 'ri:page');
+        const title = decodeHTML(page?.attribs?.['ri:content-title'] || '');
+        const spaceKey = decodeHTML(page?.attribs?.['ri:space-key'] || defaultSpaceKey || '');
+
+        if (page && title && spaceKey && Number.isInteger(node.startIndex) && Number.isInteger(node.endIndex)) {
+          const body = findDirectChild(node, 'ac:plain-text-link-body')
+            || findDirectChild(node, 'ac:link-body');
+          pageLinks.push({
+            startIndex: node.startIndex,
+            endIndex: node.endIndex,
+            spaceKey,
+            title,
+            body: readElementContents(html, body)
+          });
+          return;
+        }
+      }
+
+      (node.children || []).forEach(collectPageLinks);
+    };
+
+    collectPageLinks(document);
 
     if (pageLinks.length === 0) {
       return html;
     }
 
-    // Fetch page info for all links in parallel
+    const pageLookups = new Map();
     const pagePromises = pageLinks.map(async (link) => {
-      const pageInfo = await this.findPageByTitleAndSpace(link.spaceKey, link.title);
+      const lookupKey = `${link.spaceKey}\0${link.title}`;
+      if (!pageLookups.has(lookupKey)) {
+        pageLookups.set(lookupKey, this.findPageByTitleAndSpace(link.spaceKey, link.title));
+      }
       return {
         ...link,
-        pageInfo
+        pageInfo: await pageLookups.get(lookupKey)
       };
     });
     
     const resolvedLinks = await Promise.all(pagePromises);
-
-    // Replace page link references with markdown links
     let resolvedHtml = html;
-    resolvedLinks.forEach(({ fullMatch, title, pageInfo }) => {
-      let replacement;
-      if (pageInfo && pageInfo.url) {
-        replacement = `[${title}](${pageInfo.url})`;
-      } else {
-        // Fallback to just the title if page not found
-        replacement = `[${title}]`;
-      }
-      resolvedHtml = resolvedHtml.replace(fullMatch, replacement);
-    });
+
+    resolvedLinks
+      .filter(link => link.pageInfo?.url)
+      .sort((a, b) => b.startIndex - a.startIndex)
+      .forEach(link => {
+        const body = link.body || escapeXmlText(link.title);
+        const replacement = `<a href="${escapeXmlAttribute(link.pageInfo.url)}">${body}</a>`;
+        resolvedHtml = resolvedHtml.slice(0, link.startIndex)
+          + replacement
+          + resolvedHtml.slice(link.endIndex + 1);
+      });
 
     return resolvedHtml;
   }

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -678,7 +678,9 @@ class ConfluenceClient {
     });
     const pageLinks = [];
 
-    const collectPageLinks = (node) => {
+    const nodesToVisit = [document];
+    while (nodesToVisit.length > 0) {
+      const node = nodesToVisit.pop();
       if (
         node.type === 'tag'
         && node.name === 'ac:link'
@@ -699,14 +701,15 @@ class ConfluenceClient {
             title,
             body: readElementContents(html, body)
           });
-          return;
+          continue;
         }
       }
 
-      (node.children || []).forEach(collectPageLinks);
-    };
-
-    collectPageLinks(document);
+      const children = node.children || [];
+      for (let index = children.length - 1; index >= 0; index--) {
+        nodesToVisit.push(children[index]);
+      }
+    }
 
     if (pageLinks.length === 0) {
       return html;

--- a/lib/storage-walker.js
+++ b/lib/storage-walker.js
@@ -66,6 +66,7 @@ class StorageWalker {
   walk(storage) {
     this._depth = 0;
     this._markdownLinkLabelDepth = 0;
+    this._markdownCodeSpanDepth = 0;
     this.warnings = [];
 
     // htmlparser2 in xmlMode is lenient: malformed input (unclosed tags,
@@ -132,7 +133,7 @@ class StorageWalker {
       // &lt; &gt; &quot; &apos;). Confluence storage prose still ships HTML
       // named entities like &nbsp;, &eacute;, &ndash;, so decode them here
       // before they reach markdown output.
-      return this._markdownLinkLabelDepth > 0
+      return this._markdownLinkLabelDepth > 0 && this._markdownCodeSpanDepth === 0
         ? this.escapeMarkdownText(decodeEntities(node.data || ''))
         : decodeEntities(node.data || '');
     case 'cdata':
@@ -176,8 +177,14 @@ class StorageWalker {
       return '*' + this.walkNodes(node.children) + '*';
     case 's': case 'del':
       return '~~' + this.walkNodes(node.children) + '~~';
-    case 'code':
-      return '`' + this.walkNodes(node.children) + '`';
+    case 'code': {
+      this._markdownCodeSpanDepth++;
+      try {
+        return '`' + this.walkNodes(node.children) + '`';
+      } finally {
+        this._markdownCodeSpanDepth--;
+      }
+    }
     case 'br':
       return '\n';
     case 'hr':
@@ -534,7 +541,7 @@ class StorageWalker {
   // an existing `\` in a title isn't reinterpreted as a markdown escape.
   escapeMarkdownText(s) {
     if (!s) return '';
-    return s.replace(/([\\[\]()])/g, '\\$1');
+    return s.replace(/([\\`*_[\]()~|<>])/g, '\\$1');
   }
 
   _collectText(node) {

--- a/lib/storage-walker.js
+++ b/lib/storage-walker.js
@@ -436,12 +436,12 @@ class StorageWalker {
   handleImage(node) {
     const riAttachment = this.findChildByName(node, 'ri:attachment');
     if (riAttachment) {
-      const filename = decodeEntities(riAttachment.attribs['ri:filename'] || '');
+      const filename = this.renderText(riAttachment.attribs['ri:filename'] || '');
       return `![${filename}](${this.attachmentsDir}/${filename})`;
     }
     const riUrl = this.findChildByName(node, 'ri:url');
     if (riUrl) {
-      const url = decodeEntities(riUrl.attribs['ri:value'] || '');
+      const url = this.renderText(riUrl.attribs['ri:value'] || '');
       if (!url) return '';
       return `![](${url})`;
     }

--- a/lib/storage-walker.js
+++ b/lib/storage-walker.js
@@ -133,9 +133,7 @@ class StorageWalker {
       // &lt; &gt; &quot; &apos;). Confluence storage prose still ships HTML
       // named entities like &nbsp;, &eacute;, &ndash;, so decode them here
       // before they reach markdown output.
-      return this._markdownLinkLabelDepth > 0 && this._markdownCodeSpanDepth === 0
-        ? this.escapeMarkdownText(decodeEntities(node.data || ''))
-        : decodeEntities(node.data || '');
+      return this.renderText(node.data || '');
     case 'cdata':
       return this.walkNodes(node.children);
     case 'comment':
@@ -202,7 +200,8 @@ class StorageWalker {
       return `[${inner}](${href})`;
     }
     case 'time':
-      return decodeEntities((node.attribs && node.attribs.datetime) || '') || this.walkNodes(node.children);
+      return this.renderText((node.attribs && node.attribs.datetime) || '')
+        || this.walkNodes(node.children);
     case 'ul':
       return this.handleList(node, false);
     case 'ol':
@@ -542,6 +541,13 @@ class StorageWalker {
   escapeMarkdownText(s) {
     if (!s) return '';
     return s.replace(/([\\`*_[\]()~|<>])/g, '\\$1');
+  }
+
+  renderText(text) {
+    const decodedText = decodeEntities(text);
+    return this._markdownLinkLabelDepth > 0 && this._markdownCodeSpanDepth === 0
+      ? this.escapeMarkdownText(decodedText)
+      : decodedText;
   }
 
   renderCodeSpan(content) {

--- a/lib/storage-walker.js
+++ b/lib/storage-walker.js
@@ -180,7 +180,7 @@ class StorageWalker {
     case 'code': {
       this._markdownCodeSpanDepth++;
       try {
-        return '`' + this.walkNodes(node.children) + '`';
+        return this.renderCodeSpan(this.walkNodes(node.children));
       } finally {
         this._markdownCodeSpanDepth--;
       }
@@ -542,6 +542,14 @@ class StorageWalker {
   escapeMarkdownText(s) {
     if (!s) return '';
     return s.replace(/([\\`*_[\]()~|<>])/g, '\\$1');
+  }
+
+  renderCodeSpan(content) {
+    const backtickRuns = content.match(/`+/g) || [];
+    const longestRun = backtickRuns.reduce((max, run) => Math.max(max, run.length), 0);
+    const delimiter = '`'.repeat(longestRun + 1);
+    const padding = content.startsWith('`') || content.endsWith('`') ? ' ' : '';
+    return `${delimiter}${padding}${content}${padding}${delimiter}`;
   }
 
   _collectText(node) {

--- a/lib/storage-walker.js
+++ b/lib/storage-walker.js
@@ -65,6 +65,7 @@ class StorageWalker {
 
   walk(storage) {
     this._depth = 0;
+    this._markdownLinkLabelDepth = 0;
     this.warnings = [];
 
     // htmlparser2 in xmlMode is lenient: malformed input (unclosed tags,
@@ -131,7 +132,9 @@ class StorageWalker {
       // &lt; &gt; &quot; &apos;). Confluence storage prose still ships HTML
       // named entities like &nbsp;, &eacute;, &ndash;, so decode them here
       // before they reach markdown output.
-      return decodeEntities(node.data || '');
+      return this._markdownLinkLabelDepth > 0
+        ? this.escapeMarkdownText(decodeEntities(node.data || ''))
+        : decodeEntities(node.data || '');
     case 'cdata':
       return this.walkNodes(node.children);
     case 'comment':
@@ -181,8 +184,14 @@ class StorageWalker {
       return '\n---\n';
     case 'a': {
       const href = decodeEntities((node.attribs && node.attribs.href) || '');
-      const inner = this.walkNodes(node.children);
-      if (!href) return inner;
+      if (!href) return this.walkNodes(node.children);
+      this._markdownLinkLabelDepth++;
+      let inner;
+      try {
+        inner = this.walkNodes(node.children);
+      } finally {
+        this._markdownLinkLabelDepth--;
+      }
       return `[${inner}](${href})`;
     }
     case 'time':

--- a/plugins/confluence/skills/confluence/SKILL.md
+++ b/plugins/confluence/skills/confluence/SKILL.md
@@ -120,7 +120,7 @@ confluence read "https://company.atlassian.net/wiki/spaces/MYSPACE/pages/1234567
 
 | Format | Notes |
 |---|---|
-| `markdown` | Recommended for agent-generated content. Automatically converted by the API. |
+| `markdown` | Recommended for agent-generated content. Automatically converted by the CLI. |
 | `storage` | Confluence XML storage format (default for create/update). Use for programmatic round-trips. |
 | `html` | Raw HTML. |
 | `text` | Plain text — for read/export output only, not for creation. |
@@ -162,6 +162,8 @@ confluence read 123456789
 confluence read 123456789 --format storage
 confluence read 123456789 --format markdown
 ```
+
+Markdown output resolves accessible Confluence page links, including links to pages in the same space, to absolute URLs while preserving custom link text and inline formatting.
 
 Requires content with a storage body. Folders and other bodyless content return `Page <id> has no readable body (it may be a folder or an unsupported content type).`; use `confluence info <id>` to inspect their metadata.
 

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -628,6 +628,26 @@ describe('ConfluenceClient', () => {
       mock.restore();
     });
 
+    test('resolvePageLinksInHtml preserves implicitly closed links and trailing content', async () => {
+      client.findPageByTitleAndSpace = jest.fn();
+      const storage = '<p>Before <ac:link><ri:page ri:content-title="Target" /></p>'
+        + '<p>Trailing content</p>';
+
+      const result = await client.resolvePageLinksInHtml(storage, 'ENG');
+      const warnings = [];
+      const markdown = client.storageToMarkdown(result, {
+        onWarnings: emitted => warnings.push(...emitted)
+      });
+
+      expect(result).toBe(storage);
+      expect(client.findPageByTitleAndSpace).not.toHaveBeenCalled();
+      expect(markdown).toContain('Trailing content');
+      expect(warnings).toContainEqual(expect.objectContaining({
+        type: 'implicit-close',
+        tag: 'ac:link'
+      }));
+    });
+
     test('resolvePageLinksInHtml caps concurrent unique page lookups', async () => {
       let inFlight = 0;
       let maxInFlight = 0;

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -536,6 +536,91 @@ describe('ConfluenceClient', () => {
       mock.restore();
     });
 
+    test('readPage preserves semantic macro page references while resolving body links', async () => {
+      const mock = new MockAdapter(client.client);
+      const lookedUpTitles = [];
+      mock.onGet('/content/123').reply(200, {
+        space: { key: 'ENG' },
+        body: {
+          storage: {
+            value: '<ac:structured-macro ac:name="include"><ac:parameter ac:name=""><ac:link><ri:page ri:content-title="Included page" /></ac:link></ac:parameter></ac:structured-macro>'
+              + '<ac:structured-macro ac:name="include-shared-block"><ac:parameter ac:name="shared-block-key">block-1</ac:parameter><ac:parameter ac:name="page"><ac:link><ri:page ri:content-title="Shared source" /></ac:link></ac:parameter></ac:structured-macro>'
+              + '<p><ac:link><ri:page ri:content-title="Body target" /></ac:link></p>'
+          }
+        }
+      });
+      mock.onGet('/content').reply(config => {
+        lookedUpTitles.push(config.params.title);
+        return [200, {
+          results: [{
+            title: config.params.title,
+            _links: { webui: '/spaces/ENG/pages/456/Body-target' }
+          }]
+        }];
+      });
+
+      const result = await client.readPage('123', 'markdown');
+
+      expect(lookedUpTitles).toEqual(['Body target']);
+      expect(result).toContain('**Include Page**: [Included page]');
+      expect(result).toContain('**Include Shared Block**: block-1 (from page: Shared source');
+      expect(result).toContain('[Body target](https://test.atlassian.net/spaces/ENG/pages/456/Body-target)');
+
+      mock.restore();
+    });
+
+    test('readPage escapes resolved page-link labels while preserving inline formatting', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123').reply(200, {
+        space: { key: 'ENG' },
+        body: {
+          storage: {
+            value: '<p><ac:link><ri:page ri:content-title="evil](https://attacker) [x" /></ac:link> and '
+              + '<ac:link><ri:page ri:content-title="Custom" /><ac:link-body><strong>Read [this]</strong></ac:link-body></ac:link></p>'
+          }
+        }
+      });
+      mock.onGet('/content').reply(config => [200, {
+        results: [{
+          title: config.params.title,
+          _links: {
+            webui: config.params.title === 'Custom'
+              ? '/spaces/ENG/pages/456/Custom'
+              : '/spaces/ENG/pages/456/Fallback'
+          }
+        }]
+      }]);
+
+      await expect(client.readPage('123', 'markdown')).resolves.toBe(
+        '[evil\\]\\(https://attacker\\) \\[x](https://test.atlassian.net/spaces/ENG/pages/456/Fallback)'
+          + ' and [**Read \\[this\\]**](https://test.atlassian.net/spaces/ENG/pages/456/Custom)'
+      );
+
+      mock.restore();
+    });
+
+    test('resolvePageLinksInHtml caps concurrent unique page lookups', async () => {
+      let inFlight = 0;
+      let maxInFlight = 0;
+      const titles = Array.from({ length: 25 }, (_, index) => `Page ${index}`);
+      client.findPageByTitleAndSpace = jest.fn(async (_spaceKey, title) => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise(resolve => setImmediate(resolve));
+        inFlight--;
+        return { title, url: `https://example.com/${encodeURIComponent(title)}` };
+      });
+      const html = [...titles, titles[0]]
+        .map(title => `<ac:link><ri:page ri:content-title="${title}" /></ac:link>`)
+        .join('');
+
+      const result = await client.resolvePageLinksInHtml(html, 'ENG');
+
+      expect(client.findPageByTitleAndSpace).toHaveBeenCalledTimes(titles.length);
+      expect(maxInFlight).toBeLessThanOrEqual(10);
+      expect(result.match(/<a href=/g)).toHaveLength(titles.length + 1);
+    });
+
     describe('bodyless content (folder) handling', () => {
       const NO_BODY_MESSAGE = /Page 123 has no readable body \(it may be a folder or an unsupported content type\)\./;
 

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -478,6 +478,64 @@ describe('ConfluenceClient', () => {
       mock.restore();
     });
 
+    test('readPage resolves same-space page links in markdown output', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123').reply(config => {
+        expect(config.params.expand).toBe('body.storage,space');
+        return [200, {
+          space: { key: 'ENG' },
+          body: {
+            storage: {
+              value: '<p>See <ac:link><ri:page ri:content-title="Target page" /></ac:link>.</p>'
+            }
+          }
+        }];
+      });
+      mock.onGet('/content').reply(config => {
+        expect(config.params).toEqual({
+          spaceKey: 'ENG',
+          title: 'Target page',
+          limit: 1
+        });
+        return [200, {
+          results: [{
+            title: 'Target page',
+            _links: { webui: '/spaces/ENG/pages/456/Target-page' }
+          }]
+        }];
+      });
+
+      await expect(client.readPage('123', 'markdown')).resolves.toBe(
+        'See [Target page](https://test.atlassian.net/spaces/ENG/pages/456/Target-page).'
+      );
+
+      mock.restore();
+    });
+
+    test('readPage preserves custom text for resolved same-space page links', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123').reply(200, {
+        space: { key: 'ENG' },
+        body: {
+          storage: {
+            value: '<p><ac:link><ri:page ri:content-title="Target page" /><ac:link-body><strong>Read this</strong></ac:link-body></ac:link></p>'
+          }
+        }
+      });
+      mock.onGet('/content').reply(200, {
+        results: [{
+          title: 'Target page',
+          _links: { webui: '/spaces/ENG/pages/456/Target-page' }
+        }]
+      });
+
+      await expect(client.readPage('123', 'markdown')).resolves.toBe(
+        '[**Read this**](https://test.atlassian.net/spaces/ENG/pages/456/Target-page)'
+      );
+
+      mock.restore();
+    });
+
     describe('bodyless content (folder) handling', () => {
       const NO_BODY_MESSAGE = /Page 123 has no readable body \(it may be a folder or an unsupported content type\)\./;
 

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -601,6 +601,33 @@ describe('ConfluenceClient', () => {
       mock.restore();
     });
 
+    test('readPage uses collision-safe code spans in resolved page-link labels', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123').reply(200, {
+        space: { key: 'ENG' },
+        body: {
+          storage: {
+            value: '<p><ac:link><ri:page ri:content-title="Custom" /><ac:link-body>'
+              + '<code>safe`](https://attacker.example) [x</code>'
+              + '</ac:link-body></ac:link></p>'
+          }
+        }
+      });
+      mock.onGet('/content').reply(200, {
+        results: [{
+          title: 'Custom',
+          _links: { webui: '/spaces/ENG/pages/456/Custom' }
+        }]
+      });
+
+      await expect(client.readPage('123', 'markdown')).resolves.toBe(
+        '[``safe`](https://attacker.example) [x``]'
+          + '(https://test.atlassian.net/spaces/ENG/pages/456/Custom)'
+      );
+
+      mock.restore();
+    });
+
     test('resolvePageLinksInHtml caps concurrent unique page lookups', async () => {
       let inFlight = 0;
       let maxInFlight = 0;

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -513,6 +513,44 @@ describe('ConfluenceClient', () => {
       mock.restore();
     });
 
+    test('readPage uses the containing page base when scoped lookup results omit it', async () => {
+      const scopedClient = new ConfluenceClient({
+        domain: 'api.atlassian.com',
+        email: 'user@example.com',
+        token: 'scoped-token',
+        apiPath: '/ex/confluence/cloud-id/wiki/rest/api'
+      });
+      const mock = new MockAdapter(scopedClient.client);
+      mock.onGet('/content/123').reply(200, {
+        space: { key: 'ENG' },
+        body: {
+          storage: {
+            value: '<p><ac:link><ri:page ri:content-title="Fallback base" /></ac:link> and '
+              + '<ac:link><ri:page ri:content-title="Result base" /></ac:link></p>'
+          }
+        },
+        _links: { base: 'https://tenant.atlassian.net/wiki' }
+      });
+      mock.onGet('/content').reply(config => [200, {
+        results: [{
+          title: config.params.title,
+          _links: {
+            ...(config.params.title === 'Result base'
+              ? { base: 'https://result-tenant.atlassian.net/wiki' }
+              : {}),
+            webui: `/spaces/ENG/pages/456/${config.params.title.replace(' ', '-')}`
+          }
+        }]
+      }]);
+
+      await expect(scopedClient.readPage('123', 'markdown')).resolves.toBe(
+        '[Fallback base](https://tenant.atlassian.net/wiki/spaces/ENG/pages/456/Fallback-base)'
+          + ' and [Result base](https://result-tenant.atlassian.net/wiki/spaces/ENG/pages/456/Result-base)'
+      );
+
+      mock.restore();
+    });
+
     test('readPage preserves custom text for resolved same-space page links', async () => {
       const mock = new MockAdapter(client.client);
       mock.onGet('/content/123').reply(200, {

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -628,6 +628,33 @@ describe('ConfluenceClient', () => {
       mock.restore();
     });
 
+    test('readPage escapes datetime attributes in resolved page-link labels', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123').reply(200, {
+        space: { key: 'ENG' },
+        body: {
+          storage: {
+            value: '<p><ac:link><ri:page ri:content-title="Custom" /><ac:link-body>'
+              + '<time datetime="x](https://attacker.example) [y"></time>'
+              + '</ac:link-body></ac:link></p>'
+          }
+        }
+      });
+      mock.onGet('/content').reply(200, {
+        results: [{
+          title: 'Custom',
+          _links: { webui: '/spaces/ENG/pages/456/Custom' }
+        }]
+      });
+
+      await expect(client.readPage('123', 'markdown')).resolves.toBe(
+        '[x\\]\\(https://attacker.example\\) \\[y]'
+          + '(https://test.atlassian.net/spaces/ENG/pages/456/Custom)'
+      );
+
+      mock.restore();
+    });
+
     test('resolvePageLinksInHtml preserves implicitly closed links and trailing content', async () => {
       client.findPageByTitleAndSpace = jest.fn();
       const storage = '<p>Before <ac:link><ri:page ri:content-title="Target" /></p>'
@@ -1253,6 +1280,12 @@ describe('ConfluenceClient', () => {
       const storage = '<ac:link><ri:page ri:content-title="Some Long Page Title" ri:version-at-save="28" /><ac:link-body>Short Name</ac:link-body></ac:link>';
       const result = client.storageToMarkdown(storage);
       expect(result).toContain('Short Name');
+    });
+
+    test('should preserve datetime attributes outside markdown link labels', () => {
+      const storage = '<p>at <time datetime="x](https://example.com) [y"></time></p>';
+
+      expect(client.storageToMarkdown(storage)).toBe('at x](https://example.com) [y');
     });
 
     test('should remove ac:link tags with attributes', () => {

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -693,6 +693,61 @@ describe('ConfluenceClient', () => {
       mock.restore();
     });
 
+    test('readPage escapes attachment images in resolved page-link labels', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123').reply(200, {
+        space: { key: 'ENG' },
+        body: {
+          storage: {
+            value: '<ac:link><ri:page ri:content-title="Custom" /><ac:link-body>'
+              + '<ac:image><ri:attachment ri:filename="plot](https://attacker.example) [x.png" /></ac:image>'
+              + '</ac:link-body></ac:link>'
+          }
+        }
+      });
+      mock.onGet('/content').reply(200, {
+        results: [{
+          title: 'Custom',
+          _links: { webui: '/spaces/ENG/pages/456/Custom' }
+        }]
+      });
+
+      await expect(client.readPage('123', 'markdown')).resolves.toBe(
+        '[![plot\\]\\(https://attacker.example\\) \\[x.png]'
+          + '(attachments/plot\\]\\(https://attacker.example\\) \\[x.png)]'
+          + '(https://test.atlassian.net/spaces/ENG/pages/456/Custom)'
+      );
+
+      mock.restore();
+    });
+
+    test('readPage escapes external images in resolved page-link labels', async () => {
+      const mock = new MockAdapter(client.client);
+      mock.onGet('/content/123').reply(200, {
+        space: { key: 'ENG' },
+        body: {
+          storage: {
+            value: '<ac:link><ri:page ri:content-title="Custom" /><ac:link-body>'
+              + '<ac:image><ri:url ri:value="https://images.example/x.png)](https://attacker.example) [x" /></ac:image>'
+              + '</ac:link-body></ac:link>'
+          }
+        }
+      });
+      mock.onGet('/content').reply(200, {
+        results: [{
+          title: 'Custom',
+          _links: { webui: '/spaces/ENG/pages/456/Custom' }
+        }]
+      });
+
+      await expect(client.readPage('123', 'markdown')).resolves.toBe(
+        '[![](https://images.example/x.png\\)\\]\\(https://attacker.example\\) \\[x)]'
+          + '(https://test.atlassian.net/spaces/ENG/pages/456/Custom)'
+      );
+
+      mock.restore();
+    });
+
     test('resolvePageLinksInHtml preserves implicitly closed links and trailing content', async () => {
       client.findPageByTitleAndSpace = jest.fn();
       const storage = '<p>Before <ac:link><ri:page ri:content-title="Target" /></p>'
@@ -1324,6 +1379,18 @@ describe('ConfluenceClient', () => {
       const storage = '<p>at <time datetime="x](https://example.com) [y"></time></p>';
 
       expect(client.storageToMarkdown(storage)).toBe('at x](https://example.com) [y');
+    });
+
+    test('should preserve image attributes outside markdown link labels', () => {
+      const attachment = '<ac:image><ri:attachment ri:filename="plot](draft).png" /></ac:image>';
+      const external = '<ac:image><ri:url ri:value="https://images.example/x](draft).png" /></ac:image>';
+
+      expect(client.storageToMarkdown(attachment)).toBe(
+        '![plot](draft).png](attachments/plot](draft).png)'
+      );
+      expect(client.storageToMarkdown(external)).toBe(
+        '![](https://images.example/x](draft).png)'
+      );
     });
 
     test('should remove ac:link tags with attributes', () => {

--- a/tests/confluence-client.test.js
+++ b/tests/confluence-client.test.js
@@ -4,6 +4,7 @@ const path = require('path');
 const FormData = require('form-data');
 const axios = require('axios');
 const ConfluenceClient = require('../lib/confluence-client');
+const { StorageDepthExceededError } = require('../lib/storage-walker');
 const MockAdapter = require('axios-mock-adapter');
 
 const removeDirRecursive = (dir) => {
@@ -576,7 +577,8 @@ describe('ConfluenceClient', () => {
         body: {
           storage: {
             value: '<p><ac:link><ri:page ri:content-title="evil](https://attacker) [x" /></ac:link> and '
-              + '<ac:link><ri:page ri:content-title="Custom" /><ac:link-body><strong>Read [this]</strong></ac:link-body></ac:link></p>'
+              + '<ac:link><ri:page ri:content-title="Custom" /><ac:link-body>*literal* <code>[x]</code> '
+              + '<strong>Read [this]</strong> <em>styled</em></ac:link-body></ac:link></p>'
           }
         }
       });
@@ -593,7 +595,7 @@ describe('ConfluenceClient', () => {
 
       await expect(client.readPage('123', 'markdown')).resolves.toBe(
         '[evil\\]\\(https://attacker\\) \\[x](https://test.atlassian.net/spaces/ENG/pages/456/Fallback)'
-          + ' and [**Read \\[this\\]**](https://test.atlassian.net/spaces/ENG/pages/456/Custom)'
+          + ' and [\\*literal\\* `[x]` **Read \\[this\\]** *styled*](https://test.atlassian.net/spaces/ENG/pages/456/Custom)'
       );
 
       mock.restore();
@@ -619,6 +621,23 @@ describe('ConfluenceClient', () => {
       expect(client.findPageByTitleAndSpace).toHaveBeenCalledTimes(titles.length);
       expect(maxInFlight).toBeLessThanOrEqual(10);
       expect(result.match(/<a href=/g)).toHaveLength(titles.length + 1);
+    });
+
+    test('readPage reports controlled depth errors for deeply nested storage', async () => {
+      const mock = new MockAdapter(client.client);
+      const nesting = 20000;
+      mock.onGet('/content/123').reply(200, {
+        space: { key: 'ENG' },
+        body: {
+          storage: {
+            value: '<p>'.repeat(nesting) + 'content' + '</p>'.repeat(nesting)
+          }
+        }
+      });
+
+      await expect(client.readPage('123', 'markdown')).rejects.toThrow(StorageDepthExceededError);
+
+      mock.restore();
     });
 
     describe('bodyless content (folder) handling', () => {


### PR DESCRIPTION
## What Changed

- Resolve same-space Confluence page links to absolute tenant URLs in Markdown reads and exports while preserving custom labels and inline formatting.
- Harden link conversion for malformed storage, semantic macros, deep nesting, bounded lookups, and Markdown-safe text, code, datetime, and image labels.
- Document the behavior and add regression coverage for page-link resolution and escaping.

## Risk Assessment

✅ Low: The change is well-bounded, preserves fallback behavior, limits lookups, and includes focused regression coverage.

## Testing

Reviewed the issue intent and diff, ran focused and full regression tests, then verified an actual CLI read→update round-trip against a Confluence-compatible HTTP fixture; the internal link remained intact and the worktree stayed clean. As this is CLI behavior, the transcript and captured API payload provide the reviewer-visible evidence rather than a screenshot.

<details>
<summary>Evidence: CLI read/update round-trip</summary>

`Read emitted a tenant-qualified Markdown link; update persisted the same linked URL.`

```text
$ confluence read 123 --format markdown
Start here: [Target page](https://tenant.atlassian.net/wiki/spaces/ENG/pages/456/Target-page).

$ confluence update 123 --file same-space-read.md --format markdown
✅ Page updated successfully!
Title: Source page
ID: 123
Version: 8
URL: http://127.0.0.1:58616/spaces/ENG/pages/123/Source-page

Confluence-compatible API requests:
  GET /rest/api/content/123?expand=body.storage,space
  GET /rest/api/content?spaceKey=ENG&title=Target+page&limit=1
  GET /rest/api/content/123?expand=body.storage,version,space
  PUT /rest/api/content/123

Persisted storage body:
<p>Start here: <a href="https://tenant.atlassian.net/wiki/spaces/ENG/pages/456/Target-page" data-card-appearance="inline">Target page</a>.</p>


VERIFIED: the same-space page link is emitted as Markdown and remains linked in the update payload.
```
</details>
<details>
<summary>Evidence: Captured update payload</summary>

```text
{
  "id": "123",
  "type": "page",
  "title": "Source page",
  "space": {
    "key": "ENG"
  },
  "body": {
    "storage": {
      "value": "<p>Start here: <a href=\"https://tenant.atlassian.net/wiki/spaces/ENG/pages/456/Target-page\" data-card-appearance=\"inline\">Target page</a>.</p>\n",
      "representation": "storage"
    }
  },
  "version": {
    "number": 8
  }
}
```
</details>
<details>
<summary>Evidence: CLI read output</summary>

`Start here: [Target page](https://tenant.atlassian.net/wiki/spaces/ENG/pages/456/Target-page).`

```text
Start here: [Target page](https://tenant.atlassian.net/wiki/spaces/ENG/pages/456/Target-page).
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (7) ✅</summary>

- 🚨 `lib/confluence-client.js:668` - The resolver replaces every page link, including references inside include/shared-block macro parameters. This destroys the structure required by StorageWalker, causing macro output to disappear or lose semantics. Skip semantic macro-parameter links.
- ⚠️ `lib/confluence-client.js:715` - Fallback titles and custom bodies enter a Markdown link label without Markdown escaping. A crafted title such as `evil](https://attacker) [x` can inject another link, regressing the converter’s existing escaping invariant.
- ⚠️ `lib/confluence-client.js:697` - All unique link lookups run concurrently. Pages with many same-space links can create a large request burst, trigger rate limits, and silently leave links unresolved because lookup errors are swallowed. Apply bounded concurrency.

🔧 Fix: fix: harden same-space page link resolution
2 warnings still open:
- ⚠️ `lib/confluence-client.js:706` - Recursive DOM traversal bypasses StorageWalker’s depth guard. Pathologically nested storage can throw a native stack overflow before the controlled StorageDepthExceededError. Use iterative traversal or enforce the same depth limit.
- ⚠️ `lib/storage-walker.js:136` - Link-label escaping is context-blind and incomplete: plain `*text*` becomes unintended emphasis, while `[x]` inside `&lt;code&gt;` gains visible backslashes. Escape literal Markdown syntax outside code spans while preserving markup emitted by inline element handlers.

🔧 Fix: fix: harden deep page-link rendering
1 warning still open:
- ⚠️ `lib/storage-walker.js:183` - Code text bypasses escaping, but code spans always use one backtick. A label containing a backtick plus `](` can leave the span unmatched and inject a sibling Markdown link. Use a delimiter longer than the longest backtick run.

🔧 Fix: Harden inline code spans against Markdown link injection
1 warning still open:
- ⚠️ `lib/confluence-client.js:747` - Lenient parsing assigns EOF as `endIndex` for an unclosed `&lt;ac:link&gt;`, so replacement can delete the remainder of malformed storage and bypass StorageWalker’s warning path. Only replace explicitly closed link nodes.

🔧 Fix: Preserve malformed page links without dropping trailing content
1 warning still open:
- ⚠️ `lib/storage-walker.js:136` - Link-label escaping only covers text nodes. Attribute-derived inline content such as `&lt;time datetime=&#34;x](https://attacker) [y&#34;&gt;` bypasses escaping and can terminate a resolved page-link label. Escape every attribute-derived fragment emitted while `_markdownLinkLabelDepth` is active.

🔧 Fix: Escape datetime content in Markdown link labels
1 warning still open:
- ⚠️ `lib/confluence-client.js:451` - Only the space key reaches the resolver. Title-search result items omit `_links.base`, so scoped clients fall back to `https://api.atlassian.com/wiki/...` instead of the tenant URL. Pass the containing page’s `_links.base` through the lookup. See the [Atlassian response examples](https://developer.atlassian.com/cloud/confluence/rest-api-examples/).

🔧 Fix: Preserve tenant origins for scoped page links
1 warning still open:
- ⚠️ `lib/confluence-client.js:770` - Resolved links copy rich bodies into `&lt;a&gt;` unchanged. An embedded `ac:image` can emit an unescaped filename or URL that closes the Markdown label and injects another link. Make image rendering honor link-label escaping.

🔧 Fix: Escape images in resolved Markdown link labels
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `gh-axi issue view 215 --full`
- `npm test -- --runInBand tests/confluence-client.test.js`
- `node /var/folders/mm/mzvsb9xn40vd3pqkp4y8n_sm0000gn/T/no-mistakes-evidence/01KXJVGBVYCC6BB1P3KV9A7Y6T/cli-roundtrip-e2e.js`
- `npm test -- --runInBand`
- `git status --short --untracked-files=all`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
