### PR TITLE
docs: mention brew trust for Homebrew tap-trust warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ A powerful command-line interface for Atlassian Confluence that allows you to re
 brew install pchuri/tap/confluence-cli
 ```
 
+Homebrew 5.1.15+ warns that third-party taps are "not trusted". To trust the tap and silence the warning (required in a future Homebrew release):
+
+```bash
+brew trust pchuri/tap
+```
+
 ### npm
 
 ```bash


### PR DESCRIPTION
## Summary

Homebrew 5.1.15 introduced a tap-trust policy that flags all third-party taps as "not trusted" (and a future release will require trust before installing from them). A user hit this warning with `pchuri/tap` and asked about it in #201.

This PR adds a short note to the Homebrew installation section documenting the `brew trust pchuri/tap` step.

Refs: https://github.com/pchuri/confluence-cli/discussions/201