### PR TITLE
feat: emit structured errors in JSON mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ confluence create "Notes" ENG --content "hi" --json | jq -r '.id'   # capture th
 
 #### Structured errors
 
-When `--json` is active, command failures routed through the standard error handler (`handleCommandError`) and the `api` command's own error path are machine-parseable: the command prints exactly one JSON object to **stderr** (stdout stays empty) and exits with status `1`. This lets scripts and agents branch on covered failures without scraping prose. The shape is:
+When `--json` is active, command failures routed through the standard error handler (`handleCommandError`) and the `api` command's own error path are machine-parseable: the command prints exactly one JSON object to **stderr** (stdout stays empty) and, except as noted below, exits with status `1`. This lets scripts and agents branch on covered failures without scraping prose. The shape is:
 
 ```json
 {
@@ -416,7 +416,7 @@ confluence info 123 --json 2> >(jq -r '.code') 1>/dev/null
 
 Without `--json`, error output is unchanged (human-readable prose on stderr).
 
-Exceptions: CLI parser argument and usage errors, the unsupported-`--json` guard, and read-only or configuration-loading failures that exit before the standard handler still print human-readable prose. Partial failures from `copy-tree --fail-on-error` and `versions-purge` emit their result JSON to stdout and signal the partial failure with exit status `1` instead of a structured error on stderr.
+Exceptions: `api` failures caused by missing `jq` or a failing `--jq` expression still use the structured stderr format but preserve exit status `2`. CLI parser argument and usage errors, the unsupported-`--json` guard, and read-only or configuration-loading failures that exit before the standard handler still print human-readable prose. Partial failures from `copy-tree --fail-on-error` and `versions-purge` emit their result JSON to stdout and signal the partial failure with exit status `1` instead of a structured error on stderr.
 
 ### Read a Page
 ```bash

--- a/README.md
+++ b/README.md
@@ -391,6 +391,31 @@ confluence create "Notes" ENG --content "hi" --json | jq -r '.id'   # capture th
 
 > **Deprecation:** the per-command `--format json` form is deprecated in favor of the global `--json` flag. It still works but prints a warning to stderr and will be removed in a future major version.
 
+#### Structured errors
+
+When `--json` is active, failures are also machine-parseable: the command prints exactly one JSON object to **stderr** (stdout stays empty) and exits with status `1`. This lets scripts and agents branch on failures without scraping prose. The shape is:
+
+```json
+{
+  "error": "Authentication failed (401 Unauthorized).",
+  "code": "AUTH_FAILED",
+  "status": 401,
+  "details": { "message": "...", "status-code": 401 }
+}
+```
+
+- `error` — the human-readable message.
+- `code` — a stable machine code, one of `AUTH_FAILED`, `NOT_FOUND`, `VALIDATION`, `API_ERROR`, `NETWORK`, `UNKNOWN`.
+- `status` — the HTTP status when the failure came from the server, otherwise `null`.
+- `details` — the raw API response body when present, otherwise `null`.
+
+```bash
+# Read errors from stderr and inspect the code
+confluence info 123 --json 2> >(jq -r '.code') 1>/dev/null
+```
+
+Without `--json`, error output is unchanged (human-readable prose on stderr).
+
 ### Read a Page
 ```bash
 # Read by page ID

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ confluence create "Notes" ENG --content "hi" --json | jq -r '.id'   # capture th
 
 #### Structured errors
 
-When `--json` is active, command failures routed through the standard error handler (`handleCommandError`) and the `api` command's own error path are machine-parseable: the command prints exactly one JSON object to **stderr** (stdout stays empty) and, except as noted below, exits with status `1`. This lets scripts and agents branch on covered failures without scraping prose. The shape is:
+When `--json` is active, command failures are machine-parseable: the command prints exactly one JSON object to **stderr** (stdout stays empty) and, except as noted below, exits with status `1`. This lets scripts and agents branch on failures without scraping prose. The shape is:
 
 ```json
 {
@@ -416,7 +416,7 @@ confluence info 123 --json 2> >(jq -r '.code') 1>/dev/null
 
 Without `--json`, error output is unchanged (human-readable prose on stderr).
 
-Exceptions: `api` failures caused by missing `jq` or a failing `--jq` expression still use the structured stderr format but preserve exit status `2`. CLI parser argument and usage errors, the unsupported-`--json` guard, and read-only or configuration-loading failures that exit before the standard handler still print human-readable prose. Partial failures from `copy-tree --fail-on-error` and `versions-purge` emit their result JSON to stdout and signal the partial failure with exit status `1` instead of a structured error on stderr.
+Exceptions: `api` failures caused by missing `jq` or a failing `--jq` expression still use the structured stderr format but preserve exit status `2`. Partial failures from `copy-tree --fail-on-error` and `versions-purge` emit their result JSON to stdout and signal the partial failure with exit status `1` instead of a structured error on stderr.
 
 ### Read a Page
 ```bash

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ confluence create "Notes" ENG --content "hi" --json | jq -r '.id'   # capture th
 
 #### Structured errors
 
-When `--json` is active, failures are also machine-parseable: the command prints exactly one JSON object to **stderr** (stdout stays empty) and exits with status `1`. This lets scripts and agents branch on failures without scraping prose. The shape is:
+When `--json` is active, command failures routed through the standard error handler (`handleCommandError`) and the `api` command's own error path are machine-parseable: the command prints exactly one JSON object to **stderr** (stdout stays empty) and exits with status `1`. This lets scripts and agents branch on covered failures without scraping prose. The shape is:
 
 ```json
 {
@@ -415,6 +415,8 @@ confluence info 123 --json 2> >(jq -r '.code') 1>/dev/null
 ```
 
 Without `--json`, error output is unchanged (human-readable prose on stderr).
+
+Exceptions: CLI parser argument and usage errors, the unsupported-`--json` guard, and read-only or configuration-loading failures that exit before the standard handler still print human-readable prose. Partial failures from `copy-tree --fail-on-error` and `versions-purge` emit their result JSON to stdout and signal the partial failure with exit status `1` instead of a structured error on stderr.
 
 ### Read a Page
 ```bash

--- a/bin/commands/api.js
+++ b/bin/commands/api.js
@@ -4,6 +4,7 @@ const chalk = require('chalk');
 const ConfluenceClient = require('../../lib/confluence-client');
 const { getConfig } = require('../../lib/config');
 const Analytics = require('../../lib/analytics');
+const { emitJsonError } = require('../../lib/output');
 
 const WRITE_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
 
@@ -35,6 +36,10 @@ Endpoint resolution:
 `)
     .action(async (endpoint, options) => {
       const analytics = new Analytics();
+      // When the global --json flag is active, failures emit a single structured
+      // JSON object on stderr instead of prose (agents/scripts can then parse
+      // errors). Non-JSON output stays byte-identical.
+      const jsonMode = Boolean(program.opts().json);
       try {
         const config = getConfig(getProfileName());
         const client = new ConfluenceClient(config);
@@ -43,7 +48,9 @@ Endpoint resolution:
         for (const raw of options.field) {
           const idx = raw.indexOf('=');
           if (idx === -1) {
-            console.error(chalk.red(`Error: Invalid field "${raw}". Must be key=value.`));
+            const message = `Invalid field "${raw}". Must be key=value.`;
+            if (jsonMode) emitJsonError(null, { message, code: 'VALIDATION' });
+            else console.error(chalk.red(`Error: ${message}`));
             trackAndExit(analytics, 1);
           }
           fields[raw.slice(0, idx)] = raw.slice(idx + 1);
@@ -53,7 +60,9 @@ Endpoint resolution:
         for (const raw of options.header) {
           const idx = raw.indexOf(':');
           if (idx === -1) {
-            console.error(chalk.red(`Error: Invalid header "${raw}". Must be key:value.`));
+            const message = `Invalid header "${raw}". Must be key:value.`;
+            if (jsonMode) emitJsonError(null, { message, code: 'VALIDATION' });
+            else console.error(chalk.red(`Error: ${message}`));
             trackAndExit(analytics, 1);
           }
           extraHeaders[raw.slice(0, idx).trim()] = raw.slice(idx + 1).trim();
@@ -76,8 +85,15 @@ Endpoint resolution:
         const method = (options.method || (hasBody ? 'POST' : 'GET')).toUpperCase();
 
         if (config.readOnly && WRITE_METHODS.includes(method)) {
-          console.error(chalk.red('Error: This profile is in read-only mode. Write operations are not allowed.'));
-          console.error(chalk.yellow('Tip: Use "confluence profile add <name>" without --read-only, or set readOnly to false in config.'));
+          if (jsonMode) {
+            emitJsonError(null, {
+              message: 'This profile is in read-only mode. Write operations are not allowed.',
+              code: 'VALIDATION',
+            });
+          } else {
+            console.error(chalk.red('Error: This profile is in read-only mode. Write operations are not allowed.'));
+            console.error(chalk.yellow('Tip: Use "confluence profile add <name>" without --read-only, or set readOnly to false in config.'));
+          }
           trackAndExit(analytics, 1);
         }
 
@@ -118,16 +134,19 @@ Endpoint resolution:
             encoding: 'utf-8',
           });
           if (r.error) {
-            if (r.error.code === 'ENOENT') {
-              console.error(chalk.red('Error: jq is not installed (--jq requires jq in PATH).'));
-            } else {
-              console.error(chalk.red('Error: jq failed:'), r.error.message);
-            }
+            const message = r.error.code === 'ENOENT'
+              ? 'jq is not installed (--jq requires jq in PATH).'
+              : `jq failed: ${r.error.message}`;
+            if (jsonMode) emitJsonError(null, { message, code: 'VALIDATION' });
+            else if (r.error.code === 'ENOENT') console.error(chalk.red(`Error: ${message}`));
+            else console.error(chalk.red('Error: jq failed:'), r.error.message);
             trackAndExit(analytics, 2);
           }
           if (r.status !== 0) {
             const stderr = (r.stderr || '').toString().trim();
-            console.error(chalk.red(`Error: jq exited with status ${r.status}${stderr ? `\n${stderr}` : ''}`));
+            const message = `jq exited with status ${r.status}${stderr ? `\n${stderr}` : ''}`;
+            if (jsonMode) emitJsonError(null, { message, code: 'VALIDATION' });
+            else console.error(chalk.red(`Error: ${message}`));
             trackAndExit(analytics, 2);
           }
           output += r.stdout;
@@ -142,7 +161,9 @@ Endpoint resolution:
         analytics.track('api', true);
       } catch (error) {
         analytics.track('api', false);
-        if (error.response) {
+        if (jsonMode) {
+          emitJsonError(error);
+        } else if (error.response) {
           const errBody = error.response.data;
           const errStr = typeof errBody === 'string' ? errBody : JSON.stringify(errBody, null, 2);
           process.stderr.write(errStr + '\n');

--- a/bin/commands/api.js
+++ b/bin/commands/api.js
@@ -41,7 +41,7 @@ Endpoint resolution:
       // errors). Non-JSON output stays byte-identical.
       const jsonMode = Boolean(program.opts().json);
       try {
-        const config = getConfig(getProfileName());
+        const config = getConfig(getProfileName(), { throwOnError: jsonMode });
         const client = new ConfluenceClient(config);
 
         const fields = {};

--- a/bin/confluence.js
+++ b/bin/confluence.js
@@ -98,7 +98,7 @@ function withClient(commandName, handler, { writable = false, onError = null } =
   return async (...actionArgs) => {
     const analytics = new Analytics();
     try {
-      const config = getConfig(getProfileName());
+      const config = getConfig(getProfileName(), { throwOnError: Boolean(program.opts().json) });
       if (writable) assertWritable(config);
       const client = new ConfluenceClient(config);
       await handler({ client, config, analytics, emitJson, wantsJson }, ...actionArgs);

--- a/bin/confluence.js
+++ b/bin/confluence.js
@@ -17,7 +17,7 @@ const registerCommentCommands = require('./commands/comment');
 const registerExportCommand = require('./commands/export');
 const registerApiCommand = require('./commands/api');
 const { readStdin } = require('../lib/stdin-utils');
-const { emitJson, jsonRequested } = require('../lib/output');
+const { emitJson, emitJsonError, jsonRequested } = require('../lib/output');
 
 function assertWritable(config) {
   if (config.readOnly) {
@@ -63,6 +63,13 @@ function formatApiErrorBody(data) {
 
 function handleCommandError(analytics, commandName, error, onExtra = null) {
   analytics.track(commandName, false);
+  // In --json mode, emit a single structured error object (on stderr, preserving
+  // the stdout=data / stderr=diagnostics contract) so agents/scripts can parse
+  // failures. Non-JSON callers keep the exact human-readable prose below.
+  if (program.opts().json) {
+    emitJsonError(error);
+    process.exit(1);
+  }
   console.error(chalk.red('Error:'), error.message);
   const apiDetail = formatApiErrorBody(error.response?.data);
   if (apiDetail && !onExtra) {

--- a/bin/confluence.js
+++ b/bin/confluence.js
@@ -19,11 +19,14 @@ const registerApiCommand = require('./commands/api');
 const { readStdin } = require('../lib/stdin-utils');
 const { emitJson, emitJsonError, jsonRequested } = require('../lib/output');
 
+const READ_ONLY_MESSAGE = 'This profile is in read-only mode. Write operations are not allowed.';
+const READ_ONLY_TIP = 'Tip: Use "confluence profile add <name>" without --read-only, or set readOnly to false in config.';
+
+class ReadOnlyError extends Error {}
+
 function assertWritable(config) {
   if (config.readOnly) {
-    console.error(chalk.red('Error: This profile is in read-only mode. Write operations are not allowed.'));
-    console.error(chalk.yellow('Tip: Use "confluence profile add <name>" without --read-only, or set readOnly to false in config.'));
-    process.exit(1);
+    throw new ReadOnlyError(READ_ONLY_MESSAGE);
   }
 }
 
@@ -68,6 +71,11 @@ function handleCommandError(analytics, commandName, error, onExtra = null) {
   // failures. Non-JSON callers keep the exact human-readable prose below.
   if (program.opts().json) {
     emitJsonError(error);
+    process.exit(1);
+  }
+  if (error instanceof ReadOnlyError) {
+    console.error(chalk.red(`Error: ${error.message}`));
+    console.error(chalk.yellow(READ_ONLY_TIP));
     process.exit(1);
   }
   console.error(chalk.red('Error:'), error.message);

--- a/bin/confluence.js
+++ b/bin/confluence.js
@@ -17,7 +17,7 @@ const registerCommentCommands = require('./commands/comment');
 const registerExportCommand = require('./commands/export');
 const registerApiCommand = require('./commands/api');
 const { readStdin } = require('../lib/stdin-utils');
-const { emitJson, emitJsonError, jsonRequested } = require('../lib/output');
+const { emitJson, emitJsonError, jsonRequested, setJsonMode } = require('../lib/output');
 
 const READ_ONLY_MESSAGE = 'This profile is in read-only mode. Write operations are not allowed.';
 const READ_ONLY_TIP = 'Tip: Use "confluence profile add <name>" without --read-only, or set readOnly to false in config.';
@@ -167,6 +167,7 @@ const JSON_COMMANDS = new Set([
 ]);
 
 program.hook('preAction', (thisCommand, actionCommand) => {
+  setJsonMode(program.opts().json);
   if (program.opts().json && !JSON_COMMANDS.has(actionCommand.name())) {
     const message = `--json is not supported by "${actionCommand.name()}". ` +
       `Supported commands: ${[...JSON_COMMANDS].join(', ')}.`;

--- a/bin/confluence.js
+++ b/bin/confluence.js
@@ -130,6 +130,16 @@ program
   .option('--profile <name>', 'Use a specific configuration profile')
   .option('--json', 'Output raw JSON to stdout (for scripting / piping to jq)');
 
+program.configureOutput({
+  outputError: (message, write) => {
+    if (program.opts().json) {
+      emitJsonError(null, { message: message.trim(), code: 'VALIDATION' });
+      return;
+    }
+    write(message);
+  },
+});
+
 // Helper: resolve profile name from global --profile flag
 function getProfileName() {
   return program.opts().profile || undefined;
@@ -158,10 +168,9 @@ const JSON_COMMANDS = new Set([
 
 program.hook('preAction', (thisCommand, actionCommand) => {
   if (program.opts().json && !JSON_COMMANDS.has(actionCommand.name())) {
-    console.error(chalk.red(
-      `Error: --json is not supported by "${actionCommand.name()}". ` +
-      `Supported commands: ${[...JSON_COMMANDS].join(', ')}.`
-    ));
+    const message = `--json is not supported by "${actionCommand.name()}". ` +
+      `Supported commands: ${[...JSON_COMMANDS].join(', ')}.`;
+    emitJsonError(null, { message, code: 'VALIDATION' });
     process.exit(1);
   }
 });

--- a/lib/config.js
+++ b/lib/config.js
@@ -254,7 +254,7 @@ const normalizeApiPath = (rawValue, domain) => {
 };
 
 // Read config file with backward compatibility for old flat format
-function readConfigFile() {
+function readConfigFile({ throwOnError = false } = {}) {
   if (!fs.existsSync(CONFIG_FILE)) {
     return null;
   }
@@ -289,6 +289,7 @@ function readConfigFile() {
 
     return raw;
   } catch (error) {
+    if (throwOnError) throw error;
     console.error(chalk.yellow(`⚠ Failed to parse config file at ${CONFIG_FILE}: ${error.message}`));
     console.error(chalk.yellow('  Run "confluence init" to recreate it.'));
     return null;
@@ -892,7 +893,7 @@ function getConfig(profileName, { throwOnError = false } = {}) {
     || process.env.CONFLUENCE_PROFILE
     || null;
 
-  const fileData = readConfigFile();
+  const fileData = readConfigFile({ throwOnError });
 
   if (!fileData) {
     if (throwOnError) throw new Error('No configuration found!');

--- a/lib/config.js
+++ b/lib/config.js
@@ -52,6 +52,7 @@ const AUTH_TYPES = ['basic', 'bearer', 'mtls', 'cookie', 'none'];
 
 const { VALID_LINK_STYLES } = require('./link-style');
 const { lookupNetrc, getNetrcPath } = require('./netrc');
+const { isJsonMode } = require('./output');
 
 const normalizeLinkStyle = (rawValue, source) => {
   if (rawValue === undefined || rawValue === null || rawValue === '') {
@@ -62,9 +63,11 @@ const normalizeLinkStyle = (rawValue, source) => {
     return value;
   }
   const label = source ? `${source} ` : '';
-  console.error(chalk.yellow(
-    `⚠ Invalid linkStyle ${label}"${rawValue}"; valid values: ${VALID_LINK_STYLES.join(', ')}. Falling back to auto-detection.`
-  ));
+  if (!isJsonMode()) {
+    console.error(chalk.yellow(
+      `⚠ Invalid linkStyle ${label}"${rawValue}"; valid values: ${VALID_LINK_STYLES.join(', ')}. Falling back to auto-detection.`
+    ));
+  }
   return undefined;
 };
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -812,7 +812,7 @@ async function initConfig(cliOptions = {}) {
   }
 }
 
-function getConfig(profileName) {
+function getConfig(profileName, { throwOnError = false } = {}) {
   const envDomain = process.env.CONFLUENCE_DOMAIN || process.env.CONFLUENCE_HOST;
   const envToken = process.env.CONFLUENCE_API_TOKEN || process.env.CONFLUENCE_PASSWORD;
   const envEmail = process.env.CONFLUENCE_EMAIL || process.env.CONFLUENCE_USERNAME;
@@ -848,6 +848,7 @@ function getConfig(profileName) {
     try {
       apiPath = normalizeApiPath(envApiPath, envDomain);
     } catch (error) {
+      if (throwOnError) throw error;
       console.error(chalk.red(`❌ ${error.message}`));
       process.exit(1);
     }
@@ -857,6 +858,7 @@ function getConfig(profileName) {
       'CONFLUENCE_AUTH_TYPE=mtls'
     );
     if (authErrors.length > 0) {
+      if (throwOnError) throw new Error(authErrors.join(' '));
       console.error(chalk.red(`❌ ${authErrors.join(' ')}`));
       if (authType === 'basic' && !envEmail) {
         console.log(chalk.yellow('Set CONFLUENCE_EMAIL (or CONFLUENCE_USERNAME for on-premise) or switch to bearer auth by setting CONFLUENCE_AUTH_TYPE=bearer.'));
@@ -893,6 +895,7 @@ function getConfig(profileName) {
   const fileData = readConfigFile();
 
   if (!fileData) {
+    if (throwOnError) throw new Error('No configuration found!');
     console.error(chalk.red('❌ No configuration found!'));
     console.log(chalk.yellow('Please run "confluence init" to set up your configuration.'));
     console.log(chalk.gray('Or set environment variables: CONFLUENCE_DOMAIN, CONFLUENCE_API_TOKEN (or CONFLUENCE_PASSWORD), CONFLUENCE_EMAIL (or CONFLUENCE_USERNAME), and optionally CONFLUENCE_API_PATH, CONFLUENCE_PROTOCOL.'));
@@ -903,6 +906,7 @@ function getConfig(profileName) {
   const storedConfig = fileData.profiles && fileData.profiles[targetProfile];
 
   if (!storedConfig) {
+    if (throwOnError) throw new Error(`Profile "${targetProfile}" not found!`);
     console.error(chalk.red(`❌ Profile "${targetProfile}" not found!`));
     const available = fileData.profiles ? Object.keys(fileData.profiles) : [];
     if (available.length > 0) {
@@ -922,6 +926,7 @@ function getConfig(profileName) {
     let apiPath;
 
     if (!trimmedDomain) {
+      if (throwOnError) throw new Error('Configuration file is missing required values.');
       console.error(chalk.red('❌ Configuration file is missing required values.'));
       console.log(chalk.yellow('Run "confluence init" to refresh your settings.'));
       process.exit(1);
@@ -940,6 +945,7 @@ function getConfig(profileName) {
       'mTLS authentication'
     );
     if (authErrors.length > 0) {
+      if (throwOnError) throw new Error(authErrors.join(' '));
       console.error(chalk.red(`❌ ${authErrors.join(' ')}`));
       if (netrcAttempted && !trimmedToken) {
         console.log(chalk.yellow(
@@ -953,6 +959,7 @@ function getConfig(profileName) {
     try {
       apiPath = normalizeApiPath(storedConfig.apiPath, trimmedDomain);
     } catch (error) {
+      if (throwOnError) throw error;
       console.error(chalk.red(`❌ ${error.message}`));
       console.log(chalk.yellow('Please rerun "confluence init" to update your API path.'));
       process.exit(1);
@@ -983,6 +990,7 @@ function getConfig(profileName) {
       linkStyle
     };
   } catch (error) {
+    if (throwOnError) throw error;
     console.error(chalk.red('❌ Error reading configuration file:'), error.message);
     console.log(chalk.yellow('Please run "confluence init" to recreate your configuration.'));
     process.exit(1);

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -8,6 +8,7 @@ const { Parser, DomHandler } = require('htmlparser2');
 const { decodeHTML } = require('entities');
 const MacroConverter = require('./macro-converter');
 const { htmlToMarkdown, NAMED_ENTITIES } = require('./html-to-markdown');
+const { isJsonMode } = require('./output');
 
 const WRITE_FORMATS = ['auto', 'storage', 'html', 'markdown'];
 const PAGE_LINK_LOOKUP_CONCURRENCY = 10;
@@ -377,7 +378,9 @@ class ConfluenceClient {
           }
         } catch (error) {
           // Ignore error and fall through
-          console.error('Error resolving page ID from display URL:', error);
+          if (!isJsonMode()) {
+            console.error('Error resolving page ID from display URL:', error);
+          }
         }
 
         throw new Error(`Could not resolve page ID from display URL: ${pageIdOrUrl}`);

--- a/lib/confluence-client.js
+++ b/lib/confluence-client.js
@@ -289,7 +289,7 @@ class ConfluenceClient {
         try {
           const keyStats = fs.statSync(this.mtls.clientKey);
           const keyMode = keyStats.mode & 0o777;
-          if (keyMode & 0o077) {
+          if ((keyMode & 0o077) && !isJsonMode()) {
             console.error(
               `Warning: Client key file "${this.mtls.clientKey}" has mode ${keyMode.toString(8)}. ` +
               'Private keys should not be readable by other users (recommended: 0600). ' +

--- a/lib/netrc.js
+++ b/lib/netrc.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const chalk = require('chalk');
+const { isJsonMode } = require('./output');
 
 // Minimal reader for GNU .netrc files
 // (https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html).
@@ -101,7 +102,9 @@ function lookupNetrc({ machine, login } = {}) {
     if (error.code === 'ENOENT') {
       return null;
     }
-    console.error(chalk.yellow(`⚠ Failed to read netrc file at ${filePath}: ${error.message}`));
+    if (!isJsonMode()) {
+      console.error(chalk.yellow(`⚠ Failed to read netrc file at ${filePath}: ${error.message}`));
+    }
     return null;
   }
 

--- a/lib/output.js
+++ b/lib/output.js
@@ -2,6 +2,16 @@
 
 const chalk = require('chalk');
 
+let jsonMode = false;
+
+function setJsonMode(enabled) {
+  jsonMode = Boolean(enabled);
+}
+
+function isJsonMode() {
+  return jsonMode;
+}
+
 // Single place JSON output is produced, so piping to tools like jq stays clean:
 // pretty-printed, no colors, no human-readable preamble. Uses console.log (not
 // process.stdout.write) so it lands on stdout and stays test-spy friendly.
@@ -75,4 +85,11 @@ function jsonRequested(globalJson, options = {}) {
   return false;
 }
 
-module.exports = { emitJson, emitJsonError, classifyErrorCode, jsonRequested };
+module.exports = {
+  emitJson,
+  emitJsonError,
+  classifyErrorCode,
+  jsonRequested,
+  setJsonMode,
+  isJsonMode,
+};

--- a/lib/output.js
+++ b/lib/output.js
@@ -9,6 +9,48 @@ function emitJson(data) {
   console.log(JSON.stringify(data, null, 2));
 }
 
+// Network-level error codes (from Node/axios) that mean the request never got a
+// response — connection refused, DNS failure, timeouts, etc.
+const NETWORK_ERROR_CODES = new Set([
+  'ECONNREFUSED', 'ENOTFOUND', 'ETIMEDOUT', 'ECONNRESET',
+  'ECONNABORTED', 'EAI_AGAIN', 'EPIPE', 'EHOSTUNREACH', 'ENETUNREACH',
+]);
+
+// Map an error onto a small, stable machine code so agents/scripts can branch on
+// failures without parsing prose. Kept intentionally coarse — it only draws the
+// distinctions the existing human-readable messages already make.
+function classifyErrorCode(error) {
+  const status = error?.response?.status;
+  if (status === 401 || status === 403) return 'AUTH_FAILED';
+  if (status === 404) return 'NOT_FOUND';
+  if (typeof status === 'number' && status >= 400) return 'API_ERROR';
+  if (error?.code && NETWORK_ERROR_CODES.has(error.code)) return 'NETWORK';
+  // A thrown Error that never reached the server (validation, bad args, missing
+  // files) — the client raises these with `new Error(...)` and no `.response`.
+  if (error instanceof Error) return 'VALIDATION';
+  return 'UNKNOWN';
+}
+
+// Emit exactly one machine-parseable JSON error object on stderr (keeping stdout
+// reserved for data). Shape: { error, code, status, details }. `overrides` lets
+// synthetic call sites (arg validation, tooling failures) supply an explicit
+// message/code/status/details without constructing a fake HTTP error.
+function emitJsonError(error, overrides = {}) {
+  const status = 'status' in overrides
+    ? overrides.status
+    : (error?.response?.status ?? null);
+  const details = 'details' in overrides
+    ? overrides.details
+    : (error?.response?.data ?? null);
+  const payload = {
+    error: overrides.message ?? error?.message ?? String(error),
+    code: overrides.code ?? classifyErrorCode(error),
+    status: status ?? null,
+    details: details ?? null,
+  };
+  console.error(JSON.stringify(payload, null, 2));
+}
+
 let deprecationWarned = false;
 
 // Resolve whether a command should emit JSON.
@@ -33,4 +75,4 @@ function jsonRequested(globalJson, options = {}) {
   return false;
 }
 
-module.exports = { emitJson, jsonRequested };
+module.exports = { emitJson, emitJsonError, classifyErrorCode, jsonRequested };

--- a/plugins/confluence/skills/confluence/SKILL.md
+++ b/plugins/confluence/skills/confluence/SKILL.md
@@ -817,7 +817,7 @@ confluence search --cql 'siteSearch ~ "release notes" and space = "MYSPACE"' --l
 
 ### Parsing failures under `--json`
 
-When you pass the global `--json` flag, command failures routed through the standard error handler (`handleCommandError`) and the `api` command's own error path are machine-parseable: the command prints **exactly one JSON object to stderr** (stdout stays empty) and, except as noted below, exits `1`. Parse stderr instead of matching prose:
+When you pass the global `--json` flag, command failures are machine-parseable: the command prints **exactly one JSON object to stderr** (stdout stays empty) and, except as noted below, exits `1`. This includes CLI parser and usage errors, unsupported-`--json` errors, read-only failures, configuration-loading failures, failures routed through the standard error handler, and the `api` command's own error path. Parse stderr instead of matching prose:
 
 ```json
 { "error": "<message>", "code": "<CODE>", "status": <httpStatus|null>, "details": <api body|null> }
@@ -825,4 +825,4 @@ When you pass the global `--json` flag, command failures routed through the stan
 
 `code` is one of `AUTH_FAILED` (401/403), `NOT_FOUND` (404), `VALIDATION` (bad args / local precondition), `API_ERROR` (other 4xx/5xx), `NETWORK` (connection/DNS/timeout), `UNKNOWN`. Branch on `code` rather than the human-readable `error` string, which may change. Without `--json`, errors remain human-readable prose on stderr.
 
-Exceptions: `api` failures caused by missing `jq` or a failing `--jq` expression still use the structured stderr format but preserve exit status `2`. CLI parser argument and usage errors, the unsupported-`--json` guard, and read-only or configuration-loading failures that exit before the standard handler still print human-readable prose. Partial failures from `copy-tree --fail-on-error` and `versions-purge` emit their result JSON to stdout and signal the partial failure with exit status `1` instead of a structured error on stderr.
+Exceptions: `api` failures caused by missing `jq` or a failing `--jq` expression still use the structured stderr format but preserve exit status `2`. Partial failures from `copy-tree --fail-on-error` and `versions-purge` emit their result JSON to stdout and signal the partial failure with exit status `1` instead of a structured error on stderr.

--- a/plugins/confluence/skills/confluence/SKILL.md
+++ b/plugins/confluence/skills/confluence/SKILL.md
@@ -814,3 +814,13 @@ confluence search --cql 'siteSearch ~ "release notes" and space = "MYSPACE"' --l
 | `Profile "<name>" not found!` | Specified profile doesn't exist | Run `confluence profile list` to see available profiles |
 | `Cannot delete the only remaining profile.` | Tried to remove the last profile | Add another profile before removing |
 | `This profile is in read-only mode` | Write command used with a read-only profile | Use a writable profile or remove `readOnly` from config |
+
+### Parsing failures under `--json`
+
+When you pass the global `--json` flag, failures are machine-parseable too: the command prints **exactly one JSON object to stderr** (stdout stays empty) and exits `1`. Parse stderr instead of matching prose:
+
+```json
+{ "error": "<message>", "code": "<CODE>", "status": <httpStatus|null>, "details": <api body|null> }
+```
+
+`code` is one of `AUTH_FAILED` (401/403), `NOT_FOUND` (404), `VALIDATION` (bad args / local precondition), `API_ERROR` (other 4xx/5xx), `NETWORK` (connection/DNS/timeout), `UNKNOWN`. Branch on `code` rather than the human-readable `error` string, which may change. Without `--json`, errors remain human-readable prose on stderr.

--- a/plugins/confluence/skills/confluence/SKILL.md
+++ b/plugins/confluence/skills/confluence/SKILL.md
@@ -817,12 +817,4 @@ confluence search --cql 'siteSearch ~ "release notes" and space = "MYSPACE"' --l
 
 ### Parsing failures under `--json`
 
-When you pass the global `--json` flag, command failures are machine-parseable: the command prints **exactly one JSON object to stderr** (stdout stays empty) and, except as noted below, exits `1`. This includes CLI parser and usage errors, unsupported-`--json` errors, read-only failures, configuration-loading failures, failures routed through the standard error handler, and the `api` command's own error path. Parse stderr instead of matching prose:
-
-```json
-{ "error": "<message>", "code": "<CODE>", "status": <httpStatus|null>, "details": <api body|null> }
-```
-
-`code` is one of `AUTH_FAILED` (401/403), `NOT_FOUND` (404), `VALIDATION` (bad args / local precondition), `API_ERROR` (other 4xx/5xx), `NETWORK` (connection/DNS/timeout), `UNKNOWN`. Branch on `code` rather than the human-readable `error` string, which may change. Without `--json`, errors remain human-readable prose on stderr.
-
-Exceptions: `api` failures caused by missing `jq` or a failing `--jq` expression still use the structured stderr format but preserve exit status `2`. Partial failures from `copy-tree --fail-on-error` and `versions-purge` emit their result JSON to stdout and signal the partial failure with exit status `1` instead of a structured error on stderr.
+Parse failures according to the authoritative [structured error contract](../../../../README.md#structured-errors), branching on `code` rather than matching the human-readable `error` string.

--- a/plugins/confluence/skills/confluence/SKILL.md
+++ b/plugins/confluence/skills/confluence/SKILL.md
@@ -817,10 +817,12 @@ confluence search --cql 'siteSearch ~ "release notes" and space = "MYSPACE"' --l
 
 ### Parsing failures under `--json`
 
-When you pass the global `--json` flag, failures are machine-parseable too: the command prints **exactly one JSON object to stderr** (stdout stays empty) and exits `1`. Parse stderr instead of matching prose:
+When you pass the global `--json` flag, command failures routed through the standard error handler (`handleCommandError`) and the `api` command's own error path are machine-parseable: the command prints **exactly one JSON object to stderr** (stdout stays empty) and exits `1`. Parse stderr instead of matching prose:
 
 ```json
 { "error": "<message>", "code": "<CODE>", "status": <httpStatus|null>, "details": <api body|null> }
 ```
 
 `code` is one of `AUTH_FAILED` (401/403), `NOT_FOUND` (404), `VALIDATION` (bad args / local precondition), `API_ERROR` (other 4xx/5xx), `NETWORK` (connection/DNS/timeout), `UNKNOWN`. Branch on `code` rather than the human-readable `error` string, which may change. Without `--json`, errors remain human-readable prose on stderr.
+
+Exceptions: CLI parser argument and usage errors, the unsupported-`--json` guard, and read-only or configuration-loading failures that exit before the standard handler still print human-readable prose. Partial failures from `copy-tree --fail-on-error` and `versions-purge` emit their result JSON to stdout and signal the partial failure with exit status `1` instead of a structured error on stderr.

--- a/plugins/confluence/skills/confluence/SKILL.md
+++ b/plugins/confluence/skills/confluence/SKILL.md
@@ -817,7 +817,7 @@ confluence search --cql 'siteSearch ~ "release notes" and space = "MYSPACE"' --l
 
 ### Parsing failures under `--json`
 
-When you pass the global `--json` flag, command failures routed through the standard error handler (`handleCommandError`) and the `api` command's own error path are machine-parseable: the command prints **exactly one JSON object to stderr** (stdout stays empty) and exits `1`. Parse stderr instead of matching prose:
+When you pass the global `--json` flag, command failures routed through the standard error handler (`handleCommandError`) and the `api` command's own error path are machine-parseable: the command prints **exactly one JSON object to stderr** (stdout stays empty) and, except as noted below, exits `1`. Parse stderr instead of matching prose:
 
 ```json
 { "error": "<message>", "code": "<CODE>", "status": <httpStatus|null>, "details": <api body|null> }
@@ -825,4 +825,4 @@ When you pass the global `--json` flag, command failures routed through the stan
 
 `code` is one of `AUTH_FAILED` (401/403), `NOT_FOUND` (404), `VALIDATION` (bad args / local precondition), `API_ERROR` (other 4xx/5xx), `NETWORK` (connection/DNS/timeout), `UNKNOWN`. Branch on `code` rather than the human-readable `error` string, which may change. Without `--json`, errors remain human-readable prose on stderr.
 
-Exceptions: CLI parser argument and usage errors, the unsupported-`--json` guard, and read-only or configuration-loading failures that exit before the standard handler still print human-readable prose. Partial failures from `copy-tree --fail-on-error` and `versions-purge` emit their result JSON to stdout and signal the partial failure with exit status `1` instead of a structured error on stderr.
+Exceptions: `api` failures caused by missing `jq` or a failing `--jq` expression still use the structured stderr format but preserve exit status `2`. CLI parser argument and usage errors, the unsupported-`--json` guard, and read-only or configuration-loading failures that exit before the standard handler still print human-readable prose. Partial failures from `copy-tree --fail-on-error` and `versions-purge` emit their result JSON to stdout and signal the partial failure with exit status `1` instead of a structured error on stderr.

--- a/tests/api-command.test.js
+++ b/tests/api-command.test.js
@@ -167,6 +167,37 @@ describe('api command', () => {
     });
   });
 
+  describe('--json structured errors', () => {
+    test('invalid field under --json emits one JSON error object on stderr, nothing on stdout', () => {
+      const { stderr, stdout } = runErr(['--json', 'api', '/rest/api/content', '-f', 'badfield']);
+      expect(stdout).toBe('');
+      const payload = JSON.parse(stderr);
+      expect(payload).toEqual({
+        error: 'Invalid field "badfield". Must be key=value.',
+        code: 'VALIDATION',
+        status: null,
+        details: null,
+      });
+    });
+
+    test('read-only block under --json emits structured VALIDATION error (no Tip prose)', () => {
+      const { stderr } = runErr(['--json', 'api', '/rest/api/content/123', '-X', 'DELETE'], {
+        env: { CONFLUENCE_READ_ONLY: 'true' },
+      });
+      const payload = JSON.parse(stderr);
+      expect(payload).toMatchObject({ code: 'VALIDATION', status: null });
+      expect(payload.error).toContain('read-only');
+      expect(stderr).not.toContain('Tip:');
+    });
+
+    test('without --json, invalid field stays human-readable prose (not JSON)', () => {
+      const { stderr } = runErr(['api', '/rest/api/content', '-f', 'badfield']);
+      expect(stderr).toContain('Error:');
+      expect(stderr).toContain('Invalid field');
+      expect(() => JSON.parse(stderr)).toThrow();
+    });
+  });
+
   describe('help output', () => {
     test('api command appears in help', () => {
       const output = run(['api', '--help']);

--- a/tests/config-warning-errors.test.js
+++ b/tests/config-warning-errors.test.js
@@ -1,0 +1,88 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const CLI = path.resolve(__dirname, '../bin/index.js');
+
+const CONFIG_ENV_KEYS = [
+  'CONFLUENCE_DOMAIN', 'CONFLUENCE_HOST',
+  'CONFLUENCE_API_TOKEN', 'CONFLUENCE_PASSWORD',
+  'CONFLUENCE_EMAIL', 'CONFLUENCE_USERNAME',
+  'CONFLUENCE_AUTH_TYPE', 'CONFLUENCE_API_PATH',
+  'CONFLUENCE_PROTOCOL', 'CONFLUENCE_LINK_STYLE',
+  'CONFLUENCE_CONFIG_DIR', 'CONFLUENCE_PROFILE', 'NETRC',
+];
+
+function runCli(args, overrides) {
+  const env = { ...process.env };
+  for (const key of CONFIG_ENV_KEYS) delete env[key];
+
+  return spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf8',
+    timeout: 10000,
+    env: { ...env, ...overrides },
+  });
+}
+
+function expectStructuredError(result) {
+  expect(result.status).toBe(1);
+  expect(result.stdout).toBe('');
+  expect(JSON.parse(result.stderr)).toEqual({
+    error: expect.any(String),
+    code: expect.any(String),
+    status: null,
+    details: null,
+  });
+}
+
+describe('configuration warnings on command failures', () => {
+  test('--json suppresses unreadable netrc warnings without changing human output', () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'confluence-netrc-warning-'));
+    fs.writeFileSync(path.join(configDir, 'config.json'), JSON.stringify({
+      activeProfile: 'default',
+      profiles: {
+        default: {
+          domain: 'example.atlassian.net',
+          authType: 'bearer',
+          protocol: 'https',
+          apiPath: '/rest/api',
+        },
+      },
+    }));
+
+    try {
+      const env = { CONFLUENCE_CONFIG_DIR: configDir, NETRC: configDir };
+      const result = runCli(['--json', 'spaces'], env);
+
+      expectStructuredError(result);
+
+      const humanResult = runCli(['spaces'], env);
+      expect(humanResult.status).toBe(1);
+      expect(humanResult.stderr).toContain(`⚠ Failed to read netrc file at ${configDir}:`);
+    } finally {
+      fs.rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+
+  test('--json suppresses invalid link-style warnings without changing human output', () => {
+    const env = {
+      CONFLUENCE_DOMAIN: '127.0.0.1:1',
+      CONFLUENCE_API_TOKEN: 'test-token',
+      CONFLUENCE_AUTH_TYPE: 'bearer',
+      CONFLUENCE_PROTOCOL: 'http',
+      CONFLUENCE_API_PATH: '/rest/api',
+      CONFLUENCE_LINK_STYLE: 'smrt',
+      NO_PROXY: '127.0.0.1',
+    };
+    const result = runCli(['--json', 'spaces'], env);
+
+    expectStructuredError(result);
+
+    const humanResult = runCli(['spaces'], env);
+    expect(humanResult.status).toBe(1);
+    expect(humanResult.stderr).toContain(
+      '⚠ Invalid linkStyle from CONFLUENCE_LINK_STYLE "smrt"; valid values:'
+    );
+  });
+});

--- a/tests/display-url-errors.test.js
+++ b/tests/display-url-errors.test.js
@@ -1,0 +1,45 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const CLI = path.resolve(__dirname, '../bin/index.js');
+const DISPLAY_URL = 'http://127.0.0.1:1/display/SPACE/Title';
+
+function runCli(args) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf8',
+    timeout: 10000,
+    env: {
+      ...process.env,
+      CONFLUENCE_DOMAIN: '127.0.0.1:1',
+      CONFLUENCE_API_TOKEN: 'test-token',
+      CONFLUENCE_AUTH_TYPE: 'bearer',
+      CONFLUENCE_PROTOCOL: 'http',
+      CONFLUENCE_API_PATH: '/rest/api',
+      NO_PROXY: '127.0.0.1',
+    },
+  });
+}
+
+describe('display URL resolution failures', () => {
+  test('--json emits exactly one structured error on stderr', () => {
+    const result = runCli(['--json', 'info', DISPLAY_URL]);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: `Could not resolve page ID from display URL: ${DISPLAY_URL}`,
+      code: 'VALIDATION',
+      status: null,
+      details: null,
+    });
+  });
+
+  test('human-readable mode preserves the resolution diagnostic', () => {
+    const result = runCli(['info', DISPLAY_URL]);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Error resolving page ID from display URL:');
+    expect(result.stderr).toContain(`Error: Could not resolve page ID from display URL: ${DISPLAY_URL}`);
+  });
+});

--- a/tests/json-output.test.js
+++ b/tests/json-output.test.js
@@ -140,8 +140,13 @@ describe('Global --json output flag', () => {
 
     await expect(runCli(program, ['read', '123', '--json'])).rejects.toThrow('process.exit called');
     expect(exitSpy).toHaveBeenCalledWith(1);
-    const msg = errSpy.mock.calls.map(c => String(c[0])).find(m => m.includes('--json'));
-    expect(msg).toContain('not supported');
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(errSpy.mock.calls[0][0])).toEqual({
+      error: expect.stringContaining('--json is not supported'),
+      code: 'VALIDATION',
+      status: null,
+      details: null,
+    });
   });
 
   test('find --json prints the page object directly', async () => {

--- a/tests/json-output.test.js
+++ b/tests/json-output.test.js
@@ -187,6 +187,87 @@ describe('Global --json output flag', () => {
     expect(output).toEqual({ id: '600', title: 'Doomed', deleted: true });
   });
 
+  test('auth failure under --json emits one structured error object on stderr, nothing on stdout', async () => {
+    const authError = Object.assign(new Error('Authentication failed (401 Unauthorized).'), {
+      response: { status: 401, data: { message: 'Unauthorized', 'status-code': 401 } },
+    });
+    const { program } = await loadCli({ search: jest.fn(async () => { throw authError; }) });
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runCli(program, ['search', 'foo', '--json'])).rejects.toThrow('exit');
+
+    // stdout carries no data on failure
+    expect(logSpy).not.toHaveBeenCalled();
+    // exactly one JSON object on stderr, fully parseable
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(errSpy.mock.calls[0][0]);
+    expect(payload).toEqual({
+      error: 'Authentication failed (401 Unauthorized).',
+      code: 'AUTH_FAILED',
+      status: 401,
+      details: { message: 'Unauthorized', 'status-code': 401 },
+    });
+  });
+
+  test('API error with a response body under --json surfaces code, status and details', async () => {
+    const apiError = Object.assign(new Error('Request failed with status code 500'), {
+      response: { status: 500, data: { message: 'Internal Server Error' } },
+    });
+    const { program } = await loadCli({ getSpaces: jest.fn(async () => { throw apiError; }) });
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runCli(program, ['spaces', '--json'])).rejects.toThrow('exit');
+
+    const payload = JSON.parse(errSpy.mock.calls[0][0]);
+    expect(payload).toMatchObject({
+      code: 'API_ERROR',
+      status: 500,
+      details: { message: 'Internal Server Error' },
+    });
+  });
+
+  test('validation error (no HTTP response) under --json maps to VALIDATION with null status/details', async () => {
+    const { program } = await loadCli({
+      getPageInfo: jest.fn(async () => { throw new Error('Page 123 has no readable body.'); }),
+    });
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runCli(program, ['info', '123', '--json'])).rejects.toThrow('exit');
+
+    const payload = JSON.parse(errSpy.mock.calls[0][0]);
+    expect(payload).toEqual({
+      error: 'Page 123 has no readable body.',
+      code: 'VALIDATION',
+      status: null,
+      details: null,
+    });
+  });
+
+  test('without --json, failures stay human-readable prose (no JSON emitted)', async () => {
+    const authError = Object.assign(new Error('Authentication failed (401 Unauthorized).'), {
+      response: { status: 401, data: { message: 'Unauthorized' } },
+    });
+    const { program } = await loadCli({ search: jest.fn(async () => { throw authError; }) });
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+    await expect(runCli(program, ['search', 'foo'])).rejects.toThrow('exit');
+
+    // First stderr line is the chalk prose "Error:" label + message, not JSON
+    const first = errSpy.mock.calls[0];
+    expect(String(first[0])).toContain('Error:');
+    expect(String(first[1])).toBe('Authentication failed (401 Unauthorized).');
+    // Nothing on stderr is a parseable JSON object
+    const parsedAny = errSpy.mock.calls.some(c => {
+      try { JSON.parse(c[0]); return true; } catch { return false; }
+    });
+    expect(parsedAny).toBe(false);
+  });
+
   test('delete --json without --yes refuses instead of prompting', async () => {
     const deletePage = jest.fn();
     const { program } = await loadCli({

--- a/tests/mtls-errors.test.js
+++ b/tests/mtls-errors.test.js
@@ -1,0 +1,63 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const CLI = path.resolve(__dirname, '../bin/index.js');
+
+describe('mTLS failures', () => {
+  test('--json suppresses the client-key permission warning without changing human output', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'confluence-mtls-errors-'));
+    const clientCert = path.join(tempDir, 'client.pem');
+    const clientKey = path.join(tempDir, 'client.key');
+    fs.writeFileSync(clientCert, 'client-cert');
+    fs.writeFileSync(clientKey, 'client-key', { mode: 0o644 });
+
+    try {
+      const result = spawnSync(process.execPath, [CLI, '--json', 'info', '123'], {
+        encoding: 'utf8',
+        timeout: 10000,
+        env: {
+          ...process.env,
+          CONFLUENCE_DOMAIN: '127.0.0.1:1',
+          CONFLUENCE_AUTH_TYPE: 'mtls',
+          CONFLUENCE_TLS_CLIENT_CERT: clientCert,
+          CONFLUENCE_TLS_CLIENT_KEY: clientKey,
+          CONFLUENCE_API_PATH: '/rest/api',
+          NO_PROXY: '127.0.0.1',
+        },
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(JSON.parse(result.stderr)).toEqual({
+        error: expect.any(String),
+        code: expect.any(String),
+        status: null,
+        details: null,
+      });
+
+      const humanResult = spawnSync(process.execPath, [CLI, 'info', '123'], {
+        encoding: 'utf8',
+        timeout: 10000,
+        env: {
+          ...process.env,
+          CONFLUENCE_DOMAIN: '127.0.0.1:1',
+          CONFLUENCE_AUTH_TYPE: 'mtls',
+          CONFLUENCE_TLS_CLIENT_CERT: clientCert,
+          CONFLUENCE_TLS_CLIENT_KEY: clientKey,
+          CONFLUENCE_API_PATH: '/rest/api',
+          NO_PROXY: '127.0.0.1',
+        },
+      });
+      const warning = `Warning: Client key file "${clientKey}" has mode 644. ` +
+        'Private keys should not be readable by other users (recommended: 0600). ' +
+        `Fix with: chmod 600 "${clientKey}"\n`;
+
+      expect(humanResult.status).toBe(1);
+      expect(humanResult.stderr.startsWith(warning)).toBe(true);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/read-only.test.js
+++ b/tests/read-only.test.js
@@ -1,4 +1,6 @@
 const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { getConfig } = require('../lib/config');
 
@@ -234,7 +236,7 @@ describe('assertWritable', () => {
   });
 });
 
-describe('readOnly mode in the CLI', () => {
+describe('JSON errors in the CLI', () => {
   test('global --json write command emits one structured error on stderr', () => {
     const env = { ...process.env };
     for (const key of ENV_KEYS) delete env[key];
@@ -258,6 +260,35 @@ describe('readOnly mode in the CLI', () => {
       status: null,
       details: null,
     });
+  });
+
+  test('missing configuration emits one structured error on stderr', () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'confluence-empty-config-'));
+    const env = { ...process.env };
+    for (const key of ENV_KEYS) delete env[key];
+    Object.assign(env, {
+      CONFLUENCE_CONFIG_DIR: configDir,
+      CONFLUENCE_CLI_ANALYTICS: 'false',
+    });
+
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [CLI, '--json', 'spaces'],
+        { encoding: 'utf8', env }
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(JSON.parse(result.stderr)).toEqual({
+        error: 'No configuration found!',
+        code: 'VALIDATION',
+        status: null,
+        details: null,
+      });
+    } finally {
+      fs.rmSync(configDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/read-only.test.js
+++ b/tests/read-only.test.js
@@ -1,4 +1,8 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
 const { getConfig } = require('../lib/config');
+
+const CLI = path.resolve(__dirname, '../bin/index.js');
 
 const ENV_KEYS = [
   'CONFLUENCE_DOMAIN', 'CONFLUENCE_HOST',
@@ -210,20 +214,10 @@ describe('assertWritable', () => {
     mockError.mockRestore();
   });
 
-  test('exits with code 1 for readOnly config', () => {
-    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
-      throw new Error('process.exit called');
-    });
-    const mockError = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-    expect(() => assertWritable({ readOnly: true })).toThrow('process.exit called');
-    expect(mockExit).toHaveBeenCalledWith(1);
-    expect(mockError).toHaveBeenCalledWith(
-      expect.stringContaining('read-only mode')
+  test('throws for readOnly config', () => {
+    expect(() => assertWritable({ readOnly: true })).toThrow(
+      'This profile is in read-only mode. Write operations are not allowed.'
     );
-
-    mockExit.mockRestore();
-    mockError.mockRestore();
   });
 
   test('does not exit when readOnly is undefined', () => {
@@ -237,6 +231,33 @@ describe('assertWritable', () => {
 
     mockExit.mockRestore();
     mockError.mockRestore();
+  });
+});
+
+describe('readOnly mode in the CLI', () => {
+  test('global --json write command emits one structured error on stderr', () => {
+    const env = { ...process.env };
+    for (const key of ENV_KEYS) delete env[key];
+    Object.assign(env, {
+      CONFLUENCE_DOMAIN: 'test.atlassian.net',
+      CONFLUENCE_API_TOKEN: 'test-token',
+      CONFLUENCE_READ_ONLY: 'true',
+    });
+
+    const result = spawnSync(
+      process.execPath,
+      [CLI, '--json', 'delete', '123', '--yes'],
+      { encoding: 'utf8', env }
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: 'This profile is in read-only mode. Write operations are not allowed.',
+      code: 'VALIDATION',
+      status: null,
+      details: null,
+    });
   });
 });
 

--- a/tests/read-only.test.js
+++ b/tests/read-only.test.js
@@ -237,6 +237,22 @@ describe('assertWritable', () => {
 });
 
 describe('JSON errors in the CLI', () => {
+  test.each([
+    ['missing argument', ['--json', 'info']],
+    ['unknown command', ['--json', 'unknown-command']],
+  ])('%s emits one structured error on stderr', (name, args) => {
+    const result = spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf8' });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: expect.any(String),
+      code: 'VALIDATION',
+      status: null,
+      details: null,
+    });
+  });
+
   test('global --json write command emits one structured error on stderr', () => {
     const env = { ...process.env };
     for (const key of ENV_KEYS) delete env[key];
@@ -282,6 +298,35 @@ describe('JSON errors in the CLI', () => {
       expect(result.stdout).toBe('');
       expect(JSON.parse(result.stderr)).toEqual({
         error: 'No configuration found!',
+        code: 'VALIDATION',
+        status: null,
+        details: null,
+      });
+    } finally {
+      fs.rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
+    ['standard command', ['--json', 'spaces']],
+    ['api command', ['--json', 'api', '/rest/api/content']],
+  ])('malformed configuration in %s emits one structured error on stderr', (name, args) => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'confluence-malformed-config-'));
+    const env = { ...process.env };
+    for (const key of ENV_KEYS) delete env[key];
+    Object.assign(env, {
+      CONFLUENCE_CONFIG_DIR: configDir,
+      CONFLUENCE_CLI_ANALYTICS: 'false',
+    });
+    fs.writeFileSync(path.join(configDir, 'config.json'), '{ not valid json');
+
+    try {
+      const result = spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf8', env });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(JSON.parse(result.stderr)).toEqual({
+        error: expect.any(String),
         code: 'VALIDATION',
         status: null,
         details: null,

--- a/tests/with-client.test.js
+++ b/tests/with-client.test.js
@@ -79,6 +79,15 @@ describe('withClient wrapper', () => {
     await expect(action('title', 'KEY', {})).rejects.toThrow('process.exit called');
     expect(handler).not.toHaveBeenCalled();
     expect(ConfluenceClient).not.toHaveBeenCalled();
+    expect(trackSpy).toHaveBeenCalledWith('create', false);
+    expect(errorSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('Error: This profile is in read-only mode.')
+    );
+    expect(errorSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('Tip: Use "confluence profile add <name>" without --read-only')
+    );
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 


### PR DESCRIPTION
## Intent

Add structured error output for --json mode in confluence-cli (roadmap item #1). Problem: success output was structured JSON (lib/output.js emitJson) but failures always printed chalk-colored prose to stderr even under --json, so agents/scripts (jq pipelines, the Claude skill) could parse success but not failure. Goal: when the global --json flag is active, any command failure emits exactly ONE machine-parseable JSON object on stderr (stdout stays empty) and nothing else, shape {error, code, status, details}. Decisions/tradeoffs: (1) errors stay on stderr to preserve the existing stdout=data / stderr=diagnostics contract the README/SKILL.md already teach; (2) exit codes are unchanged (1; the api command's pre-existing jq exit-2 is preserved); (3) code is a small stable enum derived from existing classification: AUTH_FAILED (401/403), NOT_FOUND (404), API_ERROR (other 4xx/5xx), NETWORK (connection/DNS/timeout error codes), VALIDATION (thrown Error with no HTTP response), UNKNOWN; (4) details carries the raw API response body or null. Both error paths are covered: the global handleCommandError in bin/confluence.js and the api command's custom catch plus its inline validation/read-only/jq sites in bin/commands/api.js. Non-JSON output is intentionally byte-identical (existing users see the same prose, including the read-only Tip line and jq messages). Deliberately did NOT refactor handleCommandError beyond structured emission and did NOT touch the markdown/storage conversion pipeline (that is a separate roadmap item). Added unit/integration tests (auth-failure, API-error-with-body, validation-error under --json, plus a non-json-prose-unchanged assertion, and real-binary api-command --json tests) and updated README JSON section and SKILL.md Error Patterns.

## What Changed

- Emit a single structured `{error, code, status, details}` object on stderr for command failures in `--json` mode while keeping stdout empty and human-readable output unchanged.
- Cover API, validation, configuration, read-only, jq, HTTP, and network failures while suppressing warning noise and preserving existing exit-code exceptions.
- Document the error contract and add unit and real-CLI regression coverage.

## Risk Assessment

✅ Low: The follow-up accurately documents jq’s preserved exit status, and no remaining material issues were found in the reviewed scope.

## Testing

After installing missing locked dependencies, all focused and full automated tests passed; real CLI runs confirmed single parseable JSON stderr objects, empty stdout, correct classifications/details and exit codes, while preserving human diagnostics, and generated dependencies were cleaned up.

<details>
<summary>Evidence: End-to-end CLI transcript</summary>

```text
# Structured JSON CLI end-to-end evidence

## HTTP authentication failure

Command: `node bin/index.js --json spaces`
Exit status: `1`
Stdout: `0 bytes`
Whole-stderr `JSON.parse`: `PASS`

`` `json
{
  "error": "Authentication failed (401 Unauthorized).\nPlease verify your personal access token is valid and not expired.",
  "code": "AUTH_FAILED",
  "status": 401,
  "details": {
    "message": "Unauthorized evidence",
    "requestId": "auth-401"
  }
}
`` `

## API command failure with raw response details

Command: `node bin/index.js --json api /rest/api/failure`
Exit status: `1`
Stdout: `0 bytes`
Whole-stderr `JSON.parse`: `PASS`

`` `json
{
  "error": "Request failed with status code 500",
  "code": "API_ERROR",
  "status": 500,
  "details": {
    "message": "Server evidence failure",
    "traceId": "api-500"
  }
}
`` `

## Invalid link-style warning suppressed in JSON mode

Command: `node bin/index.js --json spaces`
Exit status: `1`
Stdout: `0 bytes`
Whole-stderr `JSON.parse`: `PASS`

`` `json
{
  "error": "Request failed with status code 500",
  "code": "API_ERROR",
  "status": 500,
  "details": {
    "message": "Warning-gating evidence"
  }
}
`` `

## Read-only validation failure

Command: `node bin/index.js --json delete 123 --yes`
Exit status: `1`
Stdout: `0 bytes`
Whole-stderr `JSON.parse`: `PASS`

`` `json
{
  "error": "This profile is in read-only mode. Write operations are not allowed.",
  "code": "VALIDATION",
  "status": null,
  "details": null
}
`` `

## jq failure preserves exit status 2

Command: `node bin/index.js --json api /rest/api/ok --jq [`
Exit status: `2`
Stdout: `0 bytes`
Whole-stderr `JSON.parse`: `PASS`

`` `json
{
  "error": "jq exited with status 3\njq: error: syntax error, unexpected end of file at <top-level>, line 1, column 1:\n    [\n    ^\njq: 1 compile error",
  "code": "VALIDATION",
  "status": null,
  "details": null
}
`` `

## Non-JSON diagnostics remain human-readable

Command: `node bin/index.js spaces` with `CONFLUENCE_LINK_STYLE=smrt`
Exit status: `1`
Stdout: `0 bytes`

`` `text
⚠ Invalid linkStyle from CONFLUENCE_LINK_STYLE "smrt"; valid values: smart, plain, wiki. Falling back to auto-detection.
Error: Request failed with status code 500
API response: {
  "message": "Human-output evidence"
}
`` `

## Network failure classification

Command: `node bin/index.js --json spaces`
Exit status: `1`
Stdout: `0 bytes`
Whole-stderr `JSON.parse`: `PASS`

`` `json
{
  "error": "connect ECONNREFUSED 127.0.0.1:60728",
  "code": "NETWORK",
  "status": null,
  "details": null
}
`` `
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed (6) ✅ across 7 runs (48m40s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2) ✅</summary>

- 🚨 `bin/confluence.js:69` - Required: “any command failure emits exactly ONE…JSON object on stderr (stdout stays empty).” This handler is bypassed by `getConfig()` and `assertWritable()`, which call `process.exit()` after prose output; missing config also writes guidance to stdout. Route these failures through structured handling or explicitly narrow the requirement.
- 🚨 `bin/confluence.js:69` - Commander parsing and `preAction` failures never reach this handler. Missing arguments, unknown options, and unsupported `--json` commands still emit prose, contradicting the required “any command failure” behavior. These should emit a single `VALIDATION` object unless explicitly exempted.
- 🚨 `README.md:396` - The new guarantee says failure leaves stdout empty, but `copy-tree --json --fail-on-error` and `versions-purge --json` emit success JSON to stdout before setting exit status 1 for partial failures. Decide whether these nonzero outcomes require structured stderr errors or are an intentional exception.

🔧 Fix: Clarify structured JSON error coverage and exceptions
1 error still open:
- 🚨 `README.md:396` - Intent requires “the api command&#39;s pre-existing jq exit-2 is preserved,” but this says the API error path exits `1`; jq failures still call `trackAndExit(..., 2)`. Qualify this sentence and the matching SKILL.md text with the jq exception.

🔧 Fix: Document preserved jq failure exit status
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed (6) ✅</summary>

- 🚨 `bin/confluence.js:22` - A supported global `--json` command bypasses structured emission: `--json delete 123 --yes` with a read-only profile exits 1 and prints separate Error and Tip prose lines instead of exactly one `{error, code, status, details}` object. `assertWritable()` calls `process.exit(1)` before `withClient()` can route the failure through `handleCommandError`. Route this precondition through JSON-aware error handling and add a real-binary regression test.
- <code>`npm test -- --runInBand tests/json-output.test.js tests/api-command.test.js` (initially blocked by absent dependencies, then passed after `npm ci --ignore-scripts`)</code>
- `npm test -- --runInBand`
- `Real CLI against a deterministic local HTTP mock: global 401 and 404 paths, API 500 path, inline validation, network failure, jq compile failure, and missing jq`
- <code>Real CLI with `CONFLUENCE_READ_ONLY=true`: `node bin/index.js --json delete 123 --yes`</code>
- <code>Real CLI without JSON: `node bin/index.js api /rest/api/content -f badfield`</code>
- <code>`jq -e &#39;keys == [&#34;code&#34;,&#34;details&#34;,&#34;error&#34;,&#34;status&#34;]&#39;` over captured JSON stderr and zero-byte assertions over captured stdout</code>
- <code>Removed `node_modules`, stopped the mock server, and confirmed the worktree remained clean</code>

🔧 Fix: fix: route read-only failures through JSON handler
1 error still open:
- 🚨 `lib/config.js:896` - A supported `--json spaces` invocation with no configuration exits 1 but writes setup instructions to stdout and non-JSON prose to stderr. `getConfig()` calls `process.exit(1)` before `handleCommandError`, violating the required single JSON stderr object and empty stdout contract. Route configuration failures through JSON-aware handling while preserving non-JSON output, and add a real-binary regression test.
- `npm ci --ignore-scripts`
- `npm test -- --runInBand tests/json-output.test.js tests/api-command.test.js tests/read-only.test.js tests/with-client.test.js`
- `npm test -- --runInBand`
- `Real CLI checks for 401, 404, 500, validation, read-only, jq exit 2, network failure, and non-JSON prose`
- `CONFLUENCE_CONFIG_DIR=<empty> node bin/index.js --json spaces`

🔧 Fix: fix JSON output for configuration failures
3 issues (2 errors, 1 warning) still open:
- 🚨 `bin/confluence.js:154` - `confluence --json info` and unsupported-command failures still emit Commander/plain prose rather than one structured JSON object, contrary to the required any-failure contract.
- 🚨 `lib/config.js:292` - Malformed config files print recovery prose before the JSON payload, making stderr unparsable in both standard and `api` commands.
- ⚠️ `README.md:419` - The exceptions paragraph incorrectly says read-only and configuration-loading failures remain prose, contradicting current behavior.
- `npm ci --ignore-scripts`
- `npm test -- --runInBand tests/json-output.test.js tests/api-command.test.js tests/read-only.test.js tests/with-client.test.js tests/config.test.js`
- `npm test -- --runInBand`
- `node /var/folders/mm/mzvsb9xn40vd3pqkp4y8n_sm0000gn/T/no-mistakes-evidence/01KY7CH68RKFRX3CZ9WNSQ9NHK/capture-cli-errors.js "$PWD"`
- `Real CLI checks against a controlled HTTP server for 401, 404, 503, network, validation, read-only, config, and jq failures`

🔧 Fix: fix JSON handling for usage and config errors
1 error still open:
- 🚨 `lib/confluence-client.js:380` - A supported `--json info &lt;display URL&gt;` failure logs the caught Axios error before the structured handler runs, producing a diagnostic stack plus JSON on stderr. The stream cannot be parsed as one JSON object. Suppress or route this intermediate diagnostic in JSON mode and add a real-binary regression test.
- `npm ci --ignore-scripts`
- `npm test -- --runInBand tests/json-output.test.js tests/api-command.test.js tests/read-only.test.js tests/with-client.test.js`
- `npm test -- --runInBand`
- `Real-binary local-server checks for 401, 404, 500, network, read-only, usage, jq, and non-JSON prose paths`
- `node bin/index.js --json info http://127.0.0.1:43129/display/SPACE/Title`
- <code>Missing-jq check using a restricted `PATH`</code>

🔧 Fix: Suppress display URL diagnostics in JSON mode
2 issues (1 error, 1 warning) still open:
- 🚨 `lib/confluence-client.js:293` - A mode-0644 mTLS client key prints a permission warning before the structured NETWORK payload. Whole-stderr JSON.parse fails. Suppress this warning only in JSON mode and add a real-binary regression test.
- ⚠️ `plugins/confluence/skills/confluence/SKILL.md:828` - The bundled skill incorrectly says usage, unsupported-JSON, read-only, and configuration failures remain prose, although they now emit structured JSON.
- <code>Initial focused `npm test -- --runInBand ...` attempt (Jest unavailable)</code>
- `npm ci --ignore-scripts`
- `npm test -- --runInBand tests/display-url-errors.test.js tests/json-output.test.js tests/api-command.test.js tests/read-only.test.js tests/with-client.test.js`
- `npm test -- --runInBand`
- `Real-binary JSON and non-JSON display-URL failures`
- `Real-binary JSON network failure with a mode-0644 mTLS key`
- `rm -rf node_modules && git status --short --branch`

🔧 Fix: Suppress mTLS warning noise in JSON mode
2 errors still open:
- 🚨 `lib/netrc.js:104` - An unreadable `.netrc` emits a warning before the structured error. Consequently, `JSON.parse(stderr)` fails. Suppress this warning only in JSON mode and add a real-binary regression test.
- 🚨 `lib/config.js:65` - An invalid `CONFLUENCE_LINK_STYLE` emits a fallback warning before a later structured error. Consequently, `JSON.parse(stderr)` fails. Gate this warning in JSON mode while preserving human output, with a regression test.
- `npm test -- --runInBand tests/json-output.test.js tests/api-command.test.js tests/read-only.test.js tests/display-url-errors.test.js tests/mtls-errors.test.js tests/with-client.test.js`
- `npm test -- --runInBand`
- <code>Real CLI: `confluence --json api /auth` against a local 401 server</code>
- <code>Real CLI: `confluence --json api /ok --jq &#39;.[&#39;` against a local server</code>
- `Real CLI display-URL resolution failure`
- `Real CLI mTLS failure with a mode-0644 key, in JSON and human modes`
- `Real CLI unreadable-netrc and invalid-link-style failure probes`

🔧 Fix: Suppress configuration warnings in JSON mode
✅ Re-checked - no issues remain.
- <code>Initial focused Jest command (dependencies absent: `jest: command not found`)</code>
- `npm ci --ignore-scripts`
- `npm test -- --runInBand tests/json-output.test.js tests/api-command.test.js tests/read-only.test.js tests/with-client.test.js tests/display-url-errors.test.js tests/mtls-errors.test.js tests/config-warning-errors.test.js`
- `npm test -- --runInBand`
- `Real CLI checks for HTTP 401/500, network, read-only, link-style warning suppression, non-JSON diagnostics, and jq exit status 2`
- <code>Removed `node_modules` and verified a clean worktree</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
