### PR TITLE
fix: escape passthrough tags in rendered attributes

### DIFF
--- a/lib/macro-converter.js
+++ b/lib/macro-converter.js
@@ -139,9 +139,17 @@ class MacroConverter {
     src += stashHtml(markdown.slice(pos));
 
     const html = this.markdown.render(src);
+    let contextOffset = 0;
+    let isInsideTag = false;
     return html.replace(
       new RegExp(`${STASH_DELIM}H(\\d+)${STASH_DELIM}`, 'g'),
-      (m, i, offset, str) => {
+      (m, i, offset) => {
+        for (; contextOffset < offset; contextOffset++) {
+          if (html[contextOffset] === '<') isInsideTag = true;
+          else if (html[contextOffset] === '>') isInsideTag = false;
+        }
+        contextOffset = offset + m.length;
+
         const raw = htmlStash[+i];
         if (raw == null) return m;
         // A placeholder can render into an attribute value (e.g. a link/image
@@ -152,11 +160,7 @@ class MacroConverter {
         // (`<` after the last `>`), and XML-escape the restored value if so.
         // Text-node placeholders keep their raw tag, so body passthrough is
         // byte-identical.
-        const before = str.slice(0, offset);
-        if (before.lastIndexOf('<') > before.lastIndexOf('>')) {
-          return escapeXmlAttr(raw);
-        }
-        return raw;
+        return isInsideTag ? escapeXmlAttr(raw) : raw;
       },
     );
   }

--- a/lib/macro-converter.js
+++ b/lib/macro-converter.js
@@ -30,6 +30,19 @@ const PASSTHROUGH_BLOCK_RE = /<(svg|div)(?:\s[^>]*)?>[\s\S]*?<\/\1>/gi;
 // continuation that happens to align to four spaces.
 const INLINE_CODE_RE = /`[^`\n]+`/g;
 
+// Escapes a restored passthrough tag for safe inclusion inside a double-quoted
+// XML attribute value. Only used when a stash placeholder resolved into an
+// attribute context (see `_renderMarkdownToHtml`); text-node placeholders are
+// left raw. `&` is escaped first so the entity ampersands below are not
+// double-escaped.
+function escapeXmlAttr(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 class MacroConverter {
   constructor({ isCloud = false, webUrlPrefix = '', buildUrl = null, linkStyle = null } = {}) {
     this._isCloud = isCloud;
@@ -128,7 +141,23 @@ class MacroConverter {
     const html = this.markdown.render(src);
     return html.replace(
       new RegExp(`${STASH_DELIM}H(\\d+)${STASH_DELIM}`, 'g'),
-      (m, i) => htmlStash[+i] ?? m,
+      (m, i, offset, str) => {
+        const raw = htmlStash[+i];
+        if (raw == null) return m;
+        // A placeholder can render into an attribute value (e.g. a link/image
+        // `title` built from `[x](url "<br>")`). Restoring the raw tag there
+        // would inject unescaped `<>"&` into an attribute, producing invalid
+        // storage XML that Confluence rejects. Detect the attribute context by
+        // checking whether the nearest preceding angle bracket opens a tag
+        // (`<` after the last `>`), and XML-escape the restored value if so.
+        // Text-node placeholders keep their raw tag, so body passthrough is
+        // byte-identical.
+        const before = str.slice(0, offset);
+        if (before.lastIndexOf('<') > before.lastIndexOf('>')) {
+          return escapeXmlAttr(raw);
+        }
+        return raw;
+      },
     );
   }
 

--- a/tests/macro-converter.test.js
+++ b/tests/macro-converter.test.js
@@ -1143,6 +1143,76 @@ describe('MacroConverter <br> passthrough', () => {
   });
 });
 
+describe('MacroConverter passthrough tags in link/image title attributes', () => {
+  // Whitelisted inline tags (br|u|sub|sup|mark|details|summary) are stashed as
+  // placeholders before rendering and restored across the whole HTML string.
+  // When a placeholder lands inside an attribute value (a link/image `title`),
+  // restoring the raw tag would inject unescaped `<>"&` and produce storage XML
+  // that Confluence rejects. The restore step must XML-escape those, while
+  // leaving body-text passthrough byte-identical (see the <br> passthrough suite
+  // above, which must stay green).
+  const converter = new MacroConverter({ isCloud: true });
+
+  // Focused well-formedness check for this defect class: every attribute value
+  // must be free of raw `<`/`>`. htmlparser2 (xmlMode) is too lenient to flag
+  // these, so we scan attribute values directly.
+  const assertAttrsWellFormed = (xml) => {
+    const attrRe = /\b[\w:-]+\s*=\s*"([^"]*)"/g;
+    let m;
+    while ((m = attrRe.exec(xml)) !== null) {
+      expect(m[1]).not.toMatch(/[<>]/);
+    }
+  };
+
+  test('link title with <br> is XML-escaped, not restored raw', () => {
+    const result = converter.markdownToStorage('[x](https://example.com "<br>")');
+    expect(result).toContain('title="&lt;br&gt;"');
+    expect(result).not.toContain('title="<br>"');
+    assertAttrsWellFormed(result);
+  });
+
+  test('image title with <sub>...</sub> is XML-escaped, not restored raw', () => {
+    const result = converter.markdownToStorage('![img](https://example.com/i.png "cap<sub>x</sub>")');
+    expect(result).toContain('title="cap&lt;sub&gt;x&lt;/sub&gt;"');
+    expect(result).not.toContain('title="cap<sub>');
+    assertAttrsWellFormed(result);
+  });
+
+  test('same tag in body AND title: body stays raw XHTML, title gets escaped', () => {
+    const result = converter.markdownToStorage('Line a<br>b then [x](https://example.com "<br>")');
+    // body passthrough unchanged (self-closed by markdown/storage pipeline)
+    expect(result).toContain('a<br />b');
+    // attribute context escaped
+    expect(result).toContain('title="&lt;br&gt;"');
+    assertAttrsWellFormed(result);
+  });
+
+  test('all seven whitelisted tags in a title attribute are escaped', () => {
+    const tags = ['br', 'u', 'sub', 'sup', 'mark', 'details', 'summary'];
+    for (const tag of tags) {
+      const result = converter.markdownToStorage(`[x](https://example.com "a<${tag}>b")`);
+      expect(result).toContain(`title="a&lt;${tag}&gt;b"`);
+      assertAttrsWellFormed(result);
+    }
+  });
+
+  test('output with escaped title parses as well-formed XML', () => {
+    const htmlparser2 = require('htmlparser2');
+    const result = converter.markdownToStorage('![img](https://example.com/i.png "cap<sub>x</sub>") and text a<br>b');
+    let error = null;
+    const parser = new htmlparser2.Parser(
+      { onerror: (e) => { error = e; } },
+      { xmlMode: true, recognizeSelfClosing: true }
+    );
+    parser.write(`<root>${result}</root>`);
+    parser.end();
+    expect(error).toBeNull();
+    // xmlMode is lenient about attribute contents, so also assert no raw
+    // angle brackets survive inside any attribute value.
+    assertAttrsWellFormed(result);
+  });
+});
+
 describe('MacroConverter storageToMarkdown panel formatting', () => {
   const converter = new MacroConverter({ isCloud: true });
 


### PR DESCRIPTION
## Intent

Fix the passthrough-tag attribute-escaping defect in confluence-cli's markdown->storage converter (roadmap #2, conf-passthrough-attresc-p2). lib/macro-converter.js stashes allow-listed inline tags (br|u|sub|sup|mark|details|summary) as placeholders before markdown rendering and restores them globally across the whole rendered HTML string. When a placeholder rendered into a link/image title attribute, the raw tag was restored verbatim, injecting unescaped <>"& into an attribute value and producing storage XML that Confluence rejects. The captain approved a SINGLE root-fix scope (S), NOT a broad pipeline sweep: fix only this defect, covering all seven allow-listed tags at once, and keep body-text passthrough byte-identical. Approach: at restore time detect the attribute context (nearest preceding angle bracket opens a tag: last '<' after last '>' before the placeholder offset) and XML-escape the restored value via a new escapeXmlAttr helper (& first, then < > "); text-node placeholders stay raw so body output is unchanged. Added 5 regression tests (link title <br>, image title <sub>, mixed body+title, all-seven-tags, well-formed-XML assertion). Deliberately did NOT expand into other pipeline areas (#210/#213/#215, admonitions, link rewriting) - that broader sweep was explicitly out of scope. Full suite 851 pass, lint clean. fix: type for patch release via semantic-release.

## What Changed

- Escape restored passthrough tags inside link and image title attributes while preserving raw tags in body text.
- Track tag context with a forward cursor for linear-time placeholder restoration.
- Add regression coverage for mixed contexts, all seven allowed tags, and well-formed XML output.

## Risk Assessment

✅ Low: The follow-up removes the quadratic scan while preserving the required attribute-context detection and unchanged body passthrough behavior.

## Testing

Targeted regressions, all 851 repository tests, actual CLI conversion, strict XML parsing, and base-versus-target body parity passed; evidence shows all-seven title escaping, embedded quote/ampersand escaping, and byte-identical body passthrough.

<details>
<summary>Evidence: Generated Confluence storage XML</summary>

```text
<p>Body H<sub>2</sub>O, <u>under</u>, <mark>highlight</mark>, x<sup>2</sup>, line<br />break.</p>
<p><a href="https://example.com" title="before&lt;br&gt;&lt;u&gt;&lt;sub&gt;&lt;sup&gt;&lt;mark&gt;&lt;details&gt;&lt;summary&gt;after">all seven</a></p>
<p><a href="https://example.com" title="&lt;mark data-x=&quot;A&amp;B&quot;&gt;">attribute chars</a></p>
```
</details>
<details>
<summary>Evidence: Base/target body parity</summary>

```text
body_passthrough_byte_identical=true
base_bytes=247 target_bytes=247
base_sha256=57bf12897bcd913262d29f79fbfde7b0b026e51e3e2885c3995073894170bd5d
target_sha256=57bf12897bcd913262d29f79fbfde7b0b026e51e3e2885c3995073894170bd5d
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `lib/macro-converter.js:155` - Each placeholder rescans the entire preceding HTML, making restoration O(n²) when passthrough-tag count scales with document size. Track tag context with a forward cursor so each character is scanned once.

🔧 Fix: Optimize passthrough placeholder context scanning
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Reviewed `git diff 088011cd02fb454023b156f601697471ad1b0907..b869b1ba9dc75f07904163d90a82bba97e9670a7`</code>
- `npx jest tests/macro-converter.test.js --runInBand --testNamePattern='passthrough tags in link/image title attributes|<br> passthrough|<u>/<sub>/<sup>/<mark> passthrough'`
- <code>Piped mixed body/title Markdown through `node bin/confluence.js convert --input-format markdown --output-format storage --output-file /var/folders/mm/mzvsb9xn40vd3pqkp4y8n_sm0000gn/T/no-mistakes-evidence/01KY7PSSSVT3P34GFPFAW2911A/passthrough-attribute-escaping.storage.xml`</code>
- <code>Wrapped the generated fragment in `&lt;root&gt;` and ran `xmllint --noout -`</code>
- `Compared all-seven body output from the base and target converters byte-for-byte and by SHA-256`
- `npm test -- --runInBand`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
