### PR TITLE
docs: add npm downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Confluence CLI
 
+[![npm downloads](https://img.shields.io/npm/dm/confluence-cli.svg)](https://www.npmjs.com/package/confluence-cli)
+
 A powerful command-line interface for Atlassian Confluence that allows you to read, search, and manage your Confluence content from the terminal.
 
 ## Features


### PR DESCRIPTION
## Summary

Add an npm monthly downloads badge to the top of the README so the package's adoption (~33k downloads/month) is visible at a glance.

The badge is served by shields.io (`npm/dm`) and updates automatically from the npm registry.